### PR TITLE
Remove `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,8 +1,0 @@
-[toolchain]
-channel = "1.91.1"
-profile = "minimal"
-components = [ "rustfmt", "clippy" ]
-targets = [
-    "wasm32-wasip2", # extensions
-    "x86_64-unknown-linux-musl", # remote server
-]


### PR DESCRIPTION
This file specifies the required Rust toolchain and targets for the Zed editor and is not needed for GPUI.