### PR TITLE
feat(macos): add support for macOS activation policy

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -42,6 +42,8 @@ pub use visual_test_context::*;
 
 #[cfg(any(feature = "inspector", debug_assertions))]
 use crate::InspectorElementRegistry;
+#[cfg(target_os = "macos")]
+use crate::MacActivationPolicy;
 use crate::{
     Action, ActionBuildError, ActionRegistry, Any, AnyView, AnyWindowHandle, AppContext, Arena,
     ArenaBox, Asset, AssetSource, BackgroundExecutor, Bounds, ClipboardItem, CursorStyle,
@@ -218,6 +220,28 @@ impl Application {
     /// By default, [`QuitMode::Default`] is used.
     pub fn with_quit_mode(self, mode: QuitMode) -> Self {
         self.0.borrow_mut().quit_mode = mode;
+        self
+    }
+
+    /// Sets the activation policy for the application (macOS only).
+    ///
+    /// This determines how the application appears in the system:
+    /// - `Regular`: Normal app with Dock icon and menu bar
+    /// - `Accessory`: Background app without Dock icon (LSUIElement)
+    /// - `Prohibited`: Runs in background, no UI allowed
+    ///
+    /// This must be called before the application finishes launching to take effect.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use gpui::Application;
+    /// # fn configure(app: Application) -> Application {
+    /// app.with_activation_policy(gpui::MacActivationPolicy::Accessory)
+    /// # }
+    /// ```
+    #[cfg(target_os = "macos")]
+    pub fn with_activation_policy(self, policy: MacActivationPolicy) -> Self {
+        self.0.borrow().platform.set_mac_activation_policy(policy);
         self
     }
 

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -121,12 +121,25 @@ pub fn guess_compositor() -> &'static str {
     }
 }
 
+/// The activation policy for a macOS application.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MacActivationPolicy {
+    /// The application is an ordinary app that appears in the Dock and may have a user interface.
+    #[default]
+    Regular,
+    /// The application doesn't appear in the Dock and doesn't have a menu bar, but it may be activated programmatically or by clicking on one of its windows.
+    Accessory,
+    /// The application doesn't appear in the Dock and may not create windows or be activated.
+    Prohibited,
+}
+
 #[expect(missing_docs)]
 pub trait Platform: 'static {
     fn background_executor(&self) -> BackgroundExecutor;
     fn foreground_executor(&self) -> ForegroundExecutor;
     fn text_system(&self) -> Arc<dyn PlatformTextSystem>;
 
+    fn set_mac_activation_policy(&self, _policy: MacActivationPolicy) {}
     fn run(&self, on_finish_launching: Box<dyn 'static + FnOnce()>);
     fn quit(&self);
     fn restart(&self, binary_path: Option<PathBuf>);

--- a/crates/gpui_macos/src/platform.rs
+++ b/crates/gpui_macos/src/platform.rs
@@ -8,9 +8,12 @@ use block::ConcreteBlock;
 use cocoa::{
     appkit::{
         NSAppearanceNameVibrantDark, NSAppearanceNameVibrantLight, NSApplication,
-        NSApplicationActivationPolicy::NSApplicationActivationPolicyRegular, NSControl as _,
-        NSEventModifierFlags, NSMenu, NSMenuItem, NSModalResponse, NSOpenPanel, NSSavePanel,
-        NSVisualEffectState, NSVisualEffectView, NSWindow,
+        NSApplicationActivationPolicy::{
+            NSApplicationActivationPolicyAccessory, NSApplicationActivationPolicyProhibited,
+            NSApplicationActivationPolicyRegular,
+        },
+        NSControl as _, NSEventModifierFlags, NSMenu, NSMenuItem, NSModalResponse, NSOpenPanel,
+        NSSavePanel, NSVisualEffectState, NSVisualEffectView, NSWindow,
     },
     base::{BOOL, NO, YES, id, nil, selector},
     foundation::{
@@ -30,8 +33,8 @@ use dispatch2::DispatchQueue;
 use futures::channel::oneshot;
 use gpui::{
     Action, AnyWindowHandle, BackgroundExecutor, ClipboardItem, CursorStyle, ForegroundExecutor,
-    KeyContext, Keymap, Menu, MenuItem, OsMenu, OwnedMenu, PathPromptOptions, Platform,
-    PlatformDisplay, PlatformKeyboardLayout, PlatformKeyboardMapper, PlatformTextSystem,
+    KeyContext, Keymap, MacActivationPolicy, Menu, MenuItem, OsMenu, OwnedMenu, PathPromptOptions,
+    Platform, PlatformDisplay, PlatformKeyboardLayout, PlatformKeyboardMapper, PlatformTextSystem,
     PlatformWindow, Result, SystemMenuType, Task, ThermalState, WindowAppearance, WindowKind,
     WindowParams, popup::PopupNotSupportedError,
 };
@@ -171,6 +174,7 @@ pub(crate) struct MacPlatformState {
     text_system: Arc<dyn PlatformTextSystem>,
     renderer_context: renderer::Context,
     headless: bool,
+    activation_policy: Option<MacActivationPolicy>,
     general_pasteboard: Pasteboard,
     find_pasteboard: Pasteboard,
     reopen: Option<Box<dyn FnMut()>>,
@@ -221,6 +225,7 @@ impl MacPlatform {
             background_executor: BackgroundExecutor::new(dispatcher.clone()),
             foreground_executor: ForegroundExecutor::new(dispatcher),
             renderer_context: renderer::Context::default(),
+            activation_policy: None,
             general_pasteboard: Pasteboard::general(),
             find_pasteboard: Pasteboard::find(),
             reopen: None,
@@ -489,6 +494,10 @@ impl Platform for MacPlatform {
 
     fn text_system(&self) -> Arc<dyn PlatformTextSystem> {
         self.0.lock().text_system.clone()
+    }
+
+    fn set_mac_activation_policy(&self, policy: MacActivationPolicy) {
+        self.0.lock().activation_policy = Some(policy);
     }
 
     fn run(&self, on_finish_launching: Box<dyn FnOnce()>) {
@@ -1265,7 +1274,7 @@ unsafe fn get_mac_platform(object: &mut Object) -> &MacPlatform {
     }
 }
 
-extern "C" fn will_finish_launching(_this: &mut Object, _: Sel, _: id) {
+extern "C" fn will_finish_launching(this: &mut Object, _: Sel, _: id) {
     unsafe {
         let user_defaults: id = msg_send![class!(NSUserDefaults), standardUserDefaults];
 
@@ -1279,13 +1288,30 @@ extern "C" fn will_finish_launching(_this: &mut Object, _: Sel, _: id) {
             let false_value: id = msg_send![class!(NSNumber), numberWithBool:false];
             let _: () = msg_send![user_defaults, setObject: false_value forKey: name];
         }
+
+        let platform = get_mac_platform(this);
+        let state = platform.0.lock();
+        if let Some(policy) = state.activation_policy {
+            let app: id = msg_send![APP_CLASS, sharedApplication];
+            let ns_policy = match policy {
+                MacActivationPolicy::Regular => NSApplicationActivationPolicyRegular,
+                MacActivationPolicy::Accessory => NSApplicationActivationPolicyAccessory,
+                MacActivationPolicy::Prohibited => NSApplicationActivationPolicyProhibited,
+            };
+            app.setActivationPolicy_(ns_policy);
+        }
     }
 }
 
 extern "C" fn did_finish_launching(this: &mut Object, _: Sel, _: id) {
     unsafe {
-        let app: id = msg_send![APP_CLASS, sharedApplication];
-        app.setActivationPolicy_(NSApplicationActivationPolicyRegular);
+        let platform = get_mac_platform(this);
+        let state = platform.0.lock();
+        if state.activation_policy.is_none() {
+            let app: id = msg_send![APP_CLASS, sharedApplication];
+            app.setActivationPolicy_(NSApplicationActivationPolicyRegular);
+        }
+        drop(state);
 
         let notification_center: *mut Object =
             msg_send![class!(NSNotificationCenter), defaultCenter];


### PR DESCRIPTION
1. Support to configure the application's activation policy on macOS, allowing for the creation of accessory applications (e.g., menu bar apps) that do not appear in the Dock.
2. A new `with_activation_policy` method has been added to the `Application` builder, which accepts a `MacActivationPolicy` enum (`Regular`, `Accessory`, or `Prohibited`).
3. The `Platform::run` method signature has been updated to accept a `PlatformOptions` struct. And implementations for other platforms (Windows, Linux, Test) have been updated to accommodate this change while ignoring the option. 