### PR TITLE
gpui: Add iOS platform support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ xcuserdata/
 # Don't commit any secrets to the repo.
 .env
 .env.secret.toml
+build/

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -83,6 +83,8 @@ windows-manifest = []
 [lib]
 path = "src/gpui.rs"
 doctest = false
+# Include staticlib for iOS builds (to link from Objective-C)
+crate-type = ["lib", "staticlib"]
 
 [dependencies]
 anyhow.workspace = true
@@ -161,7 +163,27 @@ objc2-metal = { version = "0.3", optional = true }
 #TODO: replace with "objc2"
 metal.workspace = true
 
-[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))'.dependencies]
+# iOS dependencies - shares many frameworks with macOS
+[target.'cfg(target_os = "ios")'.dependencies]
+block = "0.1"
+core-foundation.workspace = true
+core-foundation-sys.workspace = true
+core-graphics = "0.24"
+core-text = "21"
+font-kit = { git = "https://github.com/zed-industries/font-kit", rev = "110523127440aefb11ce0cf280ae7c5071337ec5", package = "zed-font-kit", version = "0.14.1-zed", optional = true }
+foreign-types = "0.5"
+log.workspace = true
+objc.workspace = true
+metal.workspace = true
+# Blade renderer for iOS
+blade-graphics.workspace = true
+blade-macros.workspace = true
+blade-util.workspace = true
+bytemuck = "1"
+objc2 = { version = "0.6", optional = true }
+objc2-metal = { version = "0.3", optional = true }
+
+[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos", target_os = "ios"))'.dependencies]
 pathfinder_geometry = "0.5"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "windows"))'.dependencies]
@@ -329,3 +351,7 @@ path = "examples/window_shadow.rs"
 [[example]]
 name = "grid_layout"
 path = "examples/grid_layout.rs"
+
+[[example]]
+name = "ios_hello"
+path = "examples/ios_hello.rs"

--- a/crates/gpui/examples/ios_app/Info.plist
+++ b/crates/gpui/examples/ios_app/Info.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>GpuiIOS</string>
+    <key>CFBundleIdentifier</key>
+    <string>dev.zed.gpui-ios-example</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>GPUI iOS</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UILaunchStoryboardName</key>
+    <string>LaunchScreen</string>
+    <key>UIRequiredDeviceCapabilities</key>
+    <array>
+        <string>arm64</string>
+        <string>metal</string>
+    </array>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationPortraitUpsideDown</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UIStatusBarHidden</key>
+    <false/>
+    <key>UIRequiresFullScreen</key>
+    <true/>
+</dict>
+</plist>

--- a/crates/gpui/examples/ios_app/LaunchScreen.storyboard
+++ b/crates/gpui/examples/ios_app/LaunchScreen.storyboard
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GPUI iOS" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GJd-Yh-RWb">
+                                <rect key="frame" x="0.0" y="424" width="414" height="48"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="40"/>
+                                <color key="textColor" systemColor="labelColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="Q3B-4B-g5h"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="iHw-5Y-tHk"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="x3x-2Y-q9G"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="GJd-Yh-RWb" secondAttribute="trailing" id="yWB-VM-dLH"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="52.173913043478265" y="373.66071428571428"/>
+        </scene>
+    </scenes>
+</document>

--- a/crates/gpui/examples/ios_app/README.md
+++ b/crates/gpui/examples/ios_app/README.md
@@ -1,0 +1,61 @@
+# GPUI iOS Example App
+
+A demo application showcasing GPUI rendering on iOS/iPadOS.
+
+## Quick Start
+
+```bash
+# Build and run on iOS Simulator
+./build_and_run.sh
+
+# Or manually:
+# 1. Build Rust static library
+cargo build --target aarch64-apple-ios-sim -p gpui --features font-kit
+
+# 2. Open and run in Xcode
+open GpuiIOS.xcodeproj
+# Select iPhone simulator, press Cmd+R
+```
+
+## Requirements
+
+- Xcode 16.0+
+- iOS Simulator (iOS 18.0+)
+- Rust toolchain with `aarch64-apple-ios-sim` target:
+  ```bash
+  rustup target add aarch64-apple-ios-sim
+  ```
+
+## Demos Included
+
+- **Animation Playground** - Physics-based bouncing balls with particle effects
+- **Shader Showcase** - Dynamic gradients, floating orbs, parallax effects
+- **Text Editor** - Text input via UITextInput protocol, cursor/selection handling
+
+## Architecture
+
+The app uses an Objective-C/Rust FFI bridge:
+
+```
+main.m (UIApplicationDelegate)
+    ↓
+gpui_ios.h (C FFI declarations)
+    ↓
+ffi.rs (Rust exports)
+    ↓
+GPUI Application (Rust)
+```
+
+Key FFI functions:
+- `gpui_ios_initialize()` - Create GPUI app
+- `gpui_ios_did_finish_launching()` - App lifecycle
+- `gpui_ios_run_demo()` - Start rendering loop
+- `gpui_ios_handle_touch_*()` - Touch event forwarding
+
+## Troubleshooting
+
+**Build fails with missing target**: Run `rustup target add aarch64-apple-ios-sim`
+
+**Linker errors**: Ensure `libgpui.a` is in the Xcode project's library search paths
+
+**Blank screen**: Check that Metal is available (requires real device or Apple Silicon Mac)

--- a/crates/gpui/examples/ios_app/build_and_run.sh
+++ b/crates/gpui/examples/ios_app/build_and_run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Build and run GPUI iOS example on iOS Simulator
+#
+# Usage: ./build_and_run.sh [device_name]
+# Example: ./build_and_run.sh "iPhone 15 Pro"
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+APP_NAME="gpui_ios_example"
+BUNDLE_ID="dev.zed.gpui-ios-example"
+
+# Default to iPhone 15 Pro simulator if not specified
+DEVICE_NAME="${1:-iPhone 15 Pro}"
+
+echo "Building GPUI for iOS simulator..."
+cd "$PROJECT_ROOT"
+
+# Build the Rust library for iOS simulator
+cargo build --target aarch64-apple-ios-sim -p gpui --features font-kit --release
+
+echo "Build completed successfully!"
+
+# The binary is at:
+BINARY_PATH="$PROJECT_ROOT/target/aarch64-apple-ios-sim/release/libgpui.a"
+
+if [ -f "$BINARY_PATH" ]; then
+    echo "Library built at: $BINARY_PATH"
+    echo ""
+    echo "To run on iOS simulator, you need to:"
+    echo "1. Create an Xcode project that links against this library"
+    echo "2. Add the Info.plist and LaunchScreen.storyboard from this directory"
+    echo "3. Implement a main() that calls GPUI's Application::new().run()"
+    echo ""
+    echo "Or use cargo-bundle to create an iOS app bundle:"
+    echo "  cargo install cargo-bundle"
+    echo "  cargo bundle --target aarch64-apple-ios-sim"
+else
+    echo "Warning: Expected library not found at $BINARY_PATH"
+    echo "Check build output for errors."
+fi
+
+echo ""
+echo "Available iOS simulators:"
+xcrun simctl list devices available | grep -E "iPhone|iPad" | head -10

--- a/crates/gpui/examples/ios_app/gpui_ios.h
+++ b/crates/gpui/examples/ios_app/gpui_ios.h
@@ -1,0 +1,129 @@
+//
+//  gpui_ios.h
+//  GPUI iOS FFI Header
+//
+//  This header declares the C-compatible functions exported by the GPUI Rust library
+//  for use in iOS Objective-C code.
+//
+
+#ifndef GPUI_IOS_H
+#define GPUI_IOS_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Initialize the GPUI iOS application.
+///
+/// This should be called from `application:didFinishLaunchingWithOptions:`
+/// in the iOS app delegate, before any other GPUI functions.
+///
+/// Returns a pointer to the app state that should be passed to other FFI functions.
+/// Returns NULL if initialization fails.
+void* gpui_ios_initialize(void);
+
+/// Called when the iOS app has finished launching.
+///
+/// This should be called from `application:didFinishLaunchingWithOptions:`
+/// in the iOS app delegate, after `gpui_ios_initialize()` returns.
+///
+/// This invokes the callback passed to Application::run().
+void gpui_ios_did_finish_launching(void* app_ptr);
+
+/// Called when the iOS app will enter the foreground.
+///
+/// This should be called from `applicationWillEnterForeground:` in the app delegate.
+/// This notifies all GPUI windows that the app is becoming active.
+void gpui_ios_will_enter_foreground(void* app_ptr);
+
+/// Called when the iOS app did become active.
+///
+/// This should be called from `applicationDidBecomeActive:` in the app delegate.
+/// This indicates the app is now in the foreground and receiving events.
+void gpui_ios_did_become_active(void* app_ptr);
+
+/// Called when the iOS app will resign active.
+///
+/// This should be called from `applicationWillResignActive:` in the app delegate.
+/// This indicates the app is about to become inactive (e.g., incoming call, switching apps).
+void gpui_ios_will_resign_active(void* app_ptr);
+
+/// Called when the iOS app did enter the background.
+///
+/// This should be called from `applicationDidEnterBackground:` in the app delegate.
+/// At this point, the app should save user data and release shared resources.
+void gpui_ios_did_enter_background(void* app_ptr);
+
+/// Called when the iOS app will terminate.
+///
+/// This should be called from `applicationWillTerminate:` in the app delegate.
+/// This is a good place to save any unsaved data.
+void gpui_ios_will_terminate(void* app_ptr);
+
+/// Called when a touch event occurs.
+///
+/// This bridges UIKit touch events to GPUI's input system.
+/// Parameters:
+/// - window_ptr: Pointer to the IosWindow
+/// - touch_ptr: Pointer to the UITouch object
+/// - event_ptr: Pointer to the UIEvent object
+void gpui_ios_handle_touch(void* window_ptr, void* touch_ptr, void* event_ptr);
+
+/// Request a frame to be rendered.
+///
+/// This should be called from CADisplayLink callback.
+/// The window_ptr should be the value returned by gpui_ios_get_window().
+void gpui_ios_request_frame(void* window_ptr);
+
+/// Get the most recently created GPUI window pointer.
+///
+/// Returns the pointer to the IosWindow that was most recently registered,
+/// or NULL if no windows have been created.
+/// This should be called after gpui_ios_did_finish_launching() to get the
+/// window pointer needed for gpui_ios_request_frame().
+void* gpui_ios_get_window(void);
+
+/// Run a demo GPUI application.
+///
+/// This creates a GPUI Application and opens a test window.
+/// Call this from application:didFinishLaunchingWithOptions: to start the demo.
+/// This is an alternative to using gpui_ios_initialize/gpui_ios_did_finish_launching
+/// when you want a self-contained demo.
+void gpui_ios_run_demo(void);
+
+/// Show the software keyboard.
+///
+/// Call this when a text input field gains focus.
+/// The window_ptr should be the value returned by gpui_ios_get_window().
+void gpui_ios_show_keyboard(void* window_ptr);
+
+/// Hide the software keyboard.
+///
+/// Call this when a text input field loses focus.
+/// The window_ptr should be the value returned by gpui_ios_get_window().
+void gpui_ios_hide_keyboard(void* window_ptr);
+
+/// Handle text input from the software keyboard.
+///
+/// This is called when the user types on the keyboard.
+/// Parameters:
+/// - window_ptr: Pointer to the IosWindow
+/// - text_ptr: Pointer to NSString with the entered text
+void gpui_ios_handle_text_input(void* window_ptr, void* text_ptr);
+
+/// Handle a key event from an external keyboard.
+///
+/// Parameters:
+/// - window_ptr: Pointer to the IosWindow
+/// - key_code: The key code from UIKeyboardHIDUsage
+/// - modifiers: Modifier flags from UIKeyModifierFlags
+/// - is_key_down: true for key down, false for key up
+void gpui_ios_handle_key_event(void* window_ptr, uint32_t key_code, uint32_t modifiers, _Bool is_key_down);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPUI_IOS_H */

--- a/crates/gpui/examples/ios_app/gpui_ios.h
+++ b/crates/gpui/examples/ios_app/gpui_ios.h
@@ -130,6 +130,19 @@ void gpui_ios_handle_key_event(void* window_ptr, uint32_t key_code, uint32_t mod
 /// Returns: Pointer to the UIWindow, or NULL if not available
 void* gpui_ios_get_ui_window(void* window_ptr);
 
+// =============================================================================
+// File Picker API
+// =============================================================================
+
+/// Called when the user selects files in the document picker.
+///
+/// Parameters:
+/// - urls: Pointer to NSArray<NSURL*> with selected URLs, or NULL if cancelled
+void gpui_ios_file_picker_did_pick(void* urls);
+
+/// Called when the user cancels the document picker.
+void gpui_ios_file_picker_cancelled(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/crates/gpui/examples/ios_app/gpui_ios.h
+++ b/crates/gpui/examples/ios_app/gpui_ios.h
@@ -122,6 +122,14 @@ void gpui_ios_handle_text_input(void* window_ptr, void* text_ptr);
 /// - is_key_down: true for key down, false for key up
 void gpui_ios_handle_key_event(void* window_ptr, uint32_t key_code, uint32_t modifiers, _Bool is_key_down);
 
+/// Get the UIWindow from a GPUI window.
+///
+/// Parameters:
+/// - window_ptr: Pointer to the IosWindow
+///
+/// Returns: Pointer to the UIWindow, or NULL if not available
+void* gpui_ios_get_ui_window(void* window_ptr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/crates/gpui/examples/ios_app/main.m
+++ b/crates/gpui/examples/ios_app/main.m
@@ -1,0 +1,250 @@
+// GPUI iOS Example - Main Entry Point
+//
+// This is a minimal iOS app that demonstrates GPUI running on iOS.
+// When USE_GPUI_RUST is defined, it links against the GPUI Rust static library
+// and uses GPUI for all rendering.
+
+#import <UIKit/UIKit.h>
+#import <Metal/Metal.h>
+#import <QuartzCore/QuartzCore.h>
+
+// Define USE_GPUI_RUST to enable Rust GPUI integration
+// This requires linking against libgpui.a
+#ifdef USE_GPUI_RUST
+#import "gpui_ios.h"
+#endif
+
+#ifndef USE_GPUI_RUST
+// Fallback Metal view for when GPUI is not linked
+@interface GPUIMetalView : UIView
+@property (nonatomic, strong) id<MTLDevice> device;
+@property (nonatomic, strong) id<MTLCommandQueue> commandQueue;
+@end
+
+@implementation GPUIMetalView
+
++ (Class)layerClass {
+    return [CAMetalLayer class];
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        [self setupMetal];
+    }
+    return self;
+}
+
+- (void)setupMetal {
+    self.device = MTLCreateSystemDefaultDevice();
+    if (!self.device) {
+        NSLog(@"Metal is not supported on this device");
+        return;
+    }
+
+    CAMetalLayer *metalLayer = (CAMetalLayer *)self.layer;
+    metalLayer.device = self.device;
+    metalLayer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+    metalLayer.framebufferOnly = YES;
+    metalLayer.contentsScale = [UIScreen mainScreen].scale;
+
+    self.commandQueue = [self.device newCommandQueue];
+
+    NSLog(@"Metal initialized successfully with device: %@", self.device.name);
+}
+
+- (void)drawRect:(CGRect)rect {
+    CAMetalLayer *metalLayer = (CAMetalLayer *)self.layer;
+    id<CAMetalDrawable> drawable = [metalLayer nextDrawable];
+    if (!drawable) return;
+
+    MTLRenderPassDescriptor *passDescriptor = [MTLRenderPassDescriptor renderPassDescriptor];
+    passDescriptor.colorAttachments[0].texture = drawable.texture;
+    passDescriptor.colorAttachments[0].loadAction = MTLLoadActionClear;
+    passDescriptor.colorAttachments[0].storeAction = MTLStoreActionStore;
+    // Catppuccin Mocha base color
+    passDescriptor.colorAttachments[0].clearColor = MTLClearColorMake(0.118, 0.118, 0.180, 1.0);
+
+    id<MTLCommandBuffer> commandBuffer = [self.commandQueue commandBuffer];
+    id<MTLRenderCommandEncoder> encoder = [commandBuffer renderCommandEncoderWithDescriptor:passDescriptor];
+    [encoder endEncoding];
+
+    [commandBuffer presentDrawable:drawable];
+    [commandBuffer commit];
+}
+
+@end
+
+// Fallback View Controller for non-GPUI mode
+@interface GPUIFallbackViewController : UIViewController
+@property (nonatomic, strong) GPUIMetalView *metalView;
+@property (nonatomic, strong) UILabel *statusLabel;
+@property (nonatomic, strong) CADisplayLink *displayLink;
+@end
+
+@implementation GPUIFallbackViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.metalView = [[GPUIMetalView alloc] initWithFrame:self.view.bounds];
+    self.metalView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [self.view addSubview:self.metalView];
+
+    self.statusLabel = [[UILabel alloc] init];
+    self.statusLabel.text = @"GPUI iOS\nMetal Fallback Mode";
+    self.statusLabel.numberOfLines = 0;
+    self.statusLabel.textAlignment = NSTextAlignmentCenter;
+    self.statusLabel.textColor = [UIColor colorWithRed:0.804 green:0.839 blue:0.957 alpha:1.0];
+    self.statusLabel.font = [UIFont systemFontOfSize:24 weight:UIFontWeightBold];
+    self.statusLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:self.statusLabel];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [self.statusLabel.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+        [self.statusLabel.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor],
+    ]];
+
+    self.displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(render)];
+    [self.displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+
+    NSLog(@"GPUI iOS Fallback Mode Started");
+}
+
+- (void)render {
+    [self.metalView setNeedsDisplay];
+}
+
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+    CAMetalLayer *metalLayer = (CAMetalLayer *)self.metalView.layer;
+    CGFloat scale = [UIScreen mainScreen].scale;
+    metalLayer.drawableSize = CGSizeMake(self.metalView.bounds.size.width * scale,
+                                          self.metalView.bounds.size.height * scale);
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return UIStatusBarStyleLightContent;
+}
+
+- (void)dealloc {
+    [self.displayLink invalidate];
+}
+
+@end
+#endif // !USE_GPUI_RUST
+
+// App Delegate
+@interface GPUIAppDelegate : UIResponder <UIApplicationDelegate>
+@property (nonatomic, strong) UIWindow *window;
+#ifdef USE_GPUI_RUST
+@property (nonatomic, assign) void *gpuiApp;
+@property (nonatomic, assign) void *gpuiWindow;
+@property (nonatomic, strong) CADisplayLink *displayLink;
+#endif
+@end
+
+@implementation GPUIAppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    NSLog(@"GPUI iOS Application Launching...");
+
+#ifdef USE_GPUI_RUST
+    // Run the GPUI demo application
+    // This initializes GPUI and creates a window with a test UI
+    NSLog(@"Starting GPUI demo...");
+    gpui_ios_run_demo();
+    NSLog(@"GPUI demo initialized");
+
+    // Get the GPUI window pointer that was created
+    self.gpuiWindow = gpui_ios_get_window();
+    if (self.gpuiWindow) {
+        NSLog(@"Got GPUI window pointer: %p", self.gpuiWindow);
+
+        // Setup CADisplayLink to drive rendering
+        self.displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(renderFrame)];
+        [self.displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+        NSLog(@"CADisplayLink started for GPUI rendering");
+    } else {
+        NSLog(@"Warning: No GPUI window was created");
+    }
+
+    NSLog(@"GPUI iOS Application Launched with Rust integration");
+#else
+    // Fallback mode: create our own window with demo UI
+    self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+    self.window.rootViewController = [[GPUIFallbackViewController alloc] init];
+    [self.window makeKeyAndVisible];
+    NSLog(@"GPUI iOS Application Launched in fallback mode");
+#endif
+
+    return YES;
+}
+
+#ifdef USE_GPUI_RUST
+- (void)renderFrame {
+    if (self.gpuiWindow) {
+        gpui_ios_request_frame(self.gpuiWindow);
+    }
+}
+#endif
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+    NSLog(@"GPUI iOS: Will enter foreground");
+#ifdef USE_GPUI_RUST
+    gpui_ios_will_enter_foreground(self.gpuiApp);
+
+    // Resume display link when coming to foreground
+    if (!self.displayLink && self.gpuiWindow) {
+        self.displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(renderFrame)];
+        [self.displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+    }
+#endif
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    NSLog(@"GPUI iOS: Did become active");
+#ifdef USE_GPUI_RUST
+    gpui_ios_did_become_active(self.gpuiApp);
+#endif
+}
+
+- (void)applicationWillResignActive:(UIApplication *)application {
+    NSLog(@"GPUI iOS: Will resign active");
+#ifdef USE_GPUI_RUST
+    gpui_ios_will_resign_active(self.gpuiApp);
+#endif
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+    NSLog(@"GPUI iOS: Did enter background");
+#ifdef USE_GPUI_RUST
+    gpui_ios_did_enter_background(self.gpuiApp);
+
+    // Pause display link when going to background to save power
+    if (self.displayLink) {
+        [self.displayLink invalidate];
+        self.displayLink = nil;
+    }
+#endif
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+    NSLog(@"GPUI iOS: Will terminate");
+#ifdef USE_GPUI_RUST
+    if (self.displayLink) {
+        [self.displayLink invalidate];
+        self.displayLink = nil;
+    }
+    gpui_ios_will_terminate(self.gpuiApp);
+#endif
+}
+
+@end
+
+// Main entry point
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([GPUIAppDelegate class]));
+    }
+}

--- a/crates/gpui/examples/ios_hello.rs
+++ b/crates/gpui/examples/ios_hello.rs
@@ -1,0 +1,97 @@
+//! iOS Hello World example.
+//!
+//! This example demonstrates a basic GPUI app that works on iOS.
+//! On iOS, windows are always fullscreen and touch-based.
+//!
+//! To build for iOS simulator:
+//! ```
+//! cargo build --target aarch64-apple-ios-sim --example ios_hello --features font-kit
+//! ```
+
+use gpui::{App, Application, Context, SharedString, Window, WindowOptions, div, prelude::*, rgb};
+
+struct IosHelloWorld {
+    text: SharedString,
+    tap_count: u32,
+}
+
+impl Render for IosHelloWorld {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .flex()
+            .flex_col()
+            .gap_3()
+            .bg(rgb(0x1e1e2e)) // Dark background
+            .size_full() // Full screen on iOS
+            .justify_center()
+            .items_center()
+            .text_xl()
+            .text_color(rgb(0xcdd6f4)) // Light text
+            .child(format!("Hello, {}!", &self.text))
+            .child(format!("Taps: {}", self.tap_count))
+            .child(
+                div()
+                    .flex()
+                    .gap_2()
+                    .child(
+                        div()
+                            .size_16()
+                            .bg(rgb(0xf38ba8)) // Rosewater
+                            .rounded_md(),
+                    )
+                    .child(
+                        div()
+                            .size_16()
+                            .bg(rgb(0xa6e3a1)) // Green
+                            .rounded_md(),
+                    )
+                    .child(
+                        div()
+                            .size_16()
+                            .bg(rgb(0x89b4fa)) // Blue
+                            .rounded_md(),
+                    )
+                    .child(
+                        div()
+                            .size_16()
+                            .bg(rgb(0xf9e2af)) // Yellow
+                            .rounded_md(),
+                    ),
+            )
+            .child(
+                div()
+                    .mt_8()
+                    .px_6()
+                    .py_3()
+                    .bg(rgb(0x89b4fa))
+                    .rounded_lg()
+                    .text_color(rgb(0x1e1e2e))
+                    .child("Tap to increment")
+                    .on_mouse_down(gpui::MouseButton::Left, |_, _window, _cx| {
+                        // This will be triggered by touch on iOS
+                        // Note: proper tap handling would increment tap_count
+                    }),
+            )
+    }
+}
+
+fn main() {
+    Application::new().run(|cx: &mut App| {
+        // On iOS, we use fullscreen bounds
+        cx.open_window(
+            WindowOptions {
+                // iOS windows are always fullscreen
+                window_bounds: None,
+                ..Default::default()
+            },
+            |_, cx| {
+                cx.new(|_| IosHelloWorld {
+                    text: "iOS".into(),
+                    tap_count: 0,
+                })
+            },
+        )
+        .unwrap();
+        cx.activate(true);
+    });
+}

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -8,12 +8,16 @@ mod linux;
 #[cfg(target_os = "macos")]
 mod mac;
 
+#[cfg(target_os = "ios")]
+mod ios;
+
 #[cfg(any(
     all(
         any(target_os = "linux", target_os = "freebsd"),
         any(feature = "x11", feature = "wayland")
     ),
-    all(target_os = "macos", feature = "macos-blade")
+    all(target_os = "macos", feature = "macos-blade"),
+    target_os = "ios"
 ))]
 mod blade;
 
@@ -72,6 +76,8 @@ pub use app_menu::*;
 pub use keyboard::*;
 pub use keystroke::*;
 
+#[cfg(target_os = "ios")]
+pub(crate) use ios::*;
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 pub(crate) use linux::*;
 #[cfg(target_os = "macos")]
@@ -129,6 +135,11 @@ pub(crate) fn current_platform(_headless: bool) -> Rc<dyn Platform> {
             .inspect_err(|err| show_error("Failed to launch", err.to_string()))
             .unwrap(),
     )
+}
+
+#[cfg(target_os = "ios")]
+pub(crate) fn current_platform(_headless: bool) -> Rc<dyn Platform> {
+    Rc::new(IosPlatform::new())
 }
 
 /// Return which compositor we're guessing we'll use.

--- a/crates/gpui/src/platform/blade.rs
+++ b/crates/gpui/src/platform/blade.rs
@@ -1,10 +1,10 @@
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 mod apple_compat;
 mod blade_atlas;
 mod blade_context;
 mod blade_renderer;
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub(crate) use apple_compat::*;
 pub(crate) use blade_atlas::*;
 pub(crate) use blade_context::*;

--- a/crates/gpui/src/platform/blade/apple_compat.rs
+++ b/crates/gpui/src/platform/blade/apple_compat.rs
@@ -31,13 +31,19 @@ pub unsafe fn new_renderer(
     impl rwh::HasWindowHandle for RawWindow {
         fn window_handle(&self) -> Result<rwh::WindowHandle<'_>, rwh::HandleError> {
             let view = NonNull::new(self.view).unwrap();
+            #[cfg(target_os = "macos")]
             let handle = rwh::AppKitWindowHandle::new(view);
+            #[cfg(target_os = "ios")]
+            let handle = rwh::UiKitWindowHandle::new(view);
             Ok(unsafe { rwh::WindowHandle::borrow_raw(handle.into()) })
         }
     }
     impl rwh::HasDisplayHandle for RawWindow {
         fn display_handle(&self) -> Result<rwh::DisplayHandle<'_>, rwh::HandleError> {
+            #[cfg(target_os = "macos")]
             let handle = rwh::AppKitDisplayHandle::new();
+            #[cfg(target_os = "ios")]
+            let handle = rwh::UiKitDisplayHandle::new();
             Ok(unsafe { rwh::DisplayHandle::borrow_raw(handle.into()) })
         }
     }

--- a/crates/gpui/src/platform/blade/blade_context.rs
+++ b/crates/gpui/src/platform/blade/blade_context.rs
@@ -3,7 +3,7 @@ use blade_graphics as gpu;
 use std::sync::Arc;
 use util::ResultExt;
 
-#[cfg_attr(target_os = "macos", derive(Clone))]
+#[cfg_attr(any(target_os = "macos", target_os = "ios"), derive(Clone))]
 pub struct BladeContext {
     pub(super) gpu: Arc<gpu::Context>,
 }

--- a/crates/gpui/src/platform/ios.rs
+++ b/crates/gpui/src/platform/ios.rs
@@ -1,0 +1,124 @@
+//! iOS platform implementation for GPUI.
+//!
+//! iOS uses UIKit instead of AppKit, so the platform implementation differs
+//! significantly from macOS despite sharing many underlying technologies:
+//! - Grand Central Dispatch (GCD) for threading
+//! - CoreText for text rendering
+//! - Metal for GPU rendering
+//! - CoreFoundation for many utilities
+
+pub mod demos;
+mod dispatcher;
+mod display;
+mod events;
+pub mod ffi;
+mod platform;
+mod text_input;
+mod window;
+
+// Re-use the macOS text system since CoreText is available on iOS
+#[cfg(feature = "font-kit")]
+mod text_system;
+
+use crate::{DevicePixels, Pixels, Size, px, size};
+use objc::runtime::{BOOL, NO, YES};
+use std::ops::Range;
+
+pub(crate) use dispatcher::*;
+pub(crate) use display::*;
+pub(crate) use platform::*;
+pub(crate) use window::*;
+
+#[cfg(feature = "font-kit")]
+pub(crate) use text_system::*;
+
+/// Placeholder for iOS screen capture frame type.
+/// iOS uses ReplayKit for screen capture, which would require additional implementation.
+pub(crate) type PlatformScreenCaptureFrame = ();
+
+trait BoolExt {
+    fn to_objc(self) -> BOOL;
+}
+
+impl BoolExt for bool {
+    fn to_objc(self) -> BOOL {
+        if self { YES } else { NO }
+    }
+}
+
+/// NSRange equivalent for iOS (same structure as macOS)
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+struct NSRange {
+    pub location: usize,
+    pub length: usize,
+}
+
+impl NSRange {
+    fn invalid() -> Self {
+        Self {
+            location: usize::MAX,
+            length: 0,
+        }
+    }
+
+    fn is_valid(&self) -> bool {
+        self.location != usize::MAX
+    }
+
+    fn to_range(self) -> Option<Range<usize>> {
+        if self.is_valid() {
+            let start = self.location;
+            let end = start + self.length;
+            Some(start..end)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<Range<usize>> for NSRange {
+    fn from(range: Range<usize>) -> Self {
+        NSRange {
+            location: range.start,
+            length: range.len(),
+        }
+    }
+}
+
+unsafe impl objc::Encode for NSRange {
+    fn encode() -> objc::Encoding {
+        let encoding = format!(
+            "{{NSRange={}{}}}",
+            usize::encode().as_str(),
+            usize::encode().as_str()
+        );
+        unsafe { objc::Encoding::from_str(&encoding) }
+    }
+}
+
+/// Convert a CGSize to Size<Pixels>
+impl From<core_graphics::geometry::CGSize> for Size<Pixels> {
+    fn from(value: core_graphics::geometry::CGSize) -> Self {
+        Size {
+            width: px(value.width as f32),
+            height: px(value.height as f32),
+        }
+    }
+}
+
+/// Convert a CGRect to Size<Pixels>
+impl From<core_graphics::geometry::CGRect> for Size<Pixels> {
+    fn from(rect: core_graphics::geometry::CGRect) -> Self {
+        let core_graphics::geometry::CGSize { width, height } = rect.size;
+        size(px(width as f32), px(height as f32))
+    }
+}
+
+/// Convert a CGRect to Size<DevicePixels>
+impl From<core_graphics::geometry::CGRect> for Size<DevicePixels> {
+    fn from(rect: core_graphics::geometry::CGRect) -> Self {
+        let core_graphics::geometry::CGSize { width, height } = rect.size;
+        size(DevicePixels(width as i32), DevicePixels(height as i32))
+    }
+}

--- a/crates/gpui/src/platform/ios.rs
+++ b/crates/gpui/src/platform/ios.rs
@@ -12,6 +12,7 @@ mod dispatcher;
 mod display;
 mod events;
 pub mod ffi;
+mod file_picker;
 mod platform;
 mod text_input;
 mod window;

--- a/crates/gpui/src/platform/ios/README.md
+++ b/crates/gpui/src/platform/ios/README.md
@@ -1,0 +1,63 @@
+# GPUI iOS Platform
+
+iOS platform implementation for GPUI, providing GPU-accelerated UI rendering on iOS/iPadOS.
+
+## Architecture
+
+```
+platform.rs     IosPlatform - main platform trait implementation
+window.rs       IosWindow - UIWindow/UIViewController management
+display.rs      IosDisplay - UIScreen wrapper
+dispatcher.rs   IosDispatcher - Grand Central Dispatch integration
+events.rs       Touch event handling (tap, drag → mouse events)
+text_system.rs  CoreText-based text rendering (shared with macOS)
+text_input.rs   UITextInput protocol classes for keyboard support
+ffi.rs          C FFI exports for Objective-C interop
+demos/          Interactive demo views
+```
+
+## Key Components
+
+### Rendering
+- **Metal** via Blade graphics backend
+- **60fps** via CADisplayLink
+- Scene primitives: quads, shadows, text, paths
+
+### Text Input
+- **UITextInput protocol** for software keyboard
+- **GPUITextPosition/GPUITextRange** classes wrap UTF-16 offsets
+- **IME support** via marked text handling
+
+### Touch Events
+Touch events are translated to GPUI mouse events:
+| Touch | GPUI Event |
+|-------|------------|
+| Tap | MouseDown + MouseUp |
+| Drag | MouseDown + MouseMove + MouseUp |
+| Two-finger scroll | ScrollWheel |
+
+## Adding a New Demo
+
+1. Create `demos/my_demo.rs` implementing `Render` trait
+2. Add to `demos/mod.rs` exports
+3. Add navigation in `demos/menu.rs`
+
+## Platform Differences from macOS
+
+| Feature | macOS | iOS |
+|---------|-------|-----|
+| Window management | AppKit (NSWindow) | UIKit (UIWindow) |
+| Menu bar | Yes | No |
+| Multiple windows | Yes | Single window |
+| Keyboard | Always available | Software/external |
+| Mouse | Pointer device | Touch translated |
+
+## Testing
+
+```bash
+# Build for simulator
+cargo build --target aarch64-apple-ios-sim -p gpui
+
+# Run example app
+cd examples/ios_app && ./build_and_run.sh
+```

--- a/crates/gpui/src/platform/ios/demos/animation_playground.rs
+++ b/crates/gpui/src/platform/ios/demos/animation_playground.rs
@@ -1,0 +1,544 @@
+//! Animation Playground demo - bouncing balls with physics and particle effects.
+//!
+//! This demo showcases GPUI's animation and rendering capabilities on iOS:
+//! - Tap to spawn bouncing balls with physics simulation
+//! - Balls have trails and particle effects
+//! - Demonstrates smooth 60fps rendering
+
+use super::{BACKGROUND, TEXT, back_button, random_color};
+use crate::{
+    App, Bounds, Hsla, MouseButton, MouseDownEvent, MouseUpEvent, Pixels, Point, Window, canvas,
+    div, fill, hsla, point, prelude::*, px, rgb, size,
+};
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+// Physics constants
+const GRAVITY: f32 = 980.0; // pixels/sec^2
+const BOUNCE_DAMPING: f32 = 0.7; // velocity retained after bounce
+const FRICTION: f32 = 0.995; // velocity multiplier per frame
+const MAX_BALLS: usize = 30;
+const TRAIL_LENGTH: usize = 12;
+const BALL_RADIUS: f32 = 20.0;
+const PARTICLE_COUNT: usize = 12;
+const PARTICLE_DURATION_MS: u64 = 600;
+
+/// A bouncing ball with physics
+#[derive(Clone)]
+struct Ball {
+    position: Point<f32>,
+    velocity: Point<f32>,
+    radius: f32,
+    color: Hsla,
+    trail: VecDeque<Point<f32>>,
+}
+
+impl Ball {
+    fn new(id: usize, position: Point<f32>, velocity: Point<f32>) -> Self {
+        let color_rgb = random_color(id);
+        Self {
+            position,
+            velocity,
+            radius: BALL_RADIUS,
+            color: rgb(color_rgb).into(),
+            trail: VecDeque::with_capacity(TRAIL_LENGTH),
+        }
+    }
+
+    fn update(&mut self, dt: f32, bounds: &Bounds<f32>) {
+        // Store trail position
+        if self.trail.len() >= TRAIL_LENGTH {
+            self.trail.pop_front();
+        }
+        self.trail.push_back(self.position);
+
+        // Apply gravity
+        self.velocity.y += GRAVITY * dt;
+
+        // Apply friction
+        self.velocity.x *= FRICTION;
+        self.velocity.y *= FRICTION;
+
+        // Update position
+        self.position.x += self.velocity.x * dt;
+        self.position.y += self.velocity.y * dt;
+
+        // Bounce off walls
+        let min_x = bounds.origin.x + self.radius;
+        let max_x = bounds.origin.x + bounds.size.width - self.radius;
+        let min_y = bounds.origin.y + self.radius;
+        let max_y = bounds.origin.y + bounds.size.height - self.radius;
+
+        if self.position.x < min_x {
+            self.position.x = min_x;
+            self.velocity.x = -self.velocity.x * BOUNCE_DAMPING;
+        } else if self.position.x > max_x {
+            self.position.x = max_x;
+            self.velocity.x = -self.velocity.x * BOUNCE_DAMPING;
+        }
+
+        if self.position.y < min_y {
+            self.position.y = min_y;
+            self.velocity.y = -self.velocity.y * BOUNCE_DAMPING;
+        } else if self.position.y > max_y {
+            self.position.y = max_y;
+            self.velocity.y = -self.velocity.y * BOUNCE_DAMPING;
+        }
+    }
+}
+
+/// A particle for burst effects
+#[derive(Clone)]
+struct Particle {
+    position: Point<f32>,
+    velocity: Point<f32>,
+    start_time: Instant,
+    duration: Duration,
+    color: Hsla,
+    size: f32,
+}
+
+impl Particle {
+    fn new(position: Point<f32>, angle: f32, speed: f32, color: Hsla) -> Self {
+        let velocity = point(angle.cos() * speed, angle.sin() * speed);
+        Self {
+            position,
+            velocity,
+            start_time: Instant::now(),
+            duration: Duration::from_millis(PARTICLE_DURATION_MS),
+            color,
+            size: 8.0,
+        }
+    }
+
+    fn update(&mut self, dt: f32) {
+        self.position.x += self.velocity.x * dt;
+        self.position.y += self.velocity.y * dt;
+        // Slow down
+        self.velocity.x *= 0.98;
+        self.velocity.y *= 0.98;
+    }
+
+    fn progress(&self) -> f32 {
+        let elapsed = self.start_time.elapsed().as_secs_f32();
+        (elapsed / self.duration.as_secs_f32()).min(1.0)
+    }
+
+    fn is_alive(&self) -> bool {
+        self.start_time.elapsed() < self.duration
+    }
+}
+
+/// Animation Playground demo view
+pub struct AnimationPlayground {
+    balls: Vec<Ball>,
+    particles: Vec<Particle>,
+    last_frame_time: Instant,
+    pub next_ball_id: usize,
+    pub touch_start: Option<(Point<f32>, Instant)>,
+    pub current_touch: Option<Point<f32>>,
+    bounds: Bounds<f32>,
+    #[allow(dead_code)]
+    on_back: Option<Box<dyn Fn(&mut Window, &mut App) + 'static>>,
+}
+
+impl AnimationPlayground {
+    pub fn new() -> Self {
+        Self {
+            balls: Vec::new(),
+            particles: Vec::new(),
+            last_frame_time: Instant::now(),
+            next_ball_id: 0,
+            touch_start: None,
+            current_touch: None,
+            bounds: Bounds {
+                origin: point(0.0, 0.0),
+                size: size(400.0, 800.0),
+            },
+            on_back: None,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn with_on_back<F>(mut self, on_back: F) -> Self
+    where
+        F: Fn(&mut Window, &mut App) + 'static,
+    {
+        self.on_back = Some(Box::new(on_back));
+        self
+    }
+
+    pub fn spawn_ball(&mut self, position: Point<f32>, velocity: Point<f32>) {
+        if self.balls.len() >= MAX_BALLS {
+            self.balls.remove(0);
+        }
+        let ball = Ball::new(self.next_ball_id, position, velocity);
+        self.next_ball_id += 1;
+        self.balls.push(ball);
+    }
+
+    pub fn spawn_particles(&mut self, position: Point<f32>, color: Hsla) {
+        let angle_step = std::f32::consts::PI * 2.0 / PARTICLE_COUNT as f32;
+        for i in 0..PARTICLE_COUNT {
+            let angle = angle_step * i as f32;
+            let speed = 200.0 + (i as f32 * 20.0);
+            self.particles
+                .push(Particle::new(position, angle, speed, color));
+        }
+    }
+
+    fn update_physics(&mut self) {
+        let now = Instant::now();
+        let dt = now.duration_since(self.last_frame_time).as_secs_f32();
+        self.last_frame_time = now;
+
+        // Cap dt to prevent huge jumps
+        let dt = dt.min(0.05);
+
+        // Update balls
+        for ball in &mut self.balls {
+            ball.update(dt, &self.bounds);
+        }
+
+        // Update particles
+        for particle in &mut self.particles {
+            particle.update(dt);
+        }
+
+        // Remove dead particles
+        self.particles.retain(|p| p.is_alive());
+    }
+
+    fn handle_touch_down(&mut self, event: &MouseDownEvent, cx: &mut crate::Context<Self>) {
+        let pos = point(event.position.x.0, event.position.y.0);
+        self.touch_start = Some((pos, Instant::now()));
+        self.current_touch = Some(pos);
+        cx.notify();
+    }
+
+    fn handle_touch_up(&mut self, event: &MouseUpEvent, cx: &mut crate::Context<Self>) {
+        let position = point(event.position.x.0, event.position.y.0);
+
+        if let Some((start_pos, start_time)) = self.touch_start.take() {
+            let elapsed = start_time.elapsed();
+            let dx = position.x - start_pos.x;
+            let dy = position.y - start_pos.y;
+            let distance = (dx * dx + dy * dy).sqrt();
+
+            // If short tap with little movement, spawn particles
+            if elapsed < Duration::from_millis(200) && distance < 20.0 {
+                let color_rgb = random_color(self.next_ball_id);
+                self.spawn_particles(position, rgb(color_rgb).into());
+                self.next_ball_id += 1;
+            } else {
+                // Calculate velocity from drag
+                let dt = elapsed.as_secs_f32().max(0.01);
+                let velocity = point(dx / dt * 0.5, dy / dt * 0.5);
+                self.spawn_ball(start_pos, velocity);
+            }
+        }
+        self.current_touch = None;
+        cx.notify();
+    }
+
+    pub fn render_with_back_button<F>(
+        &mut self,
+        window: &mut Window,
+        on_back: F,
+    ) -> impl IntoElement
+    where
+        F: Fn(&(), &mut Window, &mut App) + 'static,
+    {
+        // Request continuous animation frame
+        window.request_animation_frame();
+
+        // Update physics each frame
+        self.update_physics();
+
+        // Clone data for rendering
+        let balls = self.balls.clone();
+        let particles = self.particles.clone();
+        let touch_start = self.touch_start.map(|(p, _)| p);
+        let current_touch = self.current_touch;
+
+        div()
+            .size_full()
+            .bg(rgb(BACKGROUND))
+            .child(
+                canvas(
+                    move |bounds, _window, _cx| {
+                        // Convert bounds to f32 for physics
+                        let bounds_f32 = Bounds {
+                            origin: point(bounds.origin.x.0, bounds.origin.y.0),
+                            size: size(bounds.size.width.0, bounds.size.height.0),
+                        };
+                        (
+                            bounds_f32,
+                            balls.clone(),
+                            particles.clone(),
+                            touch_start,
+                            current_touch,
+                        )
+                    },
+                    move |_bounds,
+                          (_bounds_f32, balls, particles, touch_start, current_touch),
+                          window,
+                          _cx| {
+                        // Draw trails
+                        for ball in &balls {
+                            for (i, &trail_pos) in ball.trail.iter().enumerate() {
+                                let alpha = (i as f32 / TRAIL_LENGTH as f32) * 0.4;
+                                let trail_size =
+                                    ball.radius * (0.3 + 0.7 * i as f32 / TRAIL_LENGTH as f32);
+                                let color = hsla(ball.color.h, ball.color.s, ball.color.l, alpha);
+                                paint_circle(
+                                    window,
+                                    point(px(trail_pos.x), px(trail_pos.y)),
+                                    px(trail_size),
+                                    color,
+                                );
+                            }
+                        }
+
+                        // Draw particles
+                        for particle in &particles {
+                            let progress = particle.progress();
+                            let alpha = 1.0 - progress;
+                            let size = particle.size * (1.0 - progress * 0.5);
+                            let color =
+                                hsla(particle.color.h, particle.color.s, particle.color.l, alpha);
+                            paint_circle(
+                                window,
+                                point(px(particle.position.x), px(particle.position.y)),
+                                px(size),
+                                color,
+                            );
+                        }
+
+                        // Draw balls
+                        for ball in &balls {
+                            paint_circle(
+                                window,
+                                point(px(ball.position.x), px(ball.position.y)),
+                                px(ball.radius),
+                                ball.color,
+                            );
+                            // Inner highlight
+                            let highlight = hsla(ball.color.h, ball.color.s * 0.5, 0.9, 0.5);
+                            paint_circle(
+                                window,
+                                point(
+                                    px(ball.position.x - ball.radius * 0.3),
+                                    px(ball.position.y - ball.radius * 0.3),
+                                ),
+                                px(ball.radius * 0.3),
+                                highlight,
+                            );
+                        }
+
+                        // Draw drag line if dragging
+                        if let (Some(start), Some(current)) = (touch_start, current_touch) {
+                            // Draw a line from start to current (using dots)
+                            let dx = current.x - start.x;
+                            let dy = current.y - start.y;
+                            let dist = (dx * dx + dy * dy).sqrt();
+                            let steps = (dist / 10.0) as i32;
+                            for i in 0..=steps {
+                                let t = i as f32 / steps.max(1) as f32;
+                                let x = start.x + dx * t;
+                                let y = start.y + dy * t;
+                                paint_circle(
+                                    window,
+                                    point(px(x), px(y)),
+                                    px(3.0),
+                                    hsla(0.0, 0.0, 1.0, 0.5),
+                                );
+                            }
+                        }
+                    },
+                )
+                .size_full(),
+            )
+            // Instructions
+            .child(
+                div()
+                    .absolute()
+                    .bottom(px(100.0))
+                    .left_0()
+                    .right_0()
+                    .flex()
+                    .justify_center()
+                    .child(
+                        div()
+                            .px_4()
+                            .py_2()
+                            .bg(hsla(0.0, 0.0, 0.1, 0.8))
+                            .rounded_lg()
+                            .text_color(rgb(TEXT))
+                            .text_sm()
+                            .child("Tap to burst, drag to throw balls"),
+                    ),
+            )
+            // Back button
+            .child(back_button(on_back))
+    }
+
+    /// Update bounds from the canvas callback
+    pub fn set_bounds(&mut self, bounds: Bounds<f32>) {
+        self.bounds = bounds;
+    }
+}
+
+impl crate::Render for AnimationPlayground {
+    fn render(&mut self, window: &mut Window, cx: &mut crate::Context<Self>) -> impl IntoElement {
+        // Request continuous animation frame
+        window.request_animation_frame();
+
+        // Update physics each frame
+        self.update_physics();
+
+        // Clone data for rendering
+        let balls = self.balls.clone();
+        let particles = self.particles.clone();
+        let touch_start = self.touch_start.map(|(p, _)| p);
+        let current_touch = self.current_touch;
+
+        div()
+            .size_full()
+            .bg(rgb(BACKGROUND))
+            // Touch handling layer
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, event, _window, cx| {
+                    this.handle_touch_down(event, cx);
+                }),
+            )
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(|this, event, _window, cx| {
+                    this.handle_touch_up(event, cx);
+                }),
+            )
+            .child(
+                canvas(
+                    move |bounds, _window, _cx| {
+                        let bounds_f32 = Bounds {
+                            origin: point(bounds.origin.x.0, bounds.origin.y.0),
+                            size: size(bounds.size.width.0, bounds.size.height.0),
+                        };
+                        (
+                            bounds_f32,
+                            balls.clone(),
+                            particles.clone(),
+                            touch_start,
+                            current_touch,
+                        )
+                    },
+                    move |_bounds,
+                          (_bounds_f32, balls, particles, touch_start, current_touch),
+                          window,
+                          _cx| {
+                        // Draw trails
+                        for ball in &balls {
+                            for (i, &trail_pos) in ball.trail.iter().enumerate() {
+                                let alpha = (i as f32 / TRAIL_LENGTH as f32) * 0.4;
+                                let trail_size =
+                                    ball.radius * (0.3 + 0.7 * i as f32 / TRAIL_LENGTH as f32);
+                                let color = hsla(ball.color.h, ball.color.s, ball.color.l, alpha);
+                                paint_circle(
+                                    window,
+                                    point(px(trail_pos.x), px(trail_pos.y)),
+                                    px(trail_size),
+                                    color,
+                                );
+                            }
+                        }
+
+                        // Draw particles
+                        for particle in &particles {
+                            let progress = particle.progress();
+                            let alpha = 1.0 - progress;
+                            let psize = particle.size * (1.0 - progress * 0.5);
+                            let color =
+                                hsla(particle.color.h, particle.color.s, particle.color.l, alpha);
+                            paint_circle(
+                                window,
+                                point(px(particle.position.x), px(particle.position.y)),
+                                px(psize),
+                                color,
+                            );
+                        }
+
+                        // Draw balls
+                        for ball in &balls {
+                            paint_circle(
+                                window,
+                                point(px(ball.position.x), px(ball.position.y)),
+                                px(ball.radius),
+                                ball.color,
+                            );
+                            let highlight = hsla(ball.color.h, ball.color.s * 0.5, 0.9, 0.5);
+                            paint_circle(
+                                window,
+                                point(
+                                    px(ball.position.x - ball.radius * 0.3),
+                                    px(ball.position.y - ball.radius * 0.3),
+                                ),
+                                px(ball.radius * 0.3),
+                                highlight,
+                            );
+                        }
+
+                        // Draw drag line if dragging
+                        if let (Some(start), Some(current)) = (touch_start, current_touch) {
+                            let dx = current.x - start.x;
+                            let dy = current.y - start.y;
+                            let dist = (dx * dx + dy * dy).sqrt();
+                            let steps = (dist / 10.0) as i32;
+                            for i in 0..=steps {
+                                let t = i as f32 / steps.max(1) as f32;
+                                let x = start.x + dx * t;
+                                let y = start.y + dy * t;
+                                paint_circle(
+                                    window,
+                                    point(px(x), px(y)),
+                                    px(3.0),
+                                    hsla(0.0, 0.0, 1.0, 0.5),
+                                );
+                            }
+                        }
+                    },
+                )
+                .size_full(),
+            )
+            // Instructions
+            .child(
+                div()
+                    .absolute()
+                    .bottom(px(100.0))
+                    .left_0()
+                    .right_0()
+                    .flex()
+                    .justify_center()
+                    .child(
+                        div()
+                            .px_4()
+                            .py_2()
+                            .bg(hsla(0.0, 0.0, 0.1, 0.8))
+                            .rounded_lg()
+                            .text_color(rgb(TEXT))
+                            .text_sm()
+                            .child("Tap to burst, drag to throw balls"),
+                    ),
+            )
+    }
+}
+
+/// Paint a filled circle
+fn paint_circle(window: &mut Window, center: Point<Pixels>, radius: Pixels, color: Hsla) {
+    let bounds = Bounds {
+        origin: point(center.x - radius, center.y - radius),
+        size: size(radius * 2.0, radius * 2.0),
+    };
+    window.paint_quad(fill(bounds, color).corner_radii(radius));
+}

--- a/crates/gpui/src/platform/ios/demos/menu.rs
+++ b/crates/gpui/src/platform/ios/demos/menu.rs
@@ -1,0 +1,350 @@
+//! Main menu for iOS demos.
+//!
+//! Provides a menu to select between different demo views.
+
+use super::{
+    AnimationPlayground, BACKGROUND, BLUE, MAUVE, OVERLAY, SUBTEXT, SURFACE, ShaderShowcase, TEXT,
+};
+use crate::{
+    App, Bounds, Context, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Render,
+    Window, div, hsla, point, prelude::*, px, rgb, size,
+};
+
+/// Which demo is currently active
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub enum ActiveDemo {
+    #[default]
+    Menu,
+    AnimationPlayground,
+    ShaderShowcase,
+}
+
+/// Root application view that manages demo navigation
+pub struct DemoApp {
+    active: ActiveDemo,
+    animation_playground: Option<AnimationPlayground>,
+    shader_showcase: Option<ShaderShowcase>,
+}
+
+impl DemoApp {
+    pub fn new() -> Self {
+        Self {
+            active: ActiveDemo::Menu,
+            animation_playground: None,
+            shader_showcase: None,
+        }
+    }
+
+    fn go_to_animation_playground(&mut self, cx: &mut Context<Self>) {
+        self.animation_playground = Some(AnimationPlayground::new());
+        self.active = ActiveDemo::AnimationPlayground;
+        cx.notify();
+    }
+
+    fn go_to_shader_showcase(&mut self, cx: &mut Context<Self>) {
+        self.shader_showcase = Some(ShaderShowcase::new());
+        self.active = ActiveDemo::ShaderShowcase;
+        cx.notify();
+    }
+
+    fn go_to_menu(&mut self, cx: &mut Context<Self>) {
+        self.active = ActiveDemo::Menu;
+        self.animation_playground = None;
+        self.shader_showcase = None;
+        cx.notify();
+    }
+
+    fn handle_animation_touch_down(&mut self, event: &MouseDownEvent, cx: &mut Context<Self>) {
+        if let Some(playground) = &mut self.animation_playground {
+            let pos = point(event.position.x.0, event.position.y.0);
+            playground.touch_start = Some((pos, std::time::Instant::now()));
+            playground.current_touch = Some(pos);
+            cx.notify();
+        }
+    }
+
+    fn handle_animation_touch_up(&mut self, event: &MouseUpEvent, cx: &mut Context<Self>) {
+        if let Some(playground) = &mut self.animation_playground {
+            let position = point(event.position.x.0, event.position.y.0);
+
+            if let Some((start_pos, start_time)) = playground.touch_start.take() {
+                let elapsed = start_time.elapsed();
+                let dx = position.x - start_pos.x;
+                let dy = position.y - start_pos.y;
+                let distance = (dx * dx + dy * dy).sqrt();
+
+                if elapsed < std::time::Duration::from_millis(200) && distance < 20.0 {
+                    let color_rgb = super::random_color(playground.next_ball_id);
+                    playground.spawn_particles(position, rgb(color_rgb).into());
+                    playground.next_ball_id += 1;
+                } else {
+                    let dt = elapsed.as_secs_f32().max(0.01);
+                    let velocity = point(dx / dt * 0.5, dy / dt * 0.5);
+                    playground.spawn_ball(start_pos, velocity);
+                }
+            }
+            playground.current_touch = None;
+            cx.notify();
+        }
+    }
+
+    fn handle_shader_touch_down(&mut self, event: &MouseDownEvent, cx: &mut Context<Self>) {
+        if let Some(showcase) = &mut self.shader_showcase {
+            let pos = point(event.position.x.0, event.position.y.0);
+            showcase.touch_position = Some(pos);
+            showcase.spawn_ripple(pos);
+            cx.notify();
+        }
+    }
+
+    fn handle_shader_touch_move(&mut self, event: &MouseMoveEvent, cx: &mut Context<Self>) {
+        if let Some(showcase) = &mut self.shader_showcase {
+            let pos = point(event.position.x.0, event.position.y.0);
+            showcase.touch_position = Some(pos);
+            cx.notify();
+        }
+    }
+
+    fn handle_shader_touch_up(&mut self, _event: &MouseUpEvent, cx: &mut Context<Self>) {
+        if let Some(showcase) = &mut self.shader_showcase {
+            showcase.touch_position = None;
+            cx.notify();
+        }
+    }
+}
+
+impl Render for DemoApp {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        match self.active {
+            ActiveDemo::Menu => self.render_menu(window, cx).into_any_element(),
+            ActiveDemo::AnimationPlayground => self
+                .render_animation_playground(window, cx)
+                .into_any_element(),
+            ActiveDemo::ShaderShowcase => {
+                self.render_shader_showcase(window, cx).into_any_element()
+            }
+        }
+    }
+}
+
+impl DemoApp {
+    fn render_menu(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> crate::AnyElement {
+        div()
+            .flex()
+            .flex_col()
+            .size_full()
+            .bg(rgb(BACKGROUND))
+            .justify_center()
+            .items_center()
+            .gap_6()
+            // Title
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .items_center()
+                    .gap_2()
+                    .child(div().text_3xl().text_color(rgb(TEXT)).child("GPUI on iOS"))
+                    .child(
+                        div()
+                            .text_lg()
+                            .text_color(rgb(SUBTEXT))
+                            .child("Interactive Demos"),
+                    ),
+            )
+            // Demo buttons
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap_4()
+                    .w(px(300.0))
+                    // Animation Playground button
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap_1()
+                            .px_6()
+                            .py_4()
+                            .bg(rgb(SURFACE))
+                            .rounded_xl()
+                            .border_l_4()
+                            .border_color(rgb(BLUE))
+                            .child(
+                                div()
+                                    .text_xl()
+                                    .text_color(rgb(TEXT))
+                                    .child("Animation Playground"),
+                            )
+                            .child(
+                                div()
+                                    .text_sm()
+                                    .text_color(rgb(SUBTEXT))
+                                    .child("Bouncing balls & particle effects"),
+                            )
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(|this, _, _, cx| {
+                                    this.go_to_animation_playground(cx);
+                                }),
+                            ),
+                    )
+                    // Shader Showcase button
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap_1()
+                            .px_6()
+                            .py_4()
+                            .bg(rgb(SURFACE))
+                            .rounded_xl()
+                            .border_l_4()
+                            .border_color(rgb(MAUVE))
+                            .child(
+                                div()
+                                    .text_xl()
+                                    .text_color(rgb(TEXT))
+                                    .child("Shader Showcase"),
+                            )
+                            .child(
+                                div()
+                                    .text_sm()
+                                    .text_color(rgb(SUBTEXT))
+                                    .child("Dynamic gradients & visual effects"),
+                            )
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(|this, _, _, cx| {
+                                    this.go_to_shader_showcase(cx);
+                                }),
+                            ),
+                    ),
+            )
+            // Footer
+            .child(
+                div()
+                    .mt_8()
+                    .text_sm()
+                    .text_color(rgb(OVERLAY))
+                    .child("Powered by GPUI"),
+            )
+            .into_any_element()
+    }
+}
+
+impl DemoApp {
+    fn render_animation_playground(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> crate::AnyElement {
+        // Request continuous animation frame
+        window.request_animation_frame();
+
+        // Update bounds
+        let viewport = window.viewport_size();
+        if let Some(playground) = &mut self.animation_playground {
+            playground.set_bounds(Bounds {
+                origin: point(0.0, 0.0),
+                size: size(viewport.width.0, viewport.height.0),
+            });
+        }
+
+        div()
+            .size_full()
+            .bg(rgb(BACKGROUND))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, event, _window, cx| {
+                    this.handle_animation_touch_down(event, cx);
+                }),
+            )
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(|this, event, _window, cx| {
+                    this.handle_animation_touch_up(event, cx);
+                }),
+            )
+            .child(if let Some(playground) = &mut self.animation_playground {
+                playground
+                    .render_with_back_button(window, |_, _window, _cx| {
+                        // Back button handled below
+                    })
+                    .into_any_element()
+            } else {
+                div().into_any_element()
+            })
+            .child(back_button(cx.listener(|this, _, _window, cx| {
+                this.go_to_menu(cx);
+            })))
+            .into_any_element()
+    }
+
+    fn render_shader_showcase(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> crate::AnyElement {
+        // Request continuous animation frame
+        window.request_animation_frame();
+
+        // Update screen center
+        if let Some(showcase) = &mut self.shader_showcase {
+            let viewport = window.viewport_size();
+            showcase.set_screen_center(point(viewport.width.0 / 2.0, viewport.height.0 / 2.0));
+        }
+
+        div()
+            .size_full()
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, event, _window, cx| {
+                    this.handle_shader_touch_down(event, cx);
+                }),
+            )
+            .on_mouse_move(cx.listener(|this, event, _window, cx| {
+                this.handle_shader_touch_move(event, cx);
+            }))
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(|this, event, _window, cx| {
+                    this.handle_shader_touch_up(event, cx);
+                }),
+            )
+            .child(if let Some(showcase) = &mut self.shader_showcase {
+                showcase
+                    .render_with_back_button(window, |_, _window, _cx| {
+                        // Back button handled below
+                    })
+                    .into_any_element()
+            } else {
+                div().into_any_element()
+            })
+            .child(back_button(cx.listener(|this, _, _window, cx| {
+                this.go_to_menu(cx);
+            })))
+            .into_any_element()
+    }
+}
+
+/// Back button component for returning to menu
+pub fn back_button<F>(on_click: F) -> impl IntoElement
+where
+    F: Fn(&(), &mut Window, &mut App) + 'static,
+{
+    div()
+        .absolute()
+        .top(px(50.0))
+        .left(px(20.0))
+        .px_4()
+        .py_2()
+        .bg(hsla(0.0, 0.0, 0.2, 0.8))
+        .rounded_lg()
+        .text_color(rgb(TEXT))
+        .child("< Back")
+        .on_mouse_down(MouseButton::Left, move |_, window, cx| {
+            on_click(&(), window, cx);
+        })
+}

--- a/crates/gpui/src/platform/ios/demos/menu.rs
+++ b/crates/gpui/src/platform/ios/demos/menu.rs
@@ -3,11 +3,13 @@
 //! Provides a menu to select between different demo views.
 
 use super::{
-    AnimationPlayground, BACKGROUND, BLUE, MAUVE, OVERLAY, SUBTEXT, SURFACE, ShaderShowcase, TEXT,
+    AnimationPlayground, BACKGROUND, BLUE, GREEN, MAUVE, OVERLAY, SUBTEXT, SURFACE, ShaderShowcase,
+    TEXT, TextEditor,
 };
 use crate::{
-    App, Bounds, Context, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Render,
-    Window, div, hsla, point, prelude::*, px, rgb, size,
+    App, Bounds, Context, ElementInputHandler, Entity, Focusable, KeyDownEvent, MouseButton,
+    MouseDownEvent, MouseMoveEvent, MouseUpEvent, Render, ScrollDelta, ScrollWheelEvent, Window,
+    div, hsla, point, prelude::*, px, rgb, size,
 };
 
 /// Which demo is currently active
@@ -17,6 +19,7 @@ pub enum ActiveDemo {
     Menu,
     AnimationPlayground,
     ShaderShowcase,
+    TextEditor,
 }
 
 /// Root application view that manages demo navigation
@@ -24,6 +27,9 @@ pub struct DemoApp {
     active: ActiveDemo,
     animation_playground: Option<AnimationPlayground>,
     shader_showcase: Option<ShaderShowcase>,
+    text_editor: Option<Entity<TextEditor>>,
+    /// Bounds for text editor input handler
+    text_editor_bounds: Option<Bounds<crate::Pixels>>,
 }
 
 impl DemoApp {
@@ -32,6 +38,8 @@ impl DemoApp {
             active: ActiveDemo::Menu,
             animation_playground: None,
             shader_showcase: None,
+            text_editor: None,
+            text_editor_bounds: None,
         }
     }
 
@@ -47,10 +55,32 @@ impl DemoApp {
         cx.notify();
     }
 
+    fn go_to_text_editor(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        println!("GPUI iOS: go_to_text_editor called");
+        // Create TextEditor as an Entity so we can use handle_input
+        let editor = cx.new(|cx| {
+            let mut editor = TextEditor::new();
+            editor.init_focus(cx);
+            editor
+        });
+
+        // Focus the editor to enable keyboard input
+        let focus = editor.read(cx).focus_handle(cx);
+        println!("GPUI iOS: Focusing editor");
+        window.focus(&focus);
+
+        self.text_editor = Some(editor);
+        self.text_editor_bounds = None;
+        self.active = ActiveDemo::TextEditor;
+        cx.notify();
+        println!("GPUI iOS: go_to_text_editor completed");
+    }
+
     fn go_to_menu(&mut self, cx: &mut Context<Self>) {
         self.active = ActiveDemo::Menu;
         self.animation_playground = None;
         self.shader_showcase = None;
+        self.text_editor = None;
         cx.notify();
     }
 
@@ -123,6 +153,7 @@ impl Render for DemoApp {
             ActiveDemo::ShaderShowcase => {
                 self.render_shader_showcase(window, cx).into_any_element()
             }
+            ActiveDemo::TextEditor => self.render_text_editor(window, cx).into_any_element(),
         }
     }
 }
@@ -218,6 +249,37 @@ impl DemoApp {
                                 MouseButton::Left,
                                 cx.listener(|this, _, _, cx| {
                                     this.go_to_shader_showcase(cx);
+                                }),
+                            ),
+                    )
+                    // Text Editor button
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap_1()
+                            .px_6()
+                            .py_4()
+                            .bg(rgb(SURFACE))
+                            .rounded_xl()
+                            .border_l_4()
+                            .border_color(rgb(GREEN))
+                            .child(
+                                div()
+                                    .text_xl()
+                                    .text_color(rgb(TEXT))
+                                    .child("Text Editor"),
+                            )
+                            .child(
+                                div()
+                                    .text_sm()
+                                    .text_color(rgb(SUBTEXT))
+                                    .child("Text editing & cursor control"),
+                            )
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(|this, _, window, cx| {
+                                    this.go_to_text_editor(window, cx);
                                 }),
                             ),
                     ),
@@ -319,6 +381,175 @@ impl DemoApp {
                         // Back button handled below
                     })
                     .into_any_element()
+            } else {
+                div().into_any_element()
+            })
+            .child(back_button(cx.listener(|this, _, _window, cx| {
+                this.go_to_menu(cx);
+            })))
+            .into_any_element()
+    }
+
+    fn render_text_editor(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> crate::AnyElement {
+        // Calculate viewport height for scroll handling (subtract header and footer)
+        let viewport = window.viewport_size();
+        let content_viewport_height = viewport.height.0 - 100.0 - 60.0; // HEADER_HEIGHT - FOOTER_HEIGHT
+
+        // Store bounds for input handler
+        let bounds = Bounds {
+            origin: point(px(0.0), px(100.0)), // Below header
+            size: size(viewport.width, viewport.height - px(160.0)), // Minus header and footer
+        };
+        self.text_editor_bounds = Some(bounds);
+
+        // Get the entity for input handling
+        let editor_entity = self.text_editor.clone();
+
+        // Register the input handler for keyboard input
+        if let Some(editor) = &self.text_editor {
+            let focus = editor.read(cx).focus_handle(cx);
+            let is_focused = focus.is_focused(window);
+            println!("GPUI iOS: render_text_editor - focus_handle.is_focused = {}", is_focused);
+            window.handle_input(
+                &focus,
+                ElementInputHandler::new(bounds, editor.clone()),
+                cx,
+            );
+            println!("GPUI iOS: render_text_editor - handle_input called");
+        }
+
+        div()
+            .size_full()
+            // Track focus for keyboard input
+            .when_some(editor_entity.as_ref(), |div, editor| {
+                let focus = editor.read(cx).focus_handle(cx);
+                div.track_focus(&focus)
+            })
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, event: &MouseDownEvent, window, cx| {
+                    if let Some(editor) = &this.text_editor {
+                        let pos = point(event.position.x.0, event.position.y.0);
+                        editor.update(cx, |editor, _cx| {
+                            editor.set_last_touch_y(pos.y);
+                            editor.start_drag();
+                            editor.handle_touch_down(pos, window);
+                        });
+
+                        // Focus the editor on touch
+                        let focus = editor.read(cx).focus_handle(cx);
+                        window.focus(&focus);
+
+                        cx.notify();
+                    }
+                }),
+            )
+            .on_mouse_move(cx.listener(move |this, event: &MouseMoveEvent, window, cx| {
+                if let Some(editor) = &this.text_editor {
+                    let pos = point(event.position.x.0, event.position.y.0);
+                    // Check if mouse button is pressed (dragging)
+                    let is_dragging = event.pressed_button.is_some();
+                    let is_selecting = editor.read(cx).is_selecting();
+
+                    editor.update(cx, |editor, _cx| {
+                        if is_dragging && is_selecting {
+                            // Extend text selection
+                            editor.handle_touch_move(pos, window);
+                        } else {
+                            // Scroll behavior (for two-finger scroll or when not selecting)
+                            let delta_y = pos.y - editor.last_touch_y();
+                            editor.set_last_touch_y(pos.y);
+                            editor.handle_scroll(delta_y, content_viewport_height);
+                        }
+                    });
+                    cx.notify();
+                }
+            }))
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(move |this, _event: &MouseUpEvent, _window, cx| {
+                    if let Some(editor) = &this.text_editor {
+                        editor.update(cx, |editor, _cx| {
+                            editor.end_selection();
+                            editor.end_drag();
+                            editor.update_momentum(content_viewport_height);
+                        });
+                        cx.notify();
+                    }
+                }),
+            )
+            .on_scroll_wheel(cx.listener(move |this, event: &ScrollWheelEvent, _window, cx| {
+                if let Some(editor) = &this.text_editor {
+                    let delta_y = match event.delta {
+                        ScrollDelta::Pixels(p) => p.y.0,
+                        ScrollDelta::Lines(l) => l.y * 25.0,
+                    };
+                    editor.update(cx, |editor, _cx| {
+                        editor.handle_scroll(delta_y, content_viewport_height);
+                    });
+                    cx.notify();
+                }
+            }))
+            // Keyboard handling for hardware keyboards and key event fallback
+            // Note: When insertText falls back to key events (because input handler is
+            // temporarily unavailable during GPUI's rendering cycle), printable characters
+            // come through here and need to be inserted into the editor.
+            .on_key_down(cx.listener(|this, event: &KeyDownEvent, _window, cx| {
+                println!("GPUI iOS: on_key_down handler - key: {}, key_char: {:?}",
+                    event.keystroke.key, event.keystroke.key_char);
+                if let Some(editor) = &this.text_editor {
+                    let key = event.keystroke.key.as_str();
+                    let shift = event.keystroke.modifiers.shift;
+                    let cmd = event.keystroke.modifiers.platform;
+                    println!("GPUI iOS: on_key_down - processing key: {}", key);
+
+                    editor.update(cx, |editor, _cx| {
+                        match key {
+                            "left" => {
+                                if shift {
+                                    editor.select_left();
+                                } else {
+                                    editor.move_left();
+                                }
+                            }
+                            "right" => {
+                                if shift {
+                                    editor.select_right();
+                                } else {
+                                    editor.move_right();
+                                }
+                            }
+                            "up" => editor.move_up(),
+                            "down" => editor.move_down(),
+                            // Note: backspace and delete are handled by UIKeyInput protocol
+                            // (deleteBackward method in window.rs), not here.
+                            // Handling them here would cause double-deletion.
+                            "a" if cmd => editor.select_all(),
+                            _ => {
+                                // Handle printable characters (fallback from insertText when
+                                // input handler is temporarily unavailable)
+                                if let Some(key_char) = &event.keystroke.key_char {
+                                    println!("GPUI iOS: on_key_down - inserting character via fallback: {:?}", key_char);
+                                    editor.insert_text(key_char);
+                                }
+                            }
+                        }
+                    });
+                    cx.notify();
+                }
+            }))
+            .child(if let Some(editor) = &self.text_editor {
+                editor.update(cx, |editor, _cx| {
+                    editor
+                        .render_with_back_button(window, |_, _window, _cx| {
+                            // Back button handled below
+                        })
+                        .into_any_element()
+                })
             } else {
                 div().into_any_element()
             })

--- a/crates/gpui/src/platform/ios/demos/menu.rs
+++ b/crates/gpui/src/platform/ios/demos/menu.rs
@@ -3,13 +3,13 @@
 //! Provides a menu to select between different demo views.
 
 use super::{
-    AnimationPlayground, BACKGROUND, BLUE, GREEN, MAUVE, OVERLAY, SUBTEXT, SURFACE, ShaderShowcase,
-    TEXT, TextEditor,
+    AnimationPlayground, BACKGROUND, BLUE, GREEN, MAUVE, OVERLAY, PEACH, SUBTEXT, SURFACE,
+    ShaderShowcase, TEXT, TextEditor,
 };
 use crate::{
     App, Bounds, Context, ElementInputHandler, Entity, Focusable, KeyDownEvent, MouseButton,
-    MouseDownEvent, MouseMoveEvent, MouseUpEvent, Render, ScrollDelta, ScrollWheelEvent, Window,
-    div, hsla, point, prelude::*, px, rgb, size,
+    MouseDownEvent, MouseMoveEvent, MouseUpEvent, PathPromptOptions, Render, ScrollDelta,
+    ScrollWheelEvent, Window, div, hsla, point, prelude::*, px, rgb, size,
 };
 
 /// Which demo is currently active
@@ -82,6 +82,54 @@ impl DemoApp {
         self.shader_showcase = None;
         self.text_editor = None;
         cx.notify();
+    }
+
+    fn show_file_picker(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        println!("GPUI iOS: show_file_picker called");
+
+        // Use the platform's file picker
+        let options = PathPromptOptions {
+            files: true,
+            directories: false,
+            multiple: true,
+            prompt: None,
+        };
+
+        // Spawn an async task to handle the file picker result
+        cx.spawn(async move |_this, cx| {
+            println!("GPUI iOS: Spawning file picker task");
+
+            // Get the platform and show the picker
+            let result = cx.update(|cx| {
+                cx.prompt_for_paths(options)
+            });
+
+            match result {
+                Ok(receiver) => {
+                    println!("GPUI iOS: Waiting for file picker result");
+                    match receiver.await {
+                        Ok(Ok(Some(paths))) => {
+                            println!("GPUI iOS: File picker selected {} files:", paths.len());
+                            for path in &paths {
+                                println!("  - {:?}", path);
+                            }
+                        }
+                        Ok(Ok(None)) => {
+                            println!("GPUI iOS: File picker cancelled");
+                        }
+                        Ok(Err(e)) => {
+                            println!("GPUI iOS: File picker error: {:?}", e);
+                        }
+                        Err(e) => {
+                            println!("GPUI iOS: File picker channel error: {:?}", e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    println!("GPUI iOS: Failed to show file picker: {:?}", e);
+                }
+            }
+        }).detach();
     }
 
     fn handle_animation_touch_down(&mut self, event: &MouseDownEvent, cx: &mut Context<Self>) {
@@ -280,6 +328,37 @@ impl DemoApp {
                                 MouseButton::Left,
                                 cx.listener(|this, _, window, cx| {
                                     this.go_to_text_editor(window, cx);
+                                }),
+                            ),
+                    )
+                    // File Picker button
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap_1()
+                            .px_6()
+                            .py_4()
+                            .bg(rgb(SURFACE))
+                            .rounded_xl()
+                            .border_l_4()
+                            .border_color(rgb(PEACH))
+                            .child(
+                                div()
+                                    .text_xl()
+                                    .text_color(rgb(TEXT))
+                                    .child("File Picker"),
+                            )
+                            .child(
+                                div()
+                                    .text_sm()
+                                    .text_color(rgb(SUBTEXT))
+                                    .child("iOS document picker demo"),
+                            )
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(|this, _, window, cx| {
+                                    this.show_file_picker(window, cx);
                                 }),
                             ),
                     ),

--- a/crates/gpui/src/platform/ios/demos/mod.rs
+++ b/crates/gpui/src/platform/ios/demos/mod.rs
@@ -1,0 +1,37 @@
+//! iOS Demo modules for showcasing GPUI capabilities.
+//!
+//! This module contains interactive demos that demonstrate GPUI's
+//! rendering and input handling on iOS.
+
+mod animation_playground;
+mod menu;
+mod shader_showcase;
+
+pub use animation_playground::AnimationPlayground;
+pub use menu::{DemoApp, back_button};
+pub use shader_showcase::ShaderShowcase;
+
+// Color palette - Catppuccin Mocha theme
+pub const BACKGROUND: u32 = 0x1e1e2e;
+pub const SURFACE: u32 = 0x313244;
+pub const OVERLAY: u32 = 0x45475a;
+pub const TEXT: u32 = 0xcdd6f4;
+pub const SUBTEXT: u32 = 0xa6adc8;
+pub const RED: u32 = 0xf38ba8;
+pub const GREEN: u32 = 0xa6e3a1;
+pub const BLUE: u32 = 0x89b4fa;
+pub const YELLOW: u32 = 0xf9e2af;
+pub const PINK: u32 = 0xf5c2e7;
+pub const MAUVE: u32 = 0xcba6f7;
+pub const PEACH: u32 = 0xfab387;
+pub const TEAL: u32 = 0x94e2d5;
+pub const SKY: u32 = 0x89dceb;
+pub const LAVENDER: u32 = 0xb4befe;
+
+/// Get a random color from the vibrant palette
+pub fn random_color(seed: usize) -> u32 {
+    const COLORS: [u32; 10] = [
+        RED, GREEN, BLUE, YELLOW, PINK, MAUVE, PEACH, TEAL, SKY, LAVENDER,
+    ];
+    COLORS[seed % COLORS.len()]
+}

--- a/crates/gpui/src/platform/ios/demos/mod.rs
+++ b/crates/gpui/src/platform/ios/demos/mod.rs
@@ -6,10 +6,12 @@
 mod animation_playground;
 mod menu;
 mod shader_showcase;
+mod text_editor;
 
 pub use animation_playground::AnimationPlayground;
 pub use menu::{DemoApp, back_button};
 pub use shader_showcase::ShaderShowcase;
+pub use text_editor::TextEditor;
 
 // Color palette - Catppuccin Mocha theme
 pub const BACKGROUND: u32 = 0x1e1e2e;

--- a/crates/gpui/src/platform/ios/demos/shader_showcase.rs
+++ b/crates/gpui/src/platform/ios/demos/shader_showcase.rs
@@ -1,0 +1,371 @@
+//! Shader Showcase demo - dynamic gradients and visual effects.
+//!
+//! This demo showcases GPUI's GPU rendering capabilities on iOS:
+//! - Dynamic gradient backgrounds that respond to touch
+//! - Floating orbs with parallax movement
+//! - Ripple effects on tap
+//! - Color cycling animations
+
+use super::back_button;
+use crate::{
+    App, Bounds, ColorSpace, Hsla, Pixels, Point, Window, canvas, div, fill, hsla,
+    linear_color_stop, linear_gradient, point, prelude::*, px, size,
+};
+use std::time::{Duration, Instant};
+
+// Number of orbs in the demo (for reference, orbs are created manually)
+#[allow(dead_code)]
+const ORB_COUNT: usize = 8;
+const RIPPLE_DURATION_MS: u64 = 1000;
+const MAX_RIPPLES: usize = 5;
+
+/// A floating orb with parallax effect
+#[derive(Clone)]
+struct Orb {
+    base_position: Point<f32>,
+    parallax_factor: f32,
+    radius: f32,
+    color: Hsla,
+    pulse_phase: f32,
+}
+
+impl Orb {
+    fn new(x: f32, y: f32, radius: f32, parallax: f32, hue: f32) -> Self {
+        Self {
+            base_position: point(x, y),
+            parallax_factor: parallax,
+            radius,
+            color: hsla(hue, 0.7, 0.6, 0.4),
+            pulse_phase: hue * std::f32::consts::PI * 2.0,
+        }
+    }
+
+    fn current_position(&self, touch_offset: Point<f32>, time: f32) -> Point<f32> {
+        let pulse = (time * 2.0 + self.pulse_phase).sin() * 5.0;
+        point(
+            self.base_position.x + touch_offset.x * self.parallax_factor,
+            self.base_position.y + touch_offset.y * self.parallax_factor + pulse,
+        )
+    }
+
+    fn current_radius(&self, time: f32) -> f32 {
+        let pulse = (time * 1.5 + self.pulse_phase).sin() * 0.1 + 1.0;
+        self.radius * pulse
+    }
+}
+
+/// An expanding ripple effect
+#[derive(Clone)]
+struct Ripple {
+    center: Point<f32>,
+    start_time: Instant,
+    duration: Duration,
+    color: Hsla,
+}
+
+impl Ripple {
+    fn new(center: Point<f32>, hue: f32) -> Self {
+        Self {
+            center,
+            start_time: Instant::now(),
+            duration: Duration::from_millis(RIPPLE_DURATION_MS),
+            color: hsla(hue, 0.8, 0.6, 1.0),
+        }
+    }
+
+    fn progress(&self) -> f32 {
+        let elapsed = self.start_time.elapsed().as_secs_f32();
+        (elapsed / self.duration.as_secs_f32()).min(1.0)
+    }
+
+    fn is_alive(&self) -> bool {
+        self.start_time.elapsed() < self.duration
+    }
+
+    fn current_radius(&self, max_radius: f32) -> f32 {
+        let progress = self.progress();
+        // Ease out for natural expansion
+        let eased = 1.0 - (1.0 - progress).powi(3);
+        max_radius * eased
+    }
+
+    fn current_alpha(&self) -> f32 {
+        let progress = self.progress();
+        (1.0 - progress).powi(2)
+    }
+}
+
+/// Shader Showcase demo view
+pub struct ShaderShowcase {
+    start_time: Instant,
+    pub touch_position: Option<Point<f32>>,
+    pub screen_center: Point<f32>,
+    orbs: Vec<Orb>,
+    ripples: Vec<Ripple>,
+}
+
+impl ShaderShowcase {
+    pub fn new() -> Self {
+        // Create orbs at various positions
+        let orbs = vec![
+            Orb::new(100.0, 200.0, 80.0, 0.1, 0.0),
+            Orb::new(300.0, 150.0, 60.0, 0.15, 0.1),
+            Orb::new(200.0, 400.0, 100.0, 0.05, 0.2),
+            Orb::new(350.0, 500.0, 50.0, 0.2, 0.3),
+            Orb::new(50.0, 600.0, 70.0, 0.12, 0.4),
+            Orb::new(280.0, 700.0, 90.0, 0.08, 0.5),
+            Orb::new(150.0, 300.0, 40.0, 0.25, 0.6),
+            Orb::new(320.0, 350.0, 55.0, 0.18, 0.7),
+        ];
+
+        Self {
+            start_time: Instant::now(),
+            touch_position: None,
+            screen_center: point(200.0, 400.0),
+            orbs,
+            ripples: Vec::new(),
+        }
+    }
+
+    fn time(&self) -> f32 {
+        self.start_time.elapsed().as_secs_f32()
+    }
+
+    fn gradient_angle(&self) -> f32 {
+        if let Some(touch) = self.touch_position {
+            let dx = touch.x - self.screen_center.x;
+            let dy = touch.y - self.screen_center.y;
+            (dy.atan2(dx).to_degrees() + 90.0) % 360.0
+        } else {
+            // Default: slowly rotating gradient
+            (self.time() * 20.0) % 360.0
+        }
+    }
+
+    fn touch_offset(&self) -> Point<f32> {
+        if let Some(touch) = self.touch_position {
+            point(
+                touch.x - self.screen_center.x,
+                touch.y - self.screen_center.y,
+            )
+        } else {
+            point(0.0, 0.0)
+        }
+    }
+
+    fn cycling_hue(&self, base: f32) -> f32 {
+        (base + self.time() * 0.05) % 1.0
+    }
+
+    pub fn spawn_ripple(&mut self, position: Point<f32>) {
+        if self.ripples.len() >= MAX_RIPPLES {
+            self.ripples.remove(0);
+        }
+        let hue = self.cycling_hue(self.ripples.len() as f32 * 0.15);
+        self.ripples.push(Ripple::new(position, hue));
+    }
+
+    fn handle_touch_down(&mut self, position: Point<f32>) {
+        self.touch_position = Some(position);
+        self.spawn_ripple(position);
+    }
+
+    fn handle_touch_move(&mut self, position: Point<f32>) {
+        self.touch_position = Some(position);
+    }
+
+    fn handle_touch_up(&mut self) {
+        self.touch_position = None;
+    }
+
+    pub fn render_with_back_button<F>(
+        &mut self,
+        window: &mut Window,
+        on_back: F,
+    ) -> impl IntoElement
+    where
+        F: Fn(&(), &mut Window, &mut App) + 'static,
+    {
+        // Request continuous animation frame
+        window.request_animation_frame();
+
+        // Remove dead ripples
+        self.ripples.retain(|r| r.is_alive());
+
+        // Get current state for rendering
+        let time = self.time();
+        let gradient_angle = self.gradient_angle();
+        let touch_offset = self.touch_offset();
+        let hue1 = self.cycling_hue(0.6);
+        let hue2 = self.cycling_hue(0.9);
+        let orbs = self.orbs.clone();
+        let ripples = self.ripples.clone();
+
+        div()
+            .size_full()
+            // Dynamic gradient background
+            .bg(linear_gradient(
+                gradient_angle,
+                linear_color_stop(hsla(hue1, 0.8, 0.15, 1.0), 0.0),
+                linear_color_stop(hsla(hue2, 0.7, 0.25, 1.0), 1.0),
+            )
+            .color_space(ColorSpace::Oklab))
+            // Canvas for custom effects
+            .child(
+                canvas(
+                    move |bounds, _window, _cx| {
+                        let bounds_f32 = Bounds {
+                            origin: point(bounds.origin.x.0, bounds.origin.y.0),
+                            size: size(bounds.size.width.0, bounds.size.height.0),
+                        };
+                        let max_ripple_radius =
+                            (bounds_f32.size.width.max(bounds_f32.size.height)) * 0.7;
+                        (
+                            bounds_f32,
+                            max_ripple_radius,
+                            time,
+                            touch_offset,
+                            orbs.clone(),
+                            ripples.clone(),
+                        )
+                    },
+                    move |_bounds,
+                          (_bounds_f32, max_ripple_radius, time, touch_offset, orbs, ripples),
+                          window,
+                          _cx| {
+                        // Draw orbs (back to front by parallax factor)
+                        let mut sorted_orbs: Vec<_> = orbs.iter().collect();
+                        sorted_orbs.sort_by(|a, b| {
+                            a.parallax_factor.partial_cmp(&b.parallax_factor).unwrap()
+                        });
+
+                        for orb in sorted_orbs {
+                            let pos = orb.current_position(touch_offset, time);
+                            let radius = orb.current_radius(time);
+
+                            // Draw glow layers (outer to inner)
+                            for i in (0..4).rev() {
+                                let glow_radius = radius * (1.0 + i as f32 * 0.5);
+                                let glow_alpha = orb.color.a * (0.1 / (i as f32 + 1.0));
+                                let glow_color =
+                                    hsla(orb.color.h, orb.color.s, orb.color.l, glow_alpha);
+                                paint_circle(
+                                    window,
+                                    point(px(pos.x), px(pos.y)),
+                                    px(glow_radius),
+                                    glow_color,
+                                );
+                            }
+
+                            // Draw core
+                            paint_circle(
+                                window,
+                                point(px(pos.x), px(pos.y)),
+                                px(radius),
+                                orb.color,
+                            );
+
+                            // Draw highlight
+                            let highlight = hsla(orb.color.h, orb.color.s * 0.5, 0.9, 0.3);
+                            paint_circle(
+                                window,
+                                point(px(pos.x - radius * 0.3), px(pos.y - radius * 0.3)),
+                                px(radius * 0.4),
+                                highlight,
+                            );
+                        }
+
+                        // Draw ripples
+                        for ripple in ripples.iter() {
+                            let radius = ripple.current_radius(max_ripple_radius);
+                            let alpha = ripple.current_alpha() * 0.5;
+                            let color = hsla(ripple.color.h, ripple.color.s, ripple.color.l, alpha);
+
+                            // Draw expanding ring
+                            paint_ring(
+                                window,
+                                point(px(ripple.center.x), px(ripple.center.y)),
+                                px(radius),
+                                px(3.0),
+                                color,
+                            );
+                        }
+                    },
+                )
+                .size_full(),
+            )
+            // Title overlay
+            .child(
+                div()
+                    .absolute()
+                    .top(px(100.0))
+                    .left_0()
+                    .right_0()
+                    .flex()
+                    .justify_center()
+                    .child(
+                        div()
+                            .text_2xl()
+                            .text_color(hsla(0.0, 0.0, 1.0, 0.8))
+                            .child("Shader Showcase"),
+                    ),
+            )
+            // Instructions
+            .child(
+                div()
+                    .absolute()
+                    .bottom(px(100.0))
+                    .left_0()
+                    .right_0()
+                    .flex()
+                    .justify_center()
+                    .child(
+                        div()
+                            .px_4()
+                            .py_2()
+                            .bg(hsla(0.0, 0.0, 0.0, 0.3))
+                            .rounded_lg()
+                            .text_color(hsla(0.0, 0.0, 1.0, 0.9))
+                            .text_sm()
+                            .child("Touch to control gradients & create ripples"),
+                    ),
+            )
+            // Back button
+            .child(back_button(on_back))
+    }
+
+    /// Update screen center based on bounds
+    pub fn set_screen_center(&mut self, center: Point<f32>) {
+        self.screen_center = center;
+    }
+}
+
+/// Paint a filled circle
+fn paint_circle(window: &mut Window, center: Point<Pixels>, radius: Pixels, color: Hsla) {
+    let bounds = Bounds {
+        origin: point(center.x - radius, center.y - radius),
+        size: size(radius * 2.0, radius * 2.0),
+    };
+    window.paint_quad(fill(bounds, color).corner_radii(radius));
+}
+
+/// Paint a ring (circle outline)
+fn paint_ring(
+    window: &mut Window,
+    center: Point<Pixels>,
+    radius: Pixels,
+    thickness: Pixels,
+    color: Hsla,
+) {
+    // Draw as two circles: outer filled, inner transparent
+    // Since we don't have stroke, we'll draw a series of circles
+    let steps = 36;
+    let angle_step = std::f32::consts::PI * 2.0 / steps as f32;
+
+    for i in 0..steps {
+        let angle = angle_step * i as f32;
+        let x = center.x + px(radius.0 * angle.cos());
+        let y = center.y + px(radius.0 * angle.sin());
+        paint_circle(window, point(x, y), thickness, color);
+    }
+}

--- a/crates/gpui/src/platform/ios/demos/shader_showcase.rs
+++ b/crates/gpui/src/platform/ios/demos/shader_showcase.rs
@@ -225,8 +225,8 @@ impl ShaderShowcase {
                             max_ripple_radius,
                             time,
                             touch_offset,
-                            orbs.clone(),
-                            ripples.clone(),
+                            orbs,
+                            ripples,
                         )
                     },
                     move |_bounds,

--- a/crates/gpui/src/platform/ios/demos/text_editor.rs
+++ b/crates/gpui/src/platform/ios/demos/text_editor.rs
@@ -1,0 +1,1236 @@
+//! Text Editor demo - text editing and cursor control.
+//!
+//! This demo showcases GPUI's text input capabilities on iOS:
+//! - Multi-line text display with wrapping
+//! - Cursor placement via touch
+//! - Text selection
+//! - Scrollable content
+//! - Keyboard input via UITextInput protocol
+
+use super::{BACKGROUND, GREEN, SUBTEXT, SURFACE, TEXT};
+use crate::{
+    App, Bounds, Context, EntityInputHandler, FocusHandle, Focusable,
+    Hsla, Pixels, Point, SharedString, TextRun, UTF16Selection, Window,
+    div, fill, hsla, point, prelude::*, px, rgb, size,
+};
+use std::ops::Range;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Instant;
+
+/// Global counter for replace_text_in_range calls (for debugging)
+static REPLACE_CALL_COUNT: AtomicU32 = AtomicU32::new(0);
+
+/// Sample text content for the demo
+const SAMPLE_TEXT: &str = r#"Welcome to GPUI on iOS!
+
+This text editor demo showcases the text rendering and input capabilities of the GPUI framework.
+
+Features demonstrated:
+- Multi-line text rendering
+- Touch-based cursor placement
+- Text selection via drag
+- Smooth scrolling
+
+Try tapping anywhere in the text to place the cursor, or drag to select text.
+
+GPUI uses GPU-accelerated rendering to achieve smooth 60fps performance even with complex UI layouts and animations.
+
+The framework provides a declarative API similar to SwiftUI, making it easy to build responsive user interfaces that work across platforms.
+
+Additional Content for Scrolling
+
+This section contains extra text to demonstrate the scrolling functionality of the text editor. As you can see, when the content exceeds the visible area, you can scroll through it using two-finger gestures on a trackpad or by using Option+click and drag in the iOS Simulator.
+
+The scroll indicator on the right side of the text area shows your current position within the document. It updates in real-time as you scroll through the content.
+
+Technical Implementation Details
+
+The text editor uses GPUI's text shaping system to accurately measure and render text. Each line is individually shaped using the platform's text system, which ensures proper character spacing and line breaks.
+
+Word wrapping is implemented by measuring each word as it's added to a line. When a line would exceed the available width, the current line is committed and a new line begins with the overflowing word.
+
+Touch handling converts screen coordinates to text offsets by finding the line at the touch Y position, then using the shaped line's closest_index_for_x method to find the character under the touch X position.
+
+Selection is implemented by tracking the start and end offsets of the selected range. As you drag, the selection expands or contracts based on the touch position. The selection_reversed flag tracks whether you're extending the selection backwards.
+
+More Text to Ensure Scrolling
+
+Here is even more text to make absolutely sure that the content extends beyond the visible viewport, allowing you to test the scrolling functionality thoroughly.
+
+The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs. How vexingly quick daft zebras jump!
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+End of sample content. Try scrolling up and down to see the scroll indicator move!"#;
+
+/// Font configuration
+const FONT_SIZE: f32 = 18.0;
+const LINE_HEIGHT_MULTIPLIER: f32 = 1.4;
+const PADDING: f32 = 20.0;
+const HEADER_HEIGHT: f32 = 100.0;
+const FOOTER_HEIGHT: f32 = 60.0;
+
+/// Cursor blink configuration
+const CURSOR_BLINK_INTERVAL_MS: u64 = 500;
+
+/// Text Editor demo view
+pub struct TextEditor {
+    content: SharedString,
+    cursor_offset: usize,
+    selected_range: Range<usize>,
+    selection_reversed: bool,
+    scroll_offset: f32,
+    /// Cached line layout information
+    lines: Vec<LineLayout>,
+    content_height: f32,
+    /// Last touch Y position for scroll delta calculation
+    last_touch_y: f32,
+    /// Start time for cursor blink animation
+    cursor_blink_start: Instant,
+    /// Whether cursor is currently visible (for blink)
+    cursor_visible: bool,
+    /// Scroll velocity for momentum
+    scroll_velocity: f32,
+    /// Whether we're currently in a touch/drag
+    is_dragging: bool,
+    /// Whether we're selecting text (vs scrolling)
+    is_selecting: bool,
+    /// Touch start offset for selection
+    touch_start_offset: usize,
+    /// Last scroll time for momentum calculation
+    last_scroll_time: Instant,
+    /// Focus handle for keyboard input
+    focus_handle: Option<FocusHandle>,
+    /// ID of the last replace_text_in_range operation (for deduplication)
+    last_replace_id: u32,
+    /// Last deletion range (for deduplication)
+    last_delete_range: Option<Range<usize>>,
+    /// Timestamp of last delete (for debounce)
+    last_delete_time: Instant,
+    /// Marked text range for IME composition
+    marked_range: Option<Range<usize>>,
+    /// Last known bounds for input handler
+    last_bounds: Option<Bounds<Pixels>>,
+}
+
+/// Information about a laid out line
+#[derive(Clone, Debug)]
+struct LineLayout {
+    text: String,
+    byte_range: Range<usize>,
+    y_position: f32,
+    height: f32,
+}
+
+/// Momentum deceleration rate (pixels per frame squared, like gravity)
+const SCROLL_DECELERATION: f32 = 0.5;
+/// Minimum velocity threshold to stop momentum (pixels per frame)
+const MIN_VELOCITY: f32 = 0.5;
+
+impl TextEditor {
+    pub fn new() -> Self {
+        Self {
+            content: SAMPLE_TEXT.into(),
+            cursor_offset: 0,
+            selected_range: 0..0,
+            selection_reversed: false,
+            scroll_offset: 0.0,
+            lines: Vec::new(),
+            content_height: 0.0,
+            last_touch_y: 0.0,
+            cursor_blink_start: Instant::now(),
+            cursor_visible: true,
+            scroll_velocity: 0.0,
+            is_dragging: false,
+            is_selecting: false,
+            touch_start_offset: 0,
+            last_scroll_time: Instant::now(),
+            focus_handle: None,
+            last_replace_id: 0,
+            last_delete_range: None,
+            last_delete_time: Instant::now(),
+            marked_range: None,
+            last_bounds: None,
+        }
+    }
+
+    /// Initialize focus handle from context
+    pub fn init_focus(&mut self, cx: &mut Context<Self>) {
+        if self.focus_handle.is_none() {
+            self.focus_handle = Some(cx.focus_handle());
+        }
+    }
+
+    /// Get or create the focus handle
+    pub fn get_focus_handle(&self) -> FocusHandle {
+        self.focus_handle.clone().unwrap_or_else(|| {
+            // This shouldn't happen in practice as init_focus should be called first
+            panic!("TextEditor focus_handle not initialized. Call init_focus first.")
+        })
+    }
+
+    /// Request focus for this text editor
+    pub fn focus(&self, window: &mut Window) {
+        if let Some(handle) = &self.focus_handle {
+            window.focus(handle);
+        }
+    }
+
+    /// Move cursor left by one character
+    pub fn move_left(&mut self) {
+        if self.selected_range.is_empty() {
+            if self.cursor_offset > 0 {
+                self.cursor_offset = self.previous_char_boundary(self.cursor_offset);
+            }
+        } else {
+            self.cursor_offset = self.selected_range.start;
+        }
+        self.selected_range = self.cursor_offset..self.cursor_offset;
+        self.reset_cursor_blink();
+    }
+
+    /// Move cursor right by one character
+    pub fn move_right(&mut self) {
+        if self.selected_range.is_empty() {
+            if self.cursor_offset < self.content.len() {
+                self.cursor_offset = self.next_char_boundary(self.cursor_offset);
+            }
+        } else {
+            self.cursor_offset = self.selected_range.end;
+        }
+        self.selected_range = self.cursor_offset..self.cursor_offset;
+        self.reset_cursor_blink();
+    }
+
+    /// Move cursor up by one line
+    pub fn move_up(&mut self) {
+        if let Some(current_line_idx) = self.line_for_offset(self.cursor_offset) {
+            if current_line_idx > 0 {
+                let prev_line = &self.lines[current_line_idx - 1];
+                let current_line = &self.lines[current_line_idx];
+                let offset_in_line = self.cursor_offset - current_line.byte_range.start;
+                self.cursor_offset =
+                    prev_line.byte_range.start + offset_in_line.min(prev_line.text.len());
+            }
+        }
+        self.selected_range = self.cursor_offset..self.cursor_offset;
+        self.reset_cursor_blink();
+    }
+
+    /// Move cursor down by one line
+    pub fn move_down(&mut self) {
+        if let Some(current_line_idx) = self.line_for_offset(self.cursor_offset) {
+            if current_line_idx < self.lines.len() - 1 {
+                let next_line = &self.lines[current_line_idx + 1];
+                let current_line = &self.lines[current_line_idx];
+                let offset_in_line = self.cursor_offset - current_line.byte_range.start;
+                self.cursor_offset =
+                    next_line.byte_range.start + offset_in_line.min(next_line.text.len());
+            }
+        }
+        self.selected_range = self.cursor_offset..self.cursor_offset;
+        self.reset_cursor_blink();
+    }
+
+    /// Handle backspace key
+    pub fn backspace(&mut self) {
+        if !self.selected_range.is_empty() {
+            self.delete_selection();
+        } else if self.cursor_offset > 0 {
+            let prev = self.previous_char_boundary(self.cursor_offset);
+            let mut content = self.content.to_string();
+            content.drain(prev..self.cursor_offset);
+            self.content = content.into();
+            self.cursor_offset = prev;
+            self.selected_range = self.cursor_offset..self.cursor_offset;
+            self.lines.clear(); // Force re-layout
+        }
+        self.reset_cursor_blink();
+    }
+
+    /// Handle delete key
+    pub fn delete(&mut self) {
+        if !self.selected_range.is_empty() {
+            self.delete_selection();
+        } else if self.cursor_offset < self.content.len() {
+            let next = self.next_char_boundary(self.cursor_offset);
+            let mut content = self.content.to_string();
+            content.drain(self.cursor_offset..next);
+            self.content = content.into();
+            self.selected_range = self.cursor_offset..self.cursor_offset;
+            self.lines.clear(); // Force re-layout
+        }
+        self.reset_cursor_blink();
+    }
+
+    /// Insert text at cursor position (used by key event fallback when input handler is unavailable)
+    pub fn insert_text(&mut self, text: &str) {
+        println!(
+            "TextEditor::insert_text ENTRY - text={:?}, cursor={}, selected={:?}",
+            text, self.cursor_offset, self.selected_range
+        );
+
+        // Delete selection first if any
+        if !self.selected_range.is_empty() {
+            self.delete_selection();
+        }
+
+        // Insert the text at cursor
+        let mut content = self.content.to_string();
+        content.insert_str(self.cursor_offset, text);
+        self.content = content.into();
+        self.cursor_offset += text.len();
+        self.selected_range = self.cursor_offset..self.cursor_offset;
+        self.lines.clear(); // Force re-layout
+
+        println!(
+            "TextEditor::insert_text EXIT - new cursor={}, new content_len={}",
+            self.cursor_offset,
+            self.content.len()
+        );
+        self.reset_cursor_blink();
+    }
+
+    /// Extend selection to the left
+    pub fn select_left(&mut self) {
+        let new_offset = self.previous_char_boundary(self.cursor_offset);
+        self.extend_selection_to(new_offset);
+        self.reset_cursor_blink();
+    }
+
+    /// Extend selection to the right
+    pub fn select_right(&mut self) {
+        let new_offset = self.next_char_boundary(self.cursor_offset);
+        self.extend_selection_to(new_offset);
+        self.reset_cursor_blink();
+    }
+
+    /// Select all text
+    pub fn select_all(&mut self) {
+        self.selected_range = 0..self.content.len();
+        self.cursor_offset = self.content.len();
+        self.selection_reversed = false;
+        self.reset_cursor_blink();
+    }
+
+    /// Delete the currently selected text
+    fn delete_selection(&mut self) {
+        if self.selected_range.is_empty() {
+            return;
+        }
+        let mut content = self.content.to_string();
+        content.drain(self.selected_range.clone());
+        self.content = content.into();
+        self.cursor_offset = self.selected_range.start;
+        self.selected_range = self.cursor_offset..self.cursor_offset;
+        self.lines.clear(); // Force re-layout
+    }
+
+    /// Extend selection to the given offset
+    fn extend_selection_to(&mut self, offset: usize) {
+        if self.selection_reversed {
+            self.selected_range.start = offset;
+        } else {
+            self.selected_range.end = offset;
+        }
+        if self.selected_range.end < self.selected_range.start {
+            self.selection_reversed = !self.selection_reversed;
+            self.selected_range = self.selected_range.end..self.selected_range.start;
+        }
+        self.cursor_offset = if self.selection_reversed {
+            self.selected_range.start
+        } else {
+            self.selected_range.end
+        };
+    }
+
+    // ========================================
+    // UTF-8 / UTF-16 conversion methods
+    // ========================================
+
+    /// Convert UTF-8 byte offset to UTF-16 offset
+    fn offset_to_utf16(&self, offset: usize) -> usize {
+        let mut utf16_offset = 0;
+        let mut utf8_count = 0;
+
+        for ch in self.content.chars() {
+            if utf8_count >= offset {
+                break;
+            }
+            utf8_count += ch.len_utf8();
+            utf16_offset += ch.len_utf16();
+        }
+
+        utf16_offset
+    }
+
+    /// Convert UTF-16 offset to UTF-8 byte offset
+    fn offset_from_utf16(&self, offset: usize) -> usize {
+        let mut utf8_offset = 0;
+        let mut utf16_count = 0;
+
+        for ch in self.content.chars() {
+            if utf16_count >= offset {
+                break;
+            }
+            utf16_count += ch.len_utf16();
+            utf8_offset += ch.len_utf8();
+        }
+
+        utf8_offset
+    }
+
+    /// Convert a UTF-8 range to UTF-16 range
+    fn range_to_utf16(&self, range: &Range<usize>) -> Range<usize> {
+        self.offset_to_utf16(range.start)..self.offset_to_utf16(range.end)
+    }
+
+    /// Convert a UTF-16 range to UTF-8 range
+    fn range_from_utf16(&self, range: &Range<usize>) -> Range<usize> {
+        self.offset_from_utf16(range.start)..self.offset_from_utf16(range.end)
+    }
+
+    /// Find the previous character boundary
+    fn previous_char_boundary(&self, offset: usize) -> usize {
+        let content = self.content.as_ref();
+        if offset == 0 {
+            return 0;
+        }
+        let mut new_offset = offset - 1;
+        while new_offset > 0 && !content.is_char_boundary(new_offset) {
+            new_offset -= 1;
+        }
+        new_offset
+    }
+
+    /// Find the next character boundary
+    fn next_char_boundary(&self, offset: usize) -> usize {
+        let content = self.content.as_ref();
+        if offset >= content.len() {
+            return content.len();
+        }
+        let mut new_offset = offset + 1;
+        while new_offset < content.len() && !content.is_char_boundary(new_offset) {
+            new_offset += 1;
+        }
+        new_offset
+    }
+
+    /// Find which line contains the given offset
+    fn line_for_offset(&self, offset: usize) -> Option<usize> {
+        for (idx, line) in self.lines.iter().enumerate() {
+            if offset >= line.byte_range.start && offset <= line.byte_range.end {
+                return Some(idx);
+            }
+        }
+        None
+    }
+
+    /// Reset cursor blink (show cursor immediately after interaction)
+    fn reset_cursor_blink(&mut self) {
+        self.cursor_blink_start = Instant::now();
+        self.cursor_visible = true;
+    }
+
+    /// Update cursor visibility based on blink interval
+    fn update_cursor_blink(&mut self) {
+        let elapsed_ms = self.cursor_blink_start.elapsed().as_millis() as u64;
+        let blink_cycle = elapsed_ms / CURSOR_BLINK_INTERVAL_MS;
+        self.cursor_visible = blink_cycle.is_multiple_of(2);
+    }
+
+    /// Get last touch Y position
+    pub fn last_touch_y(&self) -> f32 {
+        self.last_touch_y
+    }
+
+    /// Set last touch Y position
+    pub fn set_last_touch_y(&mut self, y: f32) {
+        self.last_touch_y = y;
+    }
+
+    /// Layout text into lines with word wrapping
+    fn layout_lines(&mut self, max_width: f32, window: &mut Window) {
+        self.lines.clear();
+
+        let style = window.text_style();
+        let font = style.font();
+        let font_size = px(FONT_SIZE);
+        let line_height = FONT_SIZE * LINE_HEIGHT_MULTIPLIER;
+
+        // Clone content to avoid borrow issues
+        let content = self.content.to_string();
+
+        let mut y = 0.0;
+        let mut byte_offset = 0;
+
+        for paragraph in content.split('\n') {
+            if paragraph.is_empty() {
+                // Empty line
+                self.lines.push(LineLayout {
+                    text: String::new(),
+                    byte_range: byte_offset..byte_offset,
+                    y_position: y,
+                    height: line_height,
+                });
+                y += line_height;
+                byte_offset += 1; // newline character
+                continue;
+            }
+
+            // Convert to owned string for SharedString
+            let paragraph_str = paragraph.to_string();
+            let paragraph_shared: SharedString = paragraph_str.clone().into();
+
+            // Shape the paragraph to get accurate measurements
+            let run = TextRun {
+                len: paragraph_str.len(),
+                font: font.clone(),
+                color: rgb(TEXT).into(),
+                background_color: None,
+                underline: None,
+                strikethrough: None,
+            };
+
+            let shaped = window
+                .text_system()
+                .shape_line(paragraph_shared, font_size, &[run], None);
+
+            let paragraph_width = shaped.width.0;
+
+            if paragraph_width <= max_width {
+                // Paragraph fits on one line
+                self.lines.push(LineLayout {
+                    text: paragraph_str.clone(),
+                    byte_range: byte_offset..byte_offset + paragraph_str.len(),
+                    y_position: y,
+                    height: line_height,
+                });
+                y += line_height;
+                byte_offset += paragraph_str.len() + 1; // +1 for newline
+            } else {
+                // Need to wrap - track actual byte positions in original paragraph
+                let paragraph_start = byte_offset;
+
+                // Find word boundaries with their byte positions
+                let mut words_with_positions: Vec<(usize, &str)> = Vec::new();
+                let mut word_start: Option<usize> = None;
+
+                for (i, ch) in paragraph.char_indices() {
+                    if ch.is_whitespace() {
+                        if let Some(start) = word_start {
+                            words_with_positions.push((start, &paragraph[start..i]));
+                            word_start = None;
+                        }
+                    } else if word_start.is_none() {
+                        word_start = Some(i);
+                    }
+                }
+                // Handle last word if paragraph doesn't end with whitespace
+                if let Some(start) = word_start {
+                    words_with_positions.push((start, &paragraph[start..]));
+                }
+
+                let mut line_text = String::new();
+                let mut line_start_in_para = 0usize;
+                let mut line_end_in_para = 0usize;
+
+                for (word_idx, (word_pos, word)) in words_with_positions.iter().enumerate() {
+                    let test_text = if line_text.is_empty() {
+                        word.to_string()
+                    } else {
+                        format!("{} {}", line_text, word)
+                    };
+
+                    // Shape test line
+                    let test_shared: SharedString = test_text.clone().into();
+                    let test_run = TextRun {
+                        len: test_text.len(),
+                        font: font.clone(),
+                        color: rgb(TEXT).into(),
+                        background_color: None,
+                        underline: None,
+                        strikethrough: None,
+                    };
+
+                    let test_shaped = window
+                        .text_system()
+                        .shape_line(test_shared, font_size, &[test_run], None);
+
+                    if test_shaped.width.0 > max_width && !line_text.is_empty() {
+                        // Current line is full, emit it
+                        // line_end_in_para points to end of last word added
+                        self.lines.push(LineLayout {
+                            text: line_text.clone(),
+                            byte_range: paragraph_start + line_start_in_para
+                                ..paragraph_start + line_end_in_para,
+                            y_position: y,
+                            height: line_height,
+                        });
+                        y += line_height;
+
+                        // Start new line from this word
+                        line_start_in_para = *word_pos;
+                        line_text = word.to_string();
+                        line_end_in_para = word_pos + word.len();
+                    } else {
+                        // Word fits, update line
+                        if line_text.is_empty() {
+                            line_start_in_para = *word_pos;
+                        }
+                        line_text = test_text;
+                        line_end_in_para = word_pos + word.len();
+                    }
+
+                    // Handle last word
+                    if word_idx == words_with_positions.len() - 1 && !line_text.is_empty() {
+                        self.lines.push(LineLayout {
+                            text: line_text.clone(),
+                            byte_range: paragraph_start + line_start_in_para
+                                ..paragraph_start + line_end_in_para,
+                            y_position: y,
+                            height: line_height,
+                        });
+                        y += line_height;
+                    }
+                }
+                byte_offset += paragraph_str.len() + 1;
+            }
+        }
+
+        self.content_height = y;
+    }
+
+    /// Find the byte offset for a touch position
+    fn offset_for_position(&self, position: Point<f32>, window: &mut Window) -> usize {
+        let adjusted_y = position.y + self.scroll_offset - PADDING - HEADER_HEIGHT;
+
+        // Find the line at this y position
+        for line in &self.lines {
+            if adjusted_y >= line.y_position && adjusted_y < line.y_position + line.height {
+                if line.text.is_empty() {
+                    return line.byte_range.start;
+                }
+
+                // Use text shaping for accurate x position
+                let style = window.text_style();
+                let font = style.font();
+                let font_size = px(FONT_SIZE);
+
+                let run = TextRun {
+                    len: line.text.len(),
+                    font,
+                    color: rgb(TEXT).into(),
+                    background_color: None,
+                    underline: None,
+                    strikethrough: None,
+                };
+
+                let shaped = window
+                    .text_system()
+                    .shape_line(line.text.clone().into(), font_size, &[run], None);
+
+                let x_in_line = px((position.x - PADDING).max(0.0));
+                let char_index = shaped.closest_index_for_x(x_in_line);
+
+                return line.byte_range.start + char_index;
+            }
+        }
+
+        // Below all lines, return end
+        self.content.len()
+    }
+
+    pub fn handle_touch_down(&mut self, position: Point<f32>, window: &mut Window) {
+        let offset = self.offset_for_position(position, window);
+        self.cursor_offset = offset.min(self.content.len());
+        self.selected_range = self.cursor_offset..self.cursor_offset;
+        self.selection_reversed = false;
+        self.is_selecting = true;
+        self.touch_start_offset = self.cursor_offset;
+        self.reset_cursor_blink();
+    }
+
+    /// Check if we're in selection mode
+    pub fn is_selecting(&self) -> bool {
+        self.is_selecting
+    }
+
+    /// End selection mode
+    pub fn end_selection(&mut self) {
+        self.is_selecting = false;
+    }
+
+    pub fn handle_touch_move(&mut self, position: Point<f32>, window: &mut Window) {
+        let offset = self.offset_for_position(position, window).min(self.content.len());
+
+        if self.selection_reversed {
+            self.selected_range.start = offset;
+        } else {
+            self.selected_range.end = offset;
+        }
+
+        // Normalize range direction
+        if self.selected_range.end < self.selected_range.start {
+            self.selection_reversed = !self.selection_reversed;
+            self.selected_range = self.selected_range.end..self.selected_range.start;
+        }
+
+        self.cursor_offset = if self.selection_reversed {
+            self.selected_range.start
+        } else {
+            self.selected_range.end
+        };
+    }
+
+    /// Handle scroll wheel events
+    pub fn handle_scroll(&mut self, delta_y: f32, viewport_height: f32) {
+        let max_scroll = (self.content_height - viewport_height + PADDING * 2.0).max(0.0);
+        self.scroll_offset = (self.scroll_offset - delta_y).clamp(0.0, max_scroll);
+
+        // Track velocity for momentum - use exponential moving average
+        let now = Instant::now();
+        let dt = now.duration_since(self.last_scroll_time).as_secs_f32();
+        if dt > 0.0 && dt < 0.1 {
+            // Calculate instantaneous velocity (pixels per second)
+            let instant_velocity = delta_y / dt;
+            // Blend with previous velocity for smoother tracking
+            self.scroll_velocity = self.scroll_velocity * 0.3 + instant_velocity * 0.7;
+        }
+        self.last_scroll_time = now;
+        self.is_dragging = true;
+    }
+
+    /// Start dragging (called on touch down)
+    pub fn start_drag(&mut self) {
+        self.is_dragging = true;
+        self.scroll_velocity = 0.0;
+        self.last_scroll_time = Instant::now();
+    }
+
+    /// End dragging (called on touch up) - starts momentum
+    pub fn end_drag(&mut self) {
+        self.is_dragging = false;
+        // Scale velocity to per-frame (assuming ~60fps = 16.67ms per frame)
+        self.scroll_velocity *= 0.016;
+    }
+
+    /// Update scroll momentum - returns true if still animating
+    pub fn update_momentum(&mut self, viewport_height: f32) -> bool {
+        if self.is_dragging {
+            return false;
+        }
+
+        if self.scroll_velocity.abs() < MIN_VELOCITY {
+            self.scroll_velocity = 0.0;
+            return false;
+        }
+
+        // Apply velocity to scroll
+        let max_scroll = (self.content_height - viewport_height + PADDING * 2.0).max(0.0);
+        self.scroll_offset = (self.scroll_offset - self.scroll_velocity).clamp(0.0, max_scroll);
+
+        // Apply deceleration (like friction/air resistance)
+        if self.scroll_velocity > 0.0 {
+            self.scroll_velocity = (self.scroll_velocity - SCROLL_DECELERATION).max(0.0);
+        } else {
+            self.scroll_velocity = (self.scroll_velocity + SCROLL_DECELERATION).min(0.0);
+        }
+
+        // Stop if we hit bounds
+        if self.scroll_offset <= 0.0 || self.scroll_offset >= max_scroll {
+            self.scroll_velocity = 0.0;
+            return false;
+        }
+
+        true
+    }
+
+    pub fn render_with_back_button<F>(
+        &mut self,
+        window: &mut Window,
+        _on_back: F,
+    ) -> impl IntoElement
+    where
+        F: Fn(&(), &mut Window, &mut App) + 'static,
+    {
+        // Request animation frame for cursor blink and momentum
+        window.request_animation_frame();
+
+        // Update cursor blink state
+        self.update_cursor_blink();
+
+        // Update scroll momentum
+        let viewport = window.viewport_size();
+        let content_viewport_height = viewport.height.0 - HEADER_HEIGHT - FOOTER_HEIGHT;
+        self.update_momentum(content_viewport_height);
+
+        // Layout text if needed
+        let max_width = viewport.width.0 - PADDING * 2.0;
+        if self.lines.is_empty() {
+            self.layout_lines(max_width, window);
+        }
+
+        // Clone state for canvas closure
+        let lines = self.lines.clone();
+        let cursor_offset = self.cursor_offset;
+        let selected_range = self.selected_range.clone();
+        let scroll_offset = self.scroll_offset;
+        let content_height = self.content_height;
+        let cursor_visible = self.cursor_visible;
+
+        div()
+            .size_full()
+            .bg(rgb(BACKGROUND))
+            .flex()
+            .flex_col()
+            // Header - with left padding to avoid back button
+            .child(
+                div()
+                    .h(px(HEADER_HEIGHT))
+                    .pt(px(50.0))
+                    .pl(px(100.0)) // Leave room for back button
+                    .pr(px(PADDING))
+                    .bg(rgb(SURFACE))
+                    .shadow_sm() // Add subtle shadow below header
+                    .flex()
+                    .items_center()
+                    .child(
+                        div()
+                            .text_xl()
+                            .text_color(rgb(TEXT))
+                            .child("Text Editor"),
+                    ),
+            )
+            // Text content area
+            .child(
+                div()
+                    .flex_1()
+                    .overflow_hidden()
+                    .child(
+                        crate::canvas(
+                            move |bounds, window, _cx| {
+                                // Prepaint: prepare rendering data
+                                let style = window.text_style();
+                                let font = style.font();
+                                let font_size = px(FONT_SIZE);
+
+                                // Shape all visible lines
+                                let mut shaped_lines = Vec::new();
+                                for line in &lines {
+                                    let y = PADDING + line.y_position - scroll_offset;
+
+                                    // Skip lines outside viewport
+                                    if y + line.height < 0.0 || y > bounds.size.height.0 {
+                                        shaped_lines.push(None);
+                                        continue;
+                                    }
+
+                                    if line.text.is_empty() {
+                                        shaped_lines.push(Some((line.clone(), None)));
+                                        continue;
+                                    }
+
+                                    let run = TextRun {
+                                        len: line.text.len(),
+                                        font: font.clone(),
+                                        color: rgb(TEXT).into(),
+                                        background_color: None,
+                                        underline: None,
+                                        strikethrough: None,
+                                    };
+
+                                    let shaped = window
+                                        .text_system()
+                                        .shape_line(line.text.clone().into(), font_size, &[run], None);
+
+                                    shaped_lines.push(Some((line.clone(), Some(shaped))));
+                                }
+
+                                (bounds, shaped_lines, cursor_offset, selected_range.clone(), scroll_offset, content_height, cursor_visible)
+                            },
+                            move |_bounds,
+                                  (bounds, shaped_lines, cursor_offset, selected_range, scroll_offset, content_height, cursor_visible),
+                                  window,
+                                  cx| {
+                                let cursor_color: Hsla = rgb(GREEN).into();
+                                let selection_color = hsla(0.33, 0.7, 0.5, 0.3);
+                                let line_height = px(FONT_SIZE * LINE_HEIGHT_MULTIPLIER);
+
+                                for maybe_line in shaped_lines.iter() {
+                                    let Some((line, maybe_shaped)) = maybe_line else {
+                                        continue;
+                                    };
+
+                                    let y = PADDING + line.y_position - scroll_offset;
+
+                                    // Draw selection background if this line intersects selection
+                                    if !selected_range.is_empty()
+                                        && selected_range.start < line.byte_range.end
+                                        && selected_range.end > line.byte_range.start
+                                    {
+                                        let sel_start = selected_range.start.max(line.byte_range.start);
+                                        let sel_end = selected_range.end.min(line.byte_range.end);
+
+                                        if let Some(shaped) = maybe_shaped {
+                                            let local_start = sel_start - line.byte_range.start;
+                                            let local_end = sel_end - line.byte_range.start;
+
+                                            let x_start = shaped.x_for_index(local_start);
+                                            let x_end = shaped.x_for_index(local_end);
+
+                                            let sel_bounds = Bounds {
+                                                origin: point(
+                                                    px(bounds.origin.x.0 + PADDING) + x_start,
+                                                    px(bounds.origin.y.0 + y),
+                                                ),
+                                                size: size(x_end - x_start, line_height),
+                                            };
+                                            window.paint_quad(fill(sel_bounds, selection_color));
+                                        }
+                                    }
+
+                                    // Draw text
+                                    if let Some(shaped) = maybe_shaped {
+                                        let origin = point(
+                                            px(bounds.origin.x.0 + PADDING),
+                                            px(bounds.origin.y.0 + y),
+                                        );
+                                        shaped.paint(origin, line_height, window, cx).ok();
+                                    }
+
+                                    // Draw cursor if on this line and cursor is visible (blinking)
+                                    if cursor_visible
+                                        && cursor_offset >= line.byte_range.start
+                                        && cursor_offset <= line.byte_range.end
+                                    {
+                                        let cursor_x = if let Some(shaped) = maybe_shaped {
+                                            let local_offset = cursor_offset - line.byte_range.start;
+                                            shaped.x_for_index(local_offset)
+                                        } else {
+                                            px(0.0)
+                                        };
+
+                                        let cursor_bounds = Bounds {
+                                            origin: point(
+                                                px(bounds.origin.x.0 + PADDING) + cursor_x,
+                                                px(bounds.origin.y.0 + y),
+                                            ),
+                                            size: size(px(2.0), line_height),
+                                        };
+                                        window.paint_quad(fill(cursor_bounds, cursor_color));
+                                    }
+                                }
+
+                                // Draw scroll indicator
+                                let viewport_height = bounds.size.height.0;
+                                if content_height > viewport_height {
+                                    let scroll_track_height = viewport_height - 20.0; // 10px margin top and bottom
+                                    let scroll_ratio = viewport_height / content_height;
+                                    let indicator_height = (scroll_track_height * scroll_ratio).max(30.0);
+                                    let max_scroll = content_height - viewport_height;
+                                    let scroll_progress = if max_scroll > 0.0 {
+                                        scroll_offset / max_scroll
+                                    } else {
+                                        0.0
+                                    };
+                                    let indicator_y = 10.0 + (scroll_track_height - indicator_height) * scroll_progress;
+
+                                    let indicator_bounds = Bounds {
+                                        origin: point(
+                                            px(bounds.origin.x.0 + bounds.size.width.0 - 6.0),
+                                            px(bounds.origin.y.0 + indicator_y),
+                                        ),
+                                        size: size(px(4.0), px(indicator_height)),
+                                    };
+                                    window.paint_quad(fill(indicator_bounds, hsla(0.0, 0.0, 0.5, 0.5)));
+                                }
+                            },
+                        )
+                        .size_full(),
+                    ),
+            )
+            // Footer
+            .child(
+                div()
+                    .h(px(FOOTER_HEIGHT))
+                    .px(px(PADDING))
+                    .bg(rgb(SURFACE))
+                    .shadow_sm() // Add subtle shadow above footer
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .child(
+                        div()
+                            .text_sm()
+                            .text_color(rgb(SUBTEXT))
+                            .child("Tap to place cursor, drag to select"),
+                    ),
+            )
+    }
+}
+
+// ============================================
+// Focusable trait implementation
+// ============================================
+
+impl Focusable for TextEditor {
+    fn focus_handle(&self, _: &App) -> FocusHandle {
+        self.get_focus_handle()
+    }
+}
+
+// ============================================
+// EntityInputHandler trait implementation
+// This enables keyboard input from the iOS UITextInput protocol
+// ============================================
+
+impl EntityInputHandler for TextEditor {
+    fn text_for_range(
+        &mut self,
+        range_utf16: Range<usize>,
+        actual_range: &mut Option<Range<usize>>,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Option<String> {
+        let range = self.range_from_utf16(&range_utf16);
+        let clamped_range = range.start.min(self.content.len())..range.end.min(self.content.len());
+        actual_range.replace(self.range_to_utf16(&clamped_range));
+        Some(self.content[clamped_range].to_string())
+    }
+
+    fn selected_text_range(
+        &mut self,
+        _ignore_disabled_input: bool,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Option<UTF16Selection> {
+        Some(UTF16Selection {
+            range: self.range_to_utf16(&self.selected_range),
+            reversed: self.selection_reversed,
+        })
+    }
+
+    fn marked_text_range(
+        &self,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Option<Range<usize>> {
+        self.marked_range
+            .as_ref()
+            .map(|range| self.range_to_utf16(range))
+    }
+
+    fn unmark_text(&mut self, _window: &mut Window, _cx: &mut Context<Self>) {
+        self.marked_range = None;
+    }
+
+    fn replace_text_in_range(
+        &mut self,
+        range_utf16: Option<Range<usize>>,
+        new_text: &str,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let call_id = REPLACE_CALL_COUNT.fetch_add(1, Ordering::SeqCst);
+        let now = Instant::now();
+
+        // Detailed logging for debugging double-deletion
+        println!(
+            "TextEditor::replace_text_in_range [#{}] ENTRY - range_utf16={:?}, new_text={:?}, content_len={}, cursor={}, selected={:?}",
+            call_id, range_utf16, new_text, self.content.len(), self.cursor_offset, self.selected_range
+        );
+
+        let range = range_utf16
+            .as_ref()
+            .map(|r| {
+                let converted = self.range_from_utf16(r);
+                println!(
+                    "TextEditor::replace_text_in_range [#{}] - UTF16 {:?} -> UTF8 {:?}",
+                    call_id, r, converted
+                );
+                converted
+            })
+            .or(self.marked_range.clone())
+            .unwrap_or(self.selected_range.clone());
+
+        // Clamp range to valid bounds
+        let clamped_range = range.start.min(self.content.len())..range.end.min(self.content.len());
+
+        // Deduplication: if this is a deletion (empty new_text, non-empty range),
+        // check if we just did the exact same deletion within 100ms
+        let is_deletion = new_text.is_empty() && !clamped_range.is_empty();
+        if is_deletion {
+            let elapsed = now.duration_since(self.last_delete_time);
+            if elapsed.as_millis() < 100 {
+                if let Some(last_range) = &self.last_delete_range {
+                    // If the range starts at the same position or one position before
+                    // (accounting for the cursor having moved), skip the duplicate
+                    let likely_duplicate =
+                        clamped_range.start == last_range.start ||
+                        clamped_range.end == last_range.start;
+                    if likely_duplicate {
+                        println!(
+                            "TextEditor::replace_text_in_range [#{}] SKIPPED - duplicate deletion (last={:?}, this={:?}, elapsed={}ms)",
+                            call_id, last_range, clamped_range, elapsed.as_millis()
+                        );
+                        return;
+                    }
+                }
+            }
+        }
+
+        // Log what we're about to do
+        if new_text.is_empty() {
+            println!(
+                "TextEditor::replace_text_in_range [#{}] - DELETING range={:?}, text={:?}",
+                call_id, clamped_range,
+                &self.content[clamped_range.clone()]
+            );
+        } else {
+            println!(
+                "TextEditor::replace_text_in_range [#{}] - INSERTING {:?} at range={:?}",
+                call_id, new_text, clamped_range
+            );
+        }
+
+        // Replace text
+        let mut content = self.content.to_string();
+        content.replace_range(clamped_range.clone(), new_text);
+        self.content = content.into();
+
+        // Update cursor position
+        self.cursor_offset = clamped_range.start + new_text.len();
+        self.selected_range = self.cursor_offset..self.cursor_offset;
+        self.marked_range = None;
+        self.lines.clear(); // Force re-layout
+        self.reset_cursor_blink();
+
+        // Track this deletion for deduplication
+        if is_deletion {
+            self.last_delete_range = Some(clamped_range.clone());
+            self.last_delete_time = now;
+        } else {
+            // Clear deletion tracking on non-deletion operations
+            self.last_delete_range = None;
+        }
+
+        println!(
+            "TextEditor::replace_text_in_range [#{}] EXIT - new cursor={}, new content_len={}",
+            call_id, self.cursor_offset, self.content.len()
+        );
+
+        cx.notify();
+    }
+
+    fn replace_and_mark_text_in_range(
+        &mut self,
+        range_utf16: Option<Range<usize>>,
+        new_text: &str,
+        new_selected_range_utf16: Option<Range<usize>>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let range = range_utf16
+            .as_ref()
+            .map(|r| self.range_from_utf16(r))
+            .or(self.marked_range.clone())
+            .unwrap_or(self.selected_range.clone());
+
+        // Clamp range to valid bounds
+        let clamped_range = range.start.min(self.content.len())..range.end.min(self.content.len());
+
+        // Replace text
+        let mut content = self.content.to_string();
+        content.replace_range(clamped_range.clone(), new_text);
+        self.content = content.into();
+
+        // Set marked range
+        if !new_text.is_empty() {
+            self.marked_range = Some(clamped_range.start..clamped_range.start + new_text.len());
+        } else {
+            self.marked_range = None;
+        }
+
+        // Update selection
+        self.selected_range = new_selected_range_utf16
+            .as_ref()
+            .map(|r| self.range_from_utf16(r))
+            .map(|new_range| {
+                clamped_range.start + new_range.start..clamped_range.start + new_range.end
+            })
+            .unwrap_or_else(|| {
+                let pos = clamped_range.start + new_text.len();
+                pos..pos
+            });
+
+        self.cursor_offset = if self.selection_reversed {
+            self.selected_range.start
+        } else {
+            self.selected_range.end
+        };
+
+        self.lines.clear(); // Force re-layout
+        self.reset_cursor_blink();
+
+        cx.notify();
+    }
+
+    fn bounds_for_range(
+        &mut self,
+        range_utf16: Range<usize>,
+        bounds: Bounds<Pixels>,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Option<Bounds<Pixels>> {
+        // Return a reasonable default bounds for the cursor position
+        // This is used for IME positioning
+        let range = self.range_from_utf16(&range_utf16);
+
+        // Find which line contains this range
+        for line in &self.lines {
+            if range.start >= line.byte_range.start && range.start <= line.byte_range.end {
+                let y = PADDING + line.y_position - self.scroll_offset;
+                let line_height = px(FONT_SIZE * LINE_HEIGHT_MULTIPLIER);
+
+                return Some(Bounds {
+                    origin: point(
+                        bounds.origin.x + px(PADDING),
+                        bounds.origin.y + px(y),
+                    ),
+                    size: size(px(100.0), line_height),
+                });
+            }
+        }
+
+        // Default to top-left area
+        Some(Bounds {
+            origin: bounds.origin + point(px(PADDING), px(PADDING)),
+            size: size(px(100.0), px(FONT_SIZE * LINE_HEIGHT_MULTIPLIER)),
+        })
+    }
+
+    fn character_index_for_point(
+        &mut self,
+        point: Point<Pixels>,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Option<usize> {
+        // Convert point to text offset
+        // This is a simplified version - could be more accurate with proper hit testing
+        let y = point.y.0 + self.scroll_offset - PADDING - HEADER_HEIGHT;
+
+        for line in &self.lines {
+            if y >= line.y_position && y < line.y_position + line.height {
+                // Found the line, estimate character position based on x
+                let x = (point.x.0 - PADDING).max(0.0);
+                let char_width = FONT_SIZE * 0.6; // Approximate character width
+                let char_index = (x / char_width) as usize;
+                let offset = line.byte_range.start + char_index.min(line.text.len());
+                return Some(self.offset_to_utf16(offset));
+            }
+        }
+
+        Some(self.offset_to_utf16(self.content.len()))
+    }
+}

--- a/crates/gpui/src/platform/ios/dispatcher.rs
+++ b/crates/gpui/src/platform/ios/dispatcher.rs
@@ -1,0 +1,211 @@
+//! iOS task dispatcher using Grand Central Dispatch (GCD).
+//!
+//! iOS shares the same GCD infrastructure as macOS, so this implementation
+//! is nearly identical to the macOS dispatcher.
+
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+use crate::{
+    GLOBAL_THREAD_TIMINGS, PlatformDispatcher, RunnableMeta, RunnableVariant, THREAD_TIMINGS,
+    TaskLabel, TaskTiming, ThreadTaskTimings,
+};
+
+use async_task::Runnable;
+use objc::{
+    class, msg_send,
+    runtime::{BOOL, YES},
+    sel, sel_impl,
+};
+use std::{
+    ffi::c_void,
+    ptr::NonNull,
+    time::{Duration, Instant},
+};
+
+// GCD types - these are the same on iOS and macOS
+type dispatch_queue_t = *mut std::ffi::c_void;
+type dispatch_time_t = u64;
+
+const DISPATCH_TIME_NOW: dispatch_time_t = 0;
+const DISPATCH_QUEUE_PRIORITY_HIGH: i64 = 2;
+
+// SAFETY: These are C functions from libdispatch
+unsafe extern "C" {
+    static _dispatch_main_q: std::ffi::c_void;
+    fn dispatch_async_f(
+        queue: dispatch_queue_t,
+        context: *mut c_void,
+        work: Option<unsafe extern "C" fn(*mut c_void)>,
+    );
+    fn dispatch_after_f(
+        when: dispatch_time_t,
+        queue: dispatch_queue_t,
+        context: *mut c_void,
+        work: Option<unsafe extern "C" fn(*mut c_void)>,
+    );
+    fn dispatch_get_global_queue(identifier: i64, flags: u64) -> dispatch_queue_t;
+    fn dispatch_time(when: dispatch_time_t, delta: i64) -> dispatch_time_t;
+}
+
+pub(crate) fn dispatch_get_main_queue() -> dispatch_queue_t {
+    std::ptr::addr_of!(_dispatch_main_q) as *const _ as dispatch_queue_t
+}
+
+pub(crate) struct IosDispatcher;
+
+impl PlatformDispatcher for IosDispatcher {
+    fn get_all_timings(&self) -> Vec<ThreadTaskTimings> {
+        let global_timings = GLOBAL_THREAD_TIMINGS.lock();
+        ThreadTaskTimings::convert(&global_timings)
+    }
+
+    fn get_current_thread_timings(&self) -> Vec<TaskTiming> {
+        THREAD_TIMINGS.with(|timings| {
+            let timings = &timings.lock().timings;
+
+            let mut vec = Vec::with_capacity(timings.len());
+
+            let (s1, s2) = timings.as_slices();
+            vec.extend_from_slice(s1);
+            vec.extend_from_slice(s2);
+            vec
+        })
+    }
+
+    fn is_main_thread(&self) -> bool {
+        unsafe {
+            let is_main: BOOL = msg_send![class!(NSThread), isMainThread];
+            is_main == YES
+        }
+    }
+
+    fn dispatch(&self, runnable: RunnableVariant, _: Option<TaskLabel>) {
+        let (context, trampoline) = match runnable {
+            RunnableVariant::Meta(runnable) => (
+                runnable.into_raw().as_ptr() as *mut c_void,
+                Some(trampoline as unsafe extern "C" fn(*mut c_void)),
+            ),
+            RunnableVariant::Compat(runnable) => (
+                runnable.into_raw().as_ptr() as *mut c_void,
+                Some(trampoline_compat as unsafe extern "C" fn(*mut c_void)),
+            ),
+        };
+        unsafe {
+            dispatch_async_f(
+                dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0),
+                context,
+                trampoline,
+            );
+        }
+    }
+
+    fn dispatch_on_main_thread(&self, runnable: RunnableVariant) {
+        let (context, trampoline) = match runnable {
+            RunnableVariant::Meta(runnable) => (
+                runnable.into_raw().as_ptr() as *mut c_void,
+                Some(trampoline as unsafe extern "C" fn(*mut c_void)),
+            ),
+            RunnableVariant::Compat(runnable) => (
+                runnable.into_raw().as_ptr() as *mut c_void,
+                Some(trampoline_compat as unsafe extern "C" fn(*mut c_void)),
+            ),
+        };
+        unsafe {
+            dispatch_async_f(dispatch_get_main_queue(), context, trampoline);
+        }
+    }
+
+    fn dispatch_after(&self, duration: Duration, runnable: RunnableVariant) {
+        let (context, trampoline) = match runnable {
+            RunnableVariant::Meta(runnable) => (
+                runnable.into_raw().as_ptr() as *mut c_void,
+                Some(trampoline as unsafe extern "C" fn(*mut c_void)),
+            ),
+            RunnableVariant::Compat(runnable) => (
+                runnable.into_raw().as_ptr() as *mut c_void,
+                Some(trampoline_compat as unsafe extern "C" fn(*mut c_void)),
+            ),
+        };
+        unsafe {
+            let queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+            let when = dispatch_time(DISPATCH_TIME_NOW, duration.as_nanos() as i64);
+            dispatch_after_f(when, queue, context, trampoline);
+        }
+    }
+}
+
+extern "C" fn trampoline(runnable: *mut c_void) {
+    let task =
+        unsafe { Runnable::<RunnableMeta>::from_raw(NonNull::new_unchecked(runnable as *mut ())) };
+
+    let location = task.metadata().location;
+
+    let start = Instant::now();
+    let timing = TaskTiming {
+        location,
+        start,
+        end: None,
+    };
+
+    THREAD_TIMINGS.with(|timings| {
+        let mut timings = timings.lock();
+        let timings = &mut timings.timings;
+        if let Some(last_timing) = timings.iter_mut().rev().next() {
+            if last_timing.location == timing.location {
+                return;
+            }
+        }
+
+        timings.push_back(timing);
+    });
+
+    task.run();
+    let end = Instant::now();
+
+    THREAD_TIMINGS.with(|timings| {
+        let mut timings = timings.lock();
+        let timings = &mut timings.timings;
+        let Some(last_timing) = timings.iter_mut().rev().next() else {
+            return;
+        };
+        last_timing.end = Some(end);
+    });
+}
+
+extern "C" fn trampoline_compat(runnable: *mut c_void) {
+    let task = unsafe { Runnable::<()>::from_raw(NonNull::new_unchecked(runnable as *mut ())) };
+
+    let location = core::panic::Location::caller();
+
+    let start = Instant::now();
+    let timing = TaskTiming {
+        location,
+        start,
+        end: None,
+    };
+    THREAD_TIMINGS.with(|timings| {
+        let mut timings = timings.lock();
+        let timings = &mut timings.timings;
+        if let Some(last_timing) = timings.iter_mut().rev().next() {
+            if last_timing.location == timing.location {
+                return;
+            }
+        }
+
+        timings.push_back(timing);
+    });
+
+    task.run();
+    let end = Instant::now();
+
+    THREAD_TIMINGS.with(|timings| {
+        let mut timings = timings.lock();
+        let timings = &mut timings.timings;
+        let Some(last_timing) = timings.iter_mut().rev().next() else {
+            return;
+        };
+        last_timing.end = Some(end);
+    });
+}

--- a/crates/gpui/src/platform/ios/display.rs
+++ b/crates/gpui/src/platform/ios/display.rs
@@ -1,0 +1,97 @@
+//! iOS display handling using UIScreen.
+//!
+//! iOS has a simpler display model than macOS - typically just the main screen
+//! and possibly an external display via AirPlay or USB-C.
+
+use crate::{Bounds, DisplayId, Pixels, PlatformDisplay, px, size};
+use anyhow::Result;
+use core_graphics::geometry::CGRect;
+use objc::{class, msg_send, sel, sel_impl};
+use uuid::Uuid;
+
+/// Represents an iOS display (UIScreen).
+#[derive(Debug)]
+pub(crate) struct IosDisplay {
+    /// The UIScreen object
+    screen: *mut objc::runtime::Object,
+}
+
+unsafe impl Send for IosDisplay {}
+unsafe impl Sync for IosDisplay {}
+
+impl IosDisplay {
+    /// Get the main screen.
+    pub fn main() -> Self {
+        unsafe {
+            let screen: *mut objc::runtime::Object = msg_send![class!(UIScreen), mainScreen];
+            Self { screen }
+        }
+    }
+
+    /// Get all connected screens.
+    pub fn all() -> impl Iterator<Item = Self> {
+        unsafe {
+            let screens: *mut objc::runtime::Object = msg_send![class!(UIScreen), screens];
+            let count: usize = msg_send![screens, count];
+
+            (0..count).map(move |i| {
+                let screen: *mut objc::runtime::Object = msg_send![screens, objectAtIndex: i];
+                Self { screen }
+            })
+        }
+    }
+
+    /// Get the screen bounds in points.
+    fn bounds_in_points(&self) -> CGRect {
+        unsafe { msg_send![self.screen, bounds] }
+    }
+
+    /// Get the native scale factor of this screen.
+    pub fn native_scale(&self) -> f32 {
+        unsafe {
+            let scale: f64 = msg_send![self.screen, nativeScale];
+            scale as f32
+        }
+    }
+
+    /// Get the current scale factor (may differ from native if zoomed).
+    pub fn scale(&self) -> f32 {
+        unsafe {
+            let scale: f64 = msg_send![self.screen, scale];
+            scale as f32
+        }
+    }
+}
+
+impl PlatformDisplay for IosDisplay {
+    fn id(&self) -> DisplayId {
+        // iOS doesn't have display IDs like macOS, so we use the screen pointer as an ID
+        DisplayId(self.screen as u32)
+    }
+
+    fn uuid(&self) -> Result<Uuid> {
+        // iOS doesn't provide persistent UUIDs for displays like macOS does.
+        // We generate a deterministic UUID based on the screen properties.
+        let bounds = self.bounds_in_points();
+        let scale = self.native_scale();
+
+        // Create a deterministic UUID from screen properties
+        let bytes = format!(
+            "ios-screen-{}-{}-{}",
+            bounds.size.width as u32,
+            bounds.size.height as u32,
+            (scale * 100.0) as u32
+        );
+
+        Ok(Uuid::new_v5(&Uuid::NAMESPACE_OID, bytes.as_bytes()))
+    }
+
+    fn bounds(&self) -> Bounds<Pixels> {
+        let bounds = self.bounds_in_points();
+
+        Bounds {
+            origin: Default::default(),
+            size: size(px(bounds.size.width as f32), px(bounds.size.height as f32)),
+        }
+    }
+}

--- a/crates/gpui/src/platform/ios/events.rs
+++ b/crates/gpui/src/platform/ios/events.rs
@@ -1,0 +1,170 @@
+//! iOS event handling - converting UIKit events to GPUI's event types.
+//!
+//! iOS uses touch-based input rather than mouse input, so we need to map
+//! touch gestures to appropriate GPUI events:
+//! - Single tap → MouseDown + MouseUp (left button)
+//! - Long press → MouseDown + MouseUp (right button) for context menus
+//! - Pan gesture → ScrollWheel events
+//! - Pinch gesture → Zoom events (if supported)
+//! - Touch move → MouseMove events
+
+use crate::{
+    Modifiers, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, PlatformInput,
+    Point, ScrollDelta, ScrollWheelEvent, TouchPhase, px,
+};
+use core_graphics::geometry::CGPoint;
+use objc::{msg_send, runtime::Object, sel, sel_impl};
+
+/// Touch phase from UIKit
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i64)]
+pub enum UITouchPhase {
+    Began = 0,
+    Moved = 1,
+    Stationary = 2,
+    Ended = 3,
+    Cancelled = 4,
+}
+
+impl From<i64> for UITouchPhase {
+    fn from(value: i64) -> Self {
+        match value {
+            0 => UITouchPhase::Began,
+            1 => UITouchPhase::Moved,
+            2 => UITouchPhase::Stationary,
+            3 => UITouchPhase::Ended,
+            4 => UITouchPhase::Cancelled,
+            _ => UITouchPhase::Cancelled,
+        }
+    }
+}
+
+impl From<UITouchPhase> for TouchPhase {
+    fn from(phase: UITouchPhase) -> Self {
+        match phase {
+            UITouchPhase::Began => TouchPhase::Started,
+            UITouchPhase::Moved => TouchPhase::Moved,
+            UITouchPhase::Stationary => TouchPhase::Moved,
+            UITouchPhase::Ended => TouchPhase::Ended,
+            UITouchPhase::Cancelled => TouchPhase::Ended,
+        }
+    }
+}
+
+/// Convert a UITouch to a mouse position
+pub fn touch_location_in_view(touch: *mut Object, view: *mut Object) -> Point<Pixels> {
+    unsafe {
+        let location: CGPoint = msg_send![touch, locationInView: view];
+        Point::new(px(location.x as f32), px(location.y as f32))
+    }
+}
+
+/// Get the touch phase from a UITouch
+pub fn touch_phase(touch: *mut Object) -> UITouchPhase {
+    unsafe {
+        let phase: i64 = msg_send![touch, phase];
+        UITouchPhase::from(phase)
+    }
+}
+
+/// Get the number of taps for a touch (for detecting double-tap, etc.)
+pub fn touch_tap_count(touch: *mut Object) -> u32 {
+    unsafe {
+        let count: i64 = msg_send![touch, tapCount];
+        count as u32
+    }
+}
+
+/// Convert a single touch began event to a mouse down event
+pub fn touch_began_to_mouse_down(
+    position: Point<Pixels>,
+    tap_count: u32,
+    modifiers: Modifiers,
+) -> PlatformInput {
+    PlatformInput::MouseDown(MouseDownEvent {
+        button: MouseButton::Left,
+        position,
+        modifiers,
+        click_count: tap_count as usize,
+        first_mouse: false,
+    })
+}
+
+/// Convert a touch ended event to a mouse up event
+pub fn touch_ended_to_mouse_up(
+    position: Point<Pixels>,
+    tap_count: u32,
+    modifiers: Modifiers,
+) -> PlatformInput {
+    PlatformInput::MouseUp(MouseUpEvent {
+        button: MouseButton::Left,
+        position,
+        modifiers,
+        click_count: tap_count as usize,
+    })
+}
+
+/// Convert a touch moved event to a mouse move event
+pub fn touch_moved_to_mouse_move(
+    position: Point<Pixels>,
+    modifiers: Modifiers,
+    pressed_button: Option<MouseButton>,
+) -> PlatformInput {
+    PlatformInput::MouseMove(MouseMoveEvent {
+        position,
+        modifiers,
+        pressed_button,
+    })
+}
+
+/// Convert a pan gesture to a scroll wheel event
+pub fn pan_gesture_to_scroll(
+    position: Point<Pixels>,
+    delta: Point<Pixels>,
+    modifiers: Modifiers,
+    touch_phase: TouchPhase,
+) -> PlatformInput {
+    PlatformInput::ScrollWheel(ScrollWheelEvent {
+        position,
+        delta: ScrollDelta::Pixels(delta),
+        modifiers,
+        touch_phase,
+    })
+}
+
+/// Get current keyboard modifiers from UIKit.
+/// iOS doesn't have the same modifier key concept as macOS,
+/// but external keyboards can provide modifiers.
+pub fn get_current_modifiers() -> Modifiers {
+    // iOS 13.4+ supports modifier keys from external keyboards
+    // For now, return empty modifiers - this can be enhanced later
+    // to read from UIKeyModifierFlags when available
+    Modifiers::default()
+}
+
+/// Check if a long press should trigger a context menu (right-click equivalent)
+pub fn is_long_press_for_context_menu(touch: *mut Object) -> bool {
+    unsafe {
+        // Check the force of the touch (3D Touch / Haptic Touch)
+        let force: f64 = msg_send![touch, force];
+        let max_force: f64 = msg_send![touch, maximumPossibleForce];
+
+        // If force touch is available and pressed hard enough
+        if max_force > 0.0 && force / max_force > 0.5 {
+            return true;
+        }
+
+        false
+    }
+}
+
+/// Convert a force touch to a right-click for context menus
+pub fn force_touch_to_right_click(position: Point<Pixels>, modifiers: Modifiers) -> PlatformInput {
+    PlatformInput::MouseDown(MouseDownEvent {
+        button: MouseButton::Right,
+        position,
+        modifiers,
+        click_count: 1,
+        first_mouse: false,
+    })
+}

--- a/crates/gpui/src/platform/ios/ffi.rs
+++ b/crates/gpui/src/platform/ios/ffi.rs
@@ -1,0 +1,440 @@
+//! FFI (Foreign Function Interface) module for iOS.
+//!
+//! This module exposes C-compatible functions that can be called from
+//! Objective-C code in the iOS app delegate to initialize and control
+//! the GPUI application lifecycle.
+
+use crate::{App, AppContext, Application, RequestFrameOptions, WindowOptions};
+use std::ffi::c_void;
+use std::sync::OnceLock;
+
+/// Global storage for the GPUI application state.
+/// This is set during initialization and used by FFI callbacks.
+static IOS_APP_STATE: OnceLock<IosAppState> = OnceLock::new();
+
+/// Holds the state needed for iOS FFI callbacks.
+/// Note: On iOS, all UI code runs on the main thread, so we use a RefCell
+/// instead of Mutex and don't require Send.
+struct IosAppState {
+    /// The callback to invoke when the app finishes launching.
+    /// This is the closure passed to Application::run().
+    /// Using std::cell::UnsafeCell since this is only accessed from the main thread.
+    finish_launching: std::cell::UnsafeCell<Option<Box<dyn FnOnce()>>>,
+}
+
+// Safety: On iOS, all GPUI operations happen on the main thread.
+// The FFI functions are only called from the iOS app delegate which runs on main thread.
+// We implement both Send and Sync because OnceLock requires Send for its value type,
+// and we need Sync for the static. The actual access is always single-threaded.
+unsafe impl Send for IosAppState {}
+unsafe impl Sync for IosAppState {}
+
+// Safety wrapper for window list - only accessed from main thread
+struct WindowListWrapper(std::cell::UnsafeCell<Vec<*const super::window::IosWindow>>);
+unsafe impl Send for WindowListWrapper {}
+unsafe impl Sync for WindowListWrapper {}
+
+static IOS_WINDOW_LIST: OnceLock<WindowListWrapper> = OnceLock::new();
+
+/// Initialize the GPUI iOS application.
+///
+/// This should be called from `application:didFinishLaunchingWithOptions:`
+/// in the iOS app delegate, before any other GPUI functions.
+///
+/// Returns a pointer to the app state that should be passed to other FFI functions.
+/// Returns null if initialization fails.
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_initialize() -> *mut c_void {
+    // Initialize logging - iOS logging is typically handled via os_log
+    // or NSLog, but for debug builds we can try to use env_logger if available
+    #[cfg(all(debug_assertions, feature = "test-support"))]
+    {
+        // Try to initialize logging, ignore if already initialized
+        let _ = env_logger::try_init();
+    }
+
+    log::info!("GPUI iOS: Initializing");
+
+    // Initialize the app state
+    let state = IosAppState {
+        finish_launching: std::cell::UnsafeCell::new(None),
+    };
+
+    if IOS_APP_STATE.set(state).is_err() {
+        log::error!("GPUI iOS: Already initialized");
+        return std::ptr::null_mut();
+    }
+
+    // Initialize the window list
+    let _ = IOS_WINDOW_LIST.set(WindowListWrapper(std::cell::UnsafeCell::new(Vec::new())));
+
+    // Return a non-null pointer to indicate success
+    // The actual state is stored in the static
+    1 as *mut c_void
+}
+
+/// Register a window with the FFI layer.
+///
+/// This is called internally when a new IosWindow is created.
+/// The window pointer can then be retrieved by Objective-C code.
+///
+/// # Safety
+/// This must only be called from the main thread.
+pub(crate) fn register_window(window: *const super::window::IosWindow) {
+    if let Some(wrapper) = IOS_WINDOW_LIST.get() {
+        unsafe {
+            (*wrapper.0.get()).push(window);
+            log::info!("GPUI iOS: Registered window {:p}", window);
+        }
+    }
+}
+
+/// Get the most recently created window pointer.
+///
+/// Returns the pointer to the IosWindow that was most recently registered,
+/// or null if no windows have been created.
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_get_window() -> *mut c_void {
+    if let Some(wrapper) = IOS_WINDOW_LIST.get() {
+        unsafe {
+            let windows = &*wrapper.0.get();
+            if let Some(&window) = windows.last() {
+                log::info!("GPUI iOS: Returning window {:p}", window);
+                return window as *mut c_void;
+            }
+        }
+    }
+    log::warn!("GPUI iOS: No windows registered");
+    std::ptr::null_mut()
+}
+
+/// Store the finish launching callback.
+///
+/// This is called internally by IosPlatform::run() to store the callback
+/// that will be invoked when the app finishes launching.
+///
+/// # Safety
+/// This must only be called from the main thread.
+pub(crate) fn set_finish_launching_callback(callback: Box<dyn FnOnce()>) {
+    if let Some(state) = IOS_APP_STATE.get() {
+        // Safety: Only called from main thread
+        unsafe {
+            *state.finish_launching.get() = Some(callback);
+        }
+    }
+}
+
+/// Called when the iOS app has finished launching.
+///
+/// This should be called from `application:didFinishLaunchingWithOptions:`
+/// in the iOS app delegate, after `gpui_ios_initialize()` returns.
+///
+/// This invokes the callback passed to Application::run().
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_did_finish_launching(_app_ptr: *mut c_void) {
+    log::info!("GPUI iOS: Did finish launching");
+
+    if let Some(state) = IOS_APP_STATE.get() {
+        // Safety: Only called from main thread
+        let callback = unsafe { (*state.finish_launching.get()).take() };
+        if let Some(callback) = callback {
+            log::info!("GPUI iOS: Invoking finish launching callback");
+            callback();
+        } else {
+            log::warn!("GPUI iOS: No finish launching callback registered");
+        }
+    } else {
+        log::error!("GPUI iOS: Not initialized");
+    }
+}
+
+/// Called when the iOS app will enter the foreground.
+///
+/// This should be called from `applicationWillEnterForeground:` in the app delegate.
+/// This notifies all GPUI windows that the app is becoming active.
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_will_enter_foreground(_app_ptr: *mut c_void) {
+    log::info!("GPUI iOS: Will enter foreground");
+
+    // Notify all windows that they're becoming active
+    if let Some(wrapper) = IOS_WINDOW_LIST.get() {
+        unsafe {
+            let windows = &*wrapper.0.get();
+            for &window_ptr in windows.iter() {
+                if !window_ptr.is_null() {
+                    let window = &*window_ptr;
+                    window.notify_active_status_change(true);
+                }
+            }
+        }
+    }
+}
+
+/// Called when the iOS app did become active.
+///
+/// This should be called from `applicationDidBecomeActive:` in the app delegate.
+/// This indicates the app is now in the foreground and receiving events.
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_did_become_active(_app_ptr: *mut c_void) {
+    log::info!("GPUI iOS: Did become active");
+
+    // App is now fully active - windows should be notified
+    if let Some(wrapper) = IOS_WINDOW_LIST.get() {
+        unsafe {
+            let windows = &*wrapper.0.get();
+            for &window_ptr in windows.iter() {
+                if !window_ptr.is_null() {
+                    let window = &*window_ptr;
+                    window.notify_active_status_change(true);
+                }
+            }
+        }
+    }
+}
+
+/// Called when the iOS app will resign active.
+///
+/// This should be called from `applicationWillResignActive:` in the app delegate.
+/// This indicates the app is about to become inactive (e.g., incoming call, switching apps).
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_will_resign_active(_app_ptr: *mut c_void) {
+    log::info!("GPUI iOS: Will resign active");
+
+    // App is about to become inactive
+    if let Some(wrapper) = IOS_WINDOW_LIST.get() {
+        unsafe {
+            let windows = &*wrapper.0.get();
+            for &window_ptr in windows.iter() {
+                if !window_ptr.is_null() {
+                    let window = &*window_ptr;
+                    window.notify_active_status_change(false);
+                }
+            }
+        }
+    }
+}
+
+/// Called when the iOS app did enter the background.
+///
+/// This should be called from `applicationDidEnterBackground:` in the app delegate.
+/// At this point, the app should have already saved any user data and released
+/// shared resources. The app will be suspended shortly after this returns.
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_did_enter_background(_app_ptr: *mut c_void) {
+    log::info!("GPUI iOS: Did enter background");
+
+    // Notify windows they're no longer visible
+    if let Some(wrapper) = IOS_WINDOW_LIST.get() {
+        unsafe {
+            let windows = &*wrapper.0.get();
+            for &window_ptr in windows.iter() {
+                if !window_ptr.is_null() {
+                    let window = &*window_ptr;
+                    window.notify_active_status_change(false);
+                }
+            }
+        }
+    }
+}
+
+/// Called when the iOS app will terminate.
+///
+/// This should be called from `applicationWillTerminate:` in the app delegate.
+/// This is a good place to save any unsaved data.
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_will_terminate(_app_ptr: *mut c_void) {
+    log::info!("GPUI iOS: Will terminate");
+
+    // TODO: Could invoke quit callbacks here if needed
+}
+
+/// Called when a touch event occurs.
+///
+/// This bridges UIKit touch events to GPUI's input system.
+/// Parameters:
+/// - `window_ptr`: Pointer to the IosWindow
+/// - `touch_ptr`: Pointer to the UITouch object
+/// - `event_ptr`: Pointer to the UIEvent object
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_handle_touch(
+    window_ptr: *mut c_void,
+    touch_ptr: *mut c_void,
+    event_ptr: *mut c_void,
+) {
+    if window_ptr.is_null() || touch_ptr.is_null() {
+        return;
+    }
+
+    // Cast to IosWindow and forward the touch event
+    let window = unsafe { &*(window_ptr as *const super::window::IosWindow) };
+    window.handle_touch(
+        touch_ptr as *mut objc::runtime::Object,
+        event_ptr as *mut objc::runtime::Object,
+    );
+}
+
+/// Request a frame to be rendered.
+///
+/// This should be called from CADisplayLink callback to trigger GPUI rendering.
+/// The window_ptr should be the value returned by gpui_ios_get_window().
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_request_frame(window_ptr: *mut c_void) {
+    if window_ptr.is_null() {
+        return;
+    }
+
+    // Safety: window_ptr must be a valid pointer to an IosWindow
+    let window = unsafe { &*(window_ptr as *const super::window::IosWindow) };
+
+    // Take the callback, invoke it, then restore it
+    // We must complete the borrow before invoking the callback,
+    // as the callback might try to borrow the same RefCell
+    let callback = window.request_frame_callback.borrow_mut().take();
+    if let Some(mut cb) = callback {
+        cb(RequestFrameOptions::default());
+        // Restore the callback for the next frame
+        window.request_frame_callback.borrow_mut().replace(cb);
+    }
+}
+
+/// Show the software keyboard.
+///
+/// Call this when a text input field gains focus.
+/// The window_ptr should be the value returned by gpui_ios_get_window().
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_show_keyboard(window_ptr: *mut c_void) {
+    if window_ptr.is_null() {
+        return;
+    }
+
+    log::info!("GPUI iOS: Show keyboard requested");
+
+    let window = unsafe { &*(window_ptr as *const super::window::IosWindow) };
+    window.show_keyboard();
+}
+
+/// Hide the software keyboard.
+///
+/// Call this when a text input field loses focus.
+/// The window_ptr should be the value returned by gpui_ios_get_window().
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_hide_keyboard(window_ptr: *mut c_void) {
+    if window_ptr.is_null() {
+        return;
+    }
+
+    log::info!("GPUI iOS: Hide keyboard requested");
+
+    let window = unsafe { &*(window_ptr as *const super::window::IosWindow) };
+    window.hide_keyboard();
+}
+
+/// Handle text input from the software keyboard.
+///
+/// This is called when the user types on the keyboard.
+/// Parameters:
+/// - `window_ptr`: Pointer to the IosWindow
+/// - `text_ptr`: Pointer to NSString with the entered text
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_handle_text_input(window_ptr: *mut c_void, text_ptr: *mut c_void) {
+    if window_ptr.is_null() || text_ptr.is_null() {
+        return;
+    }
+
+    log::info!("GPUI iOS: Handle text input");
+
+    let window = unsafe { &*(window_ptr as *const super::window::IosWindow) };
+    window.handle_text_input(text_ptr as *mut objc::runtime::Object);
+}
+
+/// Handle a key event from an external keyboard.
+///
+/// Parameters:
+/// - `window_ptr`: Pointer to the IosWindow
+/// - `key_code`: The key code from UIKeyboardHIDUsage
+/// - `modifiers`: Modifier flags from UIKeyModifierFlags
+/// - `is_key_down`: true for key down, false for key up
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_handle_key_event(
+    window_ptr: *mut c_void,
+    key_code: u32,
+    modifiers: u32,
+    is_key_down: bool,
+) {
+    if window_ptr.is_null() {
+        return;
+    }
+
+    log::info!(
+        "GPUI iOS: Handle key event - code: {}, modifiers: {}, down: {}",
+        key_code,
+        modifiers,
+        is_key_down
+    );
+
+    let window = unsafe { &*(window_ptr as *const super::window::IosWindow) };
+    window.handle_key_event(key_code, modifiers, is_key_down);
+}
+
+// Import the demo module
+use super::demos::DemoApp;
+
+/// Run a demo GPUI application with interactive demos.
+///
+/// This creates a GPUI Application with a menu to select between different demos:
+/// - Animation Playground: Bouncing balls with physics and particle effects
+/// - Shader Showcase: Dynamic gradients and visual effects
+///
+/// Call this from application:didFinishLaunchingWithOptions: to start the demo.
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_run_demo() {
+    log::info!("GPUI iOS: Starting demo application with interactive demos");
+
+    // First initialize the FFI layer
+    if IOS_APP_STATE.get().is_none() {
+        let state = IosAppState {
+            finish_launching: std::cell::UnsafeCell::new(None),
+        };
+        let _ = IOS_APP_STATE.set(state);
+        let _ = IOS_WINDOW_LIST.set(WindowListWrapper(std::cell::UnsafeCell::new(Vec::new())));
+    }
+
+    // Create a boxed callback that will create our demo window
+    let callback: Box<dyn FnOnce()> = Box::new(|| {
+        log::info!("GPUI iOS: Demo callback executing, but Application context not available here");
+    });
+
+    // Store the callback
+    set_finish_launching_callback(callback);
+
+    // Now create and run the application
+    // On iOS, Application::run() stores our callback and immediately returns
+    Application::new().run(|cx: &mut App| {
+        log::info!("GPUI iOS: Creating demo window with DemoApp");
+
+        cx.open_window(
+            WindowOptions {
+                // On iOS, windows are always fullscreen, let the platform decide bounds
+                window_bounds: None,
+                ..Default::default()
+            },
+            |_, cx| cx.new(|_| DemoApp::new()),
+        )
+        .expect("Failed to open window");
+
+        cx.activate(true);
+        log::info!("GPUI iOS: Demo window created successfully");
+    });
+
+    // The callback passed to Application::run() was stored by IosPlatform::run()
+    // and forwarded to set_finish_launching_callback. Now we need to invoke it.
+    // On a real iOS app, this would be called by gpui_ios_did_finish_launching()
+    // from the app delegate. Here we call it directly.
+    if let Some(state) = IOS_APP_STATE.get() {
+        let callback = unsafe { (*state.finish_launching.get()).take() };
+        if let Some(callback) = callback {
+            log::info!("GPUI iOS: Invoking Application::run callback");
+            callback();
+        }
+    }
+}

--- a/crates/gpui/src/platform/ios/ffi.rs
+++ b/crates/gpui/src/platform/ios/ffi.rs
@@ -376,6 +376,20 @@ pub extern "C" fn gpui_ios_handle_key_event(
     window.handle_key_event(key_code, modifiers, is_key_down);
 }
 
+/// Get the UIWindow from a GPUI window.
+///
+/// # Safety
+/// The window_ptr must be a valid pointer to an IosWindow.
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_get_ui_window(window_ptr: *mut std::ffi::c_void) -> *mut std::ffi::c_void {
+    if window_ptr.is_null() {
+        return std::ptr::null_mut();
+    }
+
+    let window = unsafe { &*(window_ptr as *const super::window::IosWindow) };
+    window.ui_window() as *mut std::ffi::c_void
+}
+
 // Import the demo module
 use super::demos::DemoApp;
 

--- a/crates/gpui/src/platform/ios/file_picker.rs
+++ b/crates/gpui/src/platform/ios/file_picker.rs
@@ -1,0 +1,330 @@
+//! iOS File Picker implementation using UIDocumentPickerViewController.
+//!
+//! This module provides file selection functionality for iOS, bridging
+//! between GPUI's Platform trait and iOS's document picker APIs.
+
+use crate::PathPromptOptions;
+use futures::channel::oneshot;
+use objc::{
+    class,
+    declare::ClassDecl,
+    msg_send,
+    runtime::{Class, Object, Protocol, Sel, BOOL, NO, YES},
+    sel, sel_impl,
+};
+use std::{
+    cell::UnsafeCell,
+    ffi::c_void,
+    path::PathBuf,
+    sync::{Arc, OnceLock},
+};
+
+/// Storage for pending file picker results.
+/// Only one file picker can be active at a time on iOS.
+struct FilePickerState {
+    /// The channel to send results back to the caller.
+    sender: UnsafeCell<Option<oneshot::Sender<anyhow::Result<Option<Vec<PathBuf>>>>>>,
+    /// Whether we're selecting directories (vs files).
+    selecting_directories: UnsafeCell<bool>,
+}
+
+// Safety: Only accessed from main thread on iOS
+unsafe impl Send for FilePickerState {}
+unsafe impl Sync for FilePickerState {}
+
+static FILE_PICKER_STATE: OnceLock<FilePickerState> = OnceLock::new();
+static PICKER_DELEGATE_CLASS: OnceLock<&'static Class> = OnceLock::new();
+
+/// Initialize the file picker state.
+fn init_state() -> &'static FilePickerState {
+    FILE_PICKER_STATE.get_or_init(|| FilePickerState {
+        sender: UnsafeCell::new(None),
+        selecting_directories: UnsafeCell::new(false),
+    })
+}
+
+/// Register the Objective-C delegate class for UIDocumentPickerViewController.
+fn register_delegate_class() -> &'static Class {
+    PICKER_DELEGATE_CLASS.get_or_init(|| {
+        let superclass = class!(NSObject);
+        let mut decl = ClassDecl::new("GPUIDocumentPickerDelegate", superclass)
+            .expect("Failed to create GPUIDocumentPickerDelegate class");
+
+        // Add protocol conformance
+        let picker_delegate_protocol = Protocol::get("UIDocumentPickerDelegate")
+            .expect("UIDocumentPickerDelegate protocol not found");
+        decl.add_protocol(picker_delegate_protocol);
+
+        // documentPicker:didPickDocumentsAtURLs: - called when user selects files
+        extern "C" fn did_pick_documents(_this: &Object, _sel: Sel, _picker: *mut Object, urls: *mut Object) {
+            log::info!("GPUI iOS: File picker - user selected documents");
+
+            unsafe {
+                let mut paths: Vec<PathBuf> = Vec::new();
+
+                // urls is an NSArray of NSURL
+                let count: usize = msg_send![urls, count];
+                for i in 0..count {
+                    let url: *mut Object = msg_send![urls, objectAtIndex: i];
+
+                    // Start accessing security-scoped resource
+                    let _: BOOL = msg_send![url, startAccessingSecurityScopedResource];
+
+                    let path_string: *mut Object = msg_send![url, path];
+                    if !path_string.is_null() {
+                        let utf8: *const i8 = msg_send![path_string, UTF8String];
+                        if !utf8.is_null() {
+                            let path_str = std::ffi::CStr::from_ptr(utf8)
+                                .to_str()
+                                .unwrap_or("");
+                            if !path_str.is_empty() {
+                                paths.push(PathBuf::from(path_str));
+                            }
+                        }
+                    }
+                }
+
+                log::info!("GPUI iOS: File picker - got {} paths", paths.len());
+
+                // Send the result
+                if let Some(state) = FILE_PICKER_STATE.get() {
+                    if let Some(sender) = (*state.sender.get()).take() {
+                        let result = if paths.is_empty() {
+                            Ok(None)
+                        } else {
+                            Ok(Some(paths))
+                        };
+                        let _ = sender.send(result);
+                    }
+                }
+            }
+        }
+
+        // documentPickerWasCancelled: - called when user cancels
+        extern "C" fn was_cancelled(_this: &Object, _sel: Sel, _picker: *mut Object) {
+            log::info!("GPUI iOS: File picker - user cancelled");
+
+            if let Some(state) = FILE_PICKER_STATE.get() {
+                unsafe {
+                    if let Some(sender) = (*state.sender.get()).take() {
+                        let _ = sender.send(Ok(None));
+                    }
+                }
+            }
+        }
+
+        unsafe {
+            decl.add_method(
+                sel!(documentPicker:didPickDocumentsAtURLs:),
+                did_pick_documents as extern "C" fn(&Object, Sel, *mut Object, *mut Object),
+            );
+            decl.add_method(
+                sel!(documentPickerWasCancelled:),
+                was_cancelled as extern "C" fn(&Object, Sel, *mut Object),
+            );
+        }
+
+        decl.register()
+    })
+}
+
+/// Present the iOS file picker.
+///
+/// This function is called from the Platform trait implementation.
+/// It returns a receiver that will be fulfilled when the user
+/// selects files or cancels.
+pub(crate) fn prompt_for_paths(
+    options: PathPromptOptions,
+) -> oneshot::Receiver<anyhow::Result<Option<Vec<PathBuf>>>> {
+    let (tx, rx) = oneshot::channel();
+
+    let state = init_state();
+
+    // Store the sender for the callback
+    unsafe {
+        *state.sender.get() = Some(tx);
+        *state.selecting_directories.get() = options.directories;
+    }
+
+    // Register delegate class if not already done
+    let delegate_class = register_delegate_class();
+
+    unsafe {
+        // Create the delegate
+        let delegate: *mut Object = msg_send![delegate_class, new];
+
+        // Create UTType array for allowed content types
+        let ut_types: *mut Object = if options.directories {
+            // For directories, use UTTypeFolder
+            let folder_type: *mut Object = msg_send![class!(UTType), folderType];
+            msg_send![class!(NSArray), arrayWithObject: folder_type]
+        } else {
+            // For files, allow all types (user can filter in picker)
+            let item_type: *mut Object = msg_send![class!(UTType), itemType];
+            msg_send![class!(NSArray), arrayWithObject: item_type]
+        };
+
+        // Create UIDocumentPickerViewController
+        // iOS 14+: initForOpeningContentTypes:asCopy:
+        let picker: *mut Object = msg_send![class!(UIDocumentPickerViewController), alloc];
+        let picker: *mut Object = msg_send![picker, initForOpeningContentTypes: ut_types asCopy: NO];
+
+        // Configure the picker
+        let _: () = msg_send![picker, setDelegate: delegate];
+        let _: () = msg_send![picker, setAllowsMultipleSelection: options.multiple];
+
+        // For directories, we need to set this mode
+        if options.directories {
+            // UIDocumentPickerMode.open = 0
+            // Actually for folders we use a different approach - the UTTypeFolder
+            // should be enough with iOS 14+
+        }
+
+        // Get the root view controller to present from
+        let app: *mut Object = msg_send![class!(UIApplication), sharedApplication];
+        let key_window: *mut Object = msg_send![app, keyWindow];
+
+        if key_window.is_null() {
+            log::error!("GPUI iOS: No key window available for file picker");
+            if let Some(state) = FILE_PICKER_STATE.get() {
+                if let Some(sender) = (*state.sender.get()).take() {
+                    let _ = sender.send(Err(anyhow::anyhow!("No key window available")));
+                }
+            }
+            return rx;
+        }
+
+        let root_vc: *mut Object = msg_send![key_window, rootViewController];
+        if root_vc.is_null() {
+            log::error!("GPUI iOS: No root view controller for file picker");
+            if let Some(state) = FILE_PICKER_STATE.get() {
+                if let Some(sender) = (*state.sender.get()).take() {
+                    let _ = sender.send(Err(anyhow::anyhow!("No root view controller")));
+                }
+            }
+            return rx;
+        }
+
+        // Present the picker
+        log::info!("GPUI iOS: Presenting file picker");
+        let _: () = msg_send![root_vc, presentViewController: picker animated: YES completion: std::ptr::null::<c_void>()];
+    }
+
+    rx
+}
+
+/// Present a save dialog.
+///
+/// On iOS, this uses UIDocumentPickerViewController in export mode.
+pub(crate) fn prompt_for_new_path(
+    directory: &std::path::Path,
+    suggested_name: Option<&str>,
+) -> oneshot::Receiver<anyhow::Result<Option<PathBuf>>> {
+    let (tx, rx) = oneshot::channel();
+
+    // For save dialogs, we need to create a temporary file first,
+    // then use UIDocumentPickerViewController to let the user choose
+    // where to save it. This is more complex on iOS.
+    //
+    // For MVP, we'll save to the app's Documents directory with the suggested name.
+
+    unsafe {
+        let file_manager: *mut Object = msg_send![class!(NSFileManager), defaultManager];
+        let urls: *mut Object = msg_send![file_manager,
+            URLsForDirectory: 9u64 // NSDocumentDirectory = 9
+            inDomains: 1u64 // NSUserDomainMask = 1
+        ];
+
+        let count: usize = msg_send![urls, count];
+        if count == 0 {
+            let _ = tx.send(Err(anyhow::anyhow!("No Documents directory available")));
+            return rx;
+        }
+
+        let docs_url: *mut Object = msg_send![urls, objectAtIndex: 0usize];
+        let docs_path: *mut Object = msg_send![docs_url, path];
+        let utf8: *const i8 = msg_send![docs_path, UTF8String];
+
+        if utf8.is_null() {
+            let _ = tx.send(Err(anyhow::anyhow!("Failed to get Documents path")));
+            return rx;
+        }
+
+        let docs_str = std::ffi::CStr::from_ptr(utf8).to_str().unwrap_or("");
+        let mut save_path = PathBuf::from(docs_str);
+
+        // Add the suggested filename or a default
+        let filename = suggested_name.unwrap_or("Untitled");
+        save_path.push(filename);
+
+        log::info!("GPUI iOS: Save path: {:?}", save_path);
+        let _ = tx.send(Ok(Some(save_path)));
+    }
+
+    rx
+}
+
+/// FFI function to receive file picker results from Objective-C.
+///
+/// This is called by the Objective-C delegate when the user selects files.
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_file_picker_did_pick(urls: *mut Object) {
+    log::info!("GPUI iOS: gpui_ios_file_picker_did_pick called");
+
+    if urls.is_null() {
+        // User cancelled
+        if let Some(state) = FILE_PICKER_STATE.get() {
+            unsafe {
+                if let Some(sender) = (*state.sender.get()).take() {
+                    let _ = sender.send(Ok(None));
+                }
+            }
+        }
+        return;
+    }
+
+    unsafe {
+        let mut paths: Vec<PathBuf> = Vec::new();
+        let count: usize = msg_send![urls, count];
+
+        for i in 0..count {
+            let url: *mut Object = msg_send![urls, objectAtIndex: i];
+            let path_string: *mut Object = msg_send![url, path];
+
+            if !path_string.is_null() {
+                let utf8: *const i8 = msg_send![path_string, UTF8String];
+                if !utf8.is_null() {
+                    let path_str = std::ffi::CStr::from_ptr(utf8).to_str().unwrap_or("");
+                    if !path_str.is_empty() {
+                        paths.push(PathBuf::from(path_str));
+                    }
+                }
+            }
+        }
+
+        if let Some(state) = FILE_PICKER_STATE.get() {
+            if let Some(sender) = (*state.sender.get()).take() {
+                let result = if paths.is_empty() {
+                    Ok(None)
+                } else {
+                    Ok(Some(paths))
+                };
+                let _ = sender.send(result);
+            }
+        }
+    }
+}
+
+/// FFI function called when the file picker is cancelled.
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_file_picker_cancelled() {
+    log::info!("GPUI iOS: File picker cancelled");
+
+    if let Some(state) = FILE_PICKER_STATE.get() {
+        unsafe {
+            if let Some(sender) = (*state.sender.get()).take() {
+                let _ = sender.send(Ok(None));
+            }
+        }
+    }
+}

--- a/crates/gpui/src/platform/ios/platform.rs
+++ b/crates/gpui/src/platform/ios/platform.rs
@@ -1,0 +1,371 @@
+//! iOS Platform implementation.
+//!
+//! This implements the Platform trait for iOS using UIKit.
+//! Key differences from macOS:
+//! - Uses UIApplication instead of NSApplication
+//! - No menu bar (iOS apps don't have traditional menus)
+//! - No windowed mode (iOS apps are always fullscreen on their display)
+//! - Touch-based input instead of mouse
+//! - System keyboard handling differs significantly
+
+use super::{IosDispatcher, IosDisplay, IosWindow};
+use crate::platform::blade;
+use crate::{
+    Action, AnyWindowHandle, BackgroundExecutor, ClipboardItem, CursorStyle, ForegroundExecutor,
+    Keymap, Menu, MenuItem, PathPromptOptions, Platform, PlatformDisplay, PlatformKeyboardLayout,
+    PlatformKeyboardMapper, PlatformTextSystem, PlatformWindow, Result, Task, WindowAppearance,
+    WindowParams,
+};
+use anyhow::anyhow;
+use futures::channel::oneshot;
+use objc::{class, msg_send, runtime::Object, sel, sel_impl};
+use parking_lot::Mutex;
+use std::{
+    path::{Path, PathBuf},
+    rc::Rc,
+    sync::Arc,
+};
+
+pub(crate) struct IosPlatform(Mutex<IosPlatformState>);
+
+pub(crate) struct IosPlatformState {
+    background_executor: BackgroundExecutor,
+    foreground_executor: ForegroundExecutor,
+    text_system: Arc<dyn PlatformTextSystem>,
+    renderer_context: blade::Context,
+    finish_launching: Option<Box<dyn FnOnce()>>,
+    quit_callback: Option<Box<dyn FnMut()>>,
+    open_urls_callback: Option<Box<dyn FnMut(Vec<String>)>>,
+}
+
+impl Default for IosPlatform {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IosPlatform {
+    pub fn new() -> Self {
+        let dispatcher = Arc::new(IosDispatcher);
+
+        #[cfg(feature = "font-kit")]
+        let text_system = Arc::new(crate::platform::ios::IosTextSystem::new());
+
+        #[cfg(not(feature = "font-kit"))]
+        let text_system = Arc::new(crate::NoopTextSystem::new());
+
+        Self(Mutex::new(IosPlatformState {
+            background_executor: BackgroundExecutor::new(dispatcher.clone()),
+            foreground_executor: ForegroundExecutor::new(dispatcher),
+            text_system,
+            renderer_context: blade::Context::default(),
+            finish_launching: None,
+            quit_callback: None,
+            open_urls_callback: None,
+        }))
+    }
+}
+
+impl Platform for IosPlatform {
+    fn background_executor(&self) -> BackgroundExecutor {
+        self.0.lock().background_executor.clone()
+    }
+
+    fn foreground_executor(&self) -> ForegroundExecutor {
+        self.0.lock().foreground_executor.clone()
+    }
+
+    fn text_system(&self) -> Arc<dyn PlatformTextSystem> {
+        self.0.lock().text_system.clone()
+    }
+
+    fn run(&self, on_finish_launching: Box<dyn 'static + FnOnce()>) {
+        // Store the callback for later invocation via FFI.
+        // The callback will be invoked when gpui_ios_did_finish_launching() is called
+        // from the iOS app delegate's applicationDidFinishLaunchingWithOptions:.
+        self.0.lock().finish_launching = Some(on_finish_launching);
+
+        // On iOS, the app lifecycle is managed by UIApplicationMain which must be
+        // called from main() before any Rust code runs. The Application::run() method
+        // is called during app initialization, before UIApplicationMain starts its
+        // event loop.
+        //
+        // The finish_launching callback is stored and will be invoked when the iOS
+        // app delegate calls gpui_ios_did_finish_launching() via FFI.
+        //
+        // Unlike macOS where we call NSApplication.run() here, on iOS we don't need
+        // to start the run loop - UIApplicationMain handles that.
+        //
+        // The callback is forwarded to the FFI layer so it can be invoked from Obj-C.
+        if let Some(callback) = self.0.lock().finish_launching.take() {
+            super::ffi::set_finish_launching_callback(callback);
+        }
+
+        log::info!("GPUI iOS: Platform::run() completed, waiting for app delegate callback");
+    }
+
+    fn quit(&self) {
+        // iOS apps cannot programmatically quit - they can only be terminated by the user
+        // or the system. We can suspend to background though.
+        log::warn!("iOS apps cannot programmatically quit");
+    }
+
+    fn restart(&self, _binary_path: Option<PathBuf>) {
+        // iOS apps cannot restart themselves
+        log::warn!("iOS apps cannot restart themselves");
+    }
+
+    fn activate(&self, _ignoring_other_apps: bool) {
+        // iOS handles app activation automatically
+    }
+
+    fn hide(&self) {
+        // iOS apps cannot hide themselves
+    }
+
+    fn hide_other_apps(&self) {
+        // Not applicable on iOS
+    }
+
+    fn unhide_other_apps(&self) {
+        // Not applicable on iOS
+    }
+
+    fn displays(&self) -> Vec<Rc<dyn PlatformDisplay>> {
+        IosDisplay::all()
+            .map(|display| Rc::new(display) as Rc<dyn PlatformDisplay>)
+            .collect()
+    }
+
+    fn primary_display(&self) -> Option<Rc<dyn PlatformDisplay>> {
+        Some(Rc::new(IosDisplay::main()))
+    }
+
+    fn active_window(&self) -> Option<AnyWindowHandle> {
+        // iOS typically has one active window
+        // This would need to track the current key window
+        None
+    }
+
+    fn open_window(
+        &self,
+        handle: AnyWindowHandle,
+        options: WindowParams,
+    ) -> anyhow::Result<Box<dyn PlatformWindow>> {
+        let renderer_context = self.0.lock().renderer_context.clone();
+        let window = Box::new(IosWindow::new(handle, options, renderer_context)?);
+        // Register the window with FFI layer so Objective-C can access it for rendering
+        window.register_with_ffi();
+        Ok(window)
+    }
+
+    fn window_appearance(&self) -> WindowAppearance {
+        unsafe {
+            let style: i64 = {
+                let window: *mut Object = msg_send![class!(UIApplication), sharedApplication];
+                let key_window: *mut Object = msg_send![window, keyWindow];
+                if key_window.is_null() {
+                    return WindowAppearance::Light;
+                }
+                let trait_collection: *mut Object = msg_send![key_window, traitCollection];
+                msg_send![trait_collection, userInterfaceStyle]
+            };
+
+            // UIUserInterfaceStyle: 0 = unspecified, 1 = light, 2 = dark
+            match style {
+                2 => WindowAppearance::Dark,
+                _ => WindowAppearance::Light,
+            }
+        }
+    }
+
+    fn open_url(&self, url: &str) {
+        unsafe {
+            let url_string: *mut Object =
+                msg_send![class!(NSString), stringWithUTF8String: url.as_ptr()];
+            let url: *mut Object = msg_send![class!(NSURL), URLWithString: url_string];
+            let app: *mut Object = msg_send![class!(UIApplication), sharedApplication];
+            let _: () = msg_send![app, openURL: url options: std::ptr::null::<Object>() completionHandler: std::ptr::null::<Object>()];
+        }
+    }
+
+    fn on_open_urls(&self, callback: Box<dyn FnMut(Vec<String>)>) {
+        self.0.lock().open_urls_callback = Some(callback);
+    }
+
+    fn register_url_scheme(&self, _url: &str) -> Task<Result<()>> {
+        // URL schemes on iOS are registered in Info.plist, not programmatically
+        Task::ready(Ok(()))
+    }
+
+    fn prompt_for_paths(
+        &self,
+        _options: PathPromptOptions,
+    ) -> oneshot::Receiver<Result<Option<Vec<PathBuf>>>> {
+        let (tx, rx) = oneshot::channel();
+        // iOS uses UIDocumentPickerViewController for file selection
+        // This would need to be implemented with proper UIKit integration
+        let _ = tx.send(Err(anyhow!("File picker not yet implemented for iOS")));
+        rx
+    }
+
+    fn prompt_for_new_path(
+        &self,
+        _directory: &Path,
+        _suggested_name: Option<&str>,
+    ) -> oneshot::Receiver<Result<Option<PathBuf>>> {
+        let (tx, rx) = oneshot::channel();
+        let _ = tx.send(Err(anyhow!("Save dialog not yet implemented for iOS")));
+        rx
+    }
+
+    fn can_select_mixed_files_and_dirs(&self) -> bool {
+        false
+    }
+
+    fn reveal_path(&self, _path: &Path) {
+        // iOS doesn't have a file manager like Finder
+    }
+
+    fn open_with_system(&self, _path: &Path) {
+        // Would use UIDocumentInteractionController or UIActivityViewController
+    }
+
+    fn on_quit(&self, callback: Box<dyn FnMut()>) {
+        self.0.lock().quit_callback = Some(callback);
+    }
+
+    fn on_reopen(&self, _callback: Box<dyn FnMut()>) {
+        // iOS handles app reopening through scene lifecycle
+    }
+
+    fn set_menus(&self, _menus: Vec<Menu>, _keymap: &Keymap) {
+        // iOS doesn't have a menu bar
+        // Could potentially integrate with UIMenuBuilder for context menus
+    }
+
+    fn set_dock_menu(&self, _menu: Vec<MenuItem>, _keymap: &Keymap) {
+        // iOS doesn't have a dock menu
+    }
+
+    fn on_app_menu_action(&self, _callback: Box<dyn FnMut(&dyn Action)>) {
+        // Not applicable on iOS
+    }
+
+    fn on_will_open_app_menu(&self, _callback: Box<dyn FnMut()>) {
+        // Not applicable on iOS
+    }
+
+    fn on_validate_app_menu_command(&self, _callback: Box<dyn FnMut(&dyn Action) -> bool>) {
+        // Not applicable on iOS
+    }
+
+    fn app_path(&self) -> Result<PathBuf> {
+        unsafe {
+            let bundle: *mut Object = msg_send![class!(NSBundle), mainBundle];
+            let path: *mut Object = msg_send![bundle, bundlePath];
+            let utf8: *const i8 = msg_send![path, UTF8String];
+            if utf8.is_null() {
+                return Err(anyhow!("Failed to get bundle path"));
+            }
+            let path_str = std::ffi::CStr::from_ptr(utf8).to_str()?;
+            Ok(PathBuf::from(path_str))
+        }
+    }
+
+    fn path_for_auxiliary_executable(&self, name: &str) -> Result<PathBuf> {
+        let app_path = self.app_path()?;
+        Ok(app_path.join(name))
+    }
+
+    fn set_cursor_style(&self, _style: CursorStyle) {
+        // iOS doesn't have visible cursors (except for Apple Pencil hover on iPad)
+    }
+
+    fn should_auto_hide_scrollbars(&self) -> bool {
+        true // iOS always auto-hides scrollbars
+    }
+
+    fn write_to_clipboard(&self, item: ClipboardItem) {
+        unsafe {
+            let pasteboard: *mut Object = msg_send![class!(UIPasteboard), generalPasteboard];
+            if let Some(text) = item.text() {
+                let ns_string: *mut Object =
+                    msg_send![class!(NSString), stringWithUTF8String: text.as_ptr()];
+                let _: () = msg_send![pasteboard, setString: ns_string];
+            }
+        }
+    }
+
+    fn read_from_clipboard(&self) -> Option<ClipboardItem> {
+        unsafe {
+            let pasteboard: *mut Object = msg_send![class!(UIPasteboard), generalPasteboard];
+            let string: *mut Object = msg_send![pasteboard, string];
+            if string.is_null() {
+                return None;
+            }
+            let utf8: *const i8 = msg_send![string, UTF8String];
+            if utf8.is_null() {
+                return None;
+            }
+            let text = std::ffi::CStr::from_ptr(utf8).to_str().ok()?;
+            Some(ClipboardItem::new_string(text.to_string()))
+        }
+    }
+
+    fn write_credentials(&self, _url: &str, _username: &str, _password: &[u8]) -> Task<Result<()>> {
+        // Would use iOS Keychain Services
+        Task::ready(Err(anyhow!("Keychain not yet implemented for iOS")))
+    }
+
+    fn read_credentials(&self, _url: &str) -> Task<Result<Option<(String, Vec<u8>)>>> {
+        Task::ready(Err(anyhow!("Keychain not yet implemented for iOS")))
+    }
+
+    fn delete_credentials(&self, _url: &str) -> Task<Result<()>> {
+        Task::ready(Err(anyhow!("Keychain not yet implemented for iOS")))
+    }
+
+    fn keyboard_layout(&self) -> Box<dyn PlatformKeyboardLayout> {
+        Box::new(IosKeyboardLayout)
+    }
+
+    fn keyboard_mapper(&self) -> Rc<dyn PlatformKeyboardMapper> {
+        Rc::new(IosKeyboardMapper)
+    }
+
+    fn on_keyboard_layout_change(&self, _callback: Box<dyn FnMut()>) {
+        // iOS handles keyboard layout changes differently
+    }
+}
+
+/// iOS keyboard layout implementation.
+/// iOS doesn't expose the same keyboard layout APIs as macOS.
+pub struct IosKeyboardLayout;
+
+impl PlatformKeyboardLayout for IosKeyboardLayout {
+    fn id(&self) -> &str {
+        "ios"
+    }
+
+    fn name(&self) -> &str {
+        "iOS"
+    }
+}
+
+/// iOS keyboard mapper implementation.
+pub struct IosKeyboardMapper;
+
+impl PlatformKeyboardMapper for IosKeyboardMapper {
+    fn map_key_equivalent(
+        &self,
+        keystroke: crate::Keystroke,
+        _use_key_equivalents: bool,
+    ) -> crate::KeybindingKeystroke {
+        crate::KeybindingKeystroke::from_keystroke(keystroke)
+    }
+
+    fn get_key_equivalents(&self) -> Option<&collections::HashMap<char, char>> {
+        None
+    }
+}

--- a/crates/gpui/src/platform/ios/platform.rs
+++ b/crates/gpui/src/platform/ios/platform.rs
@@ -200,23 +200,19 @@ impl Platform for IosPlatform {
 
     fn prompt_for_paths(
         &self,
-        _options: PathPromptOptions,
+        options: PathPromptOptions,
     ) -> oneshot::Receiver<Result<Option<Vec<PathBuf>>>> {
-        let (tx, rx) = oneshot::channel();
-        // iOS uses UIDocumentPickerViewController for file selection
-        // This would need to be implemented with proper UIKit integration
-        let _ = tx.send(Err(anyhow!("File picker not yet implemented for iOS")));
-        rx
+        // Use the iOS file picker implementation
+        super::file_picker::prompt_for_paths(options)
     }
 
     fn prompt_for_new_path(
         &self,
-        _directory: &Path,
-        _suggested_name: Option<&str>,
+        directory: &Path,
+        suggested_name: Option<&str>,
     ) -> oneshot::Receiver<Result<Option<PathBuf>>> {
-        let (tx, rx) = oneshot::channel();
-        let _ = tx.send(Err(anyhow!("Save dialog not yet implemented for iOS")));
-        rx
+        // Use the iOS file picker implementation for save dialogs
+        super::file_picker::prompt_for_new_path(directory, suggested_name)
     }
 
     fn can_select_mixed_files_and_dirs(&self) -> bool {

--- a/crates/gpui/src/platform/ios/text_input.rs
+++ b/crates/gpui/src/platform/ios/text_input.rs
@@ -1,0 +1,167 @@
+//! iOS text input handling.
+//!
+//! This module provides keyboard input support for iOS.
+//! For now, we use a simple approach that handles software keyboard input
+//! through the window's text input view.
+//!
+//! Full UITextInput protocol support (for IME, marked text, etc.) can be
+//! added later if needed.
+
+use crate::{KeyDownEvent, Keystroke, Modifiers, PlatformInput};
+
+/// Convert a key code from UIKeyboardHIDUsage to a GPUI key string.
+///
+/// UIKeyboardHIDUsage values are based on the USB HID specification.
+pub fn key_code_to_string(code: u32) -> String {
+    match code {
+        // Letters (0x04-0x1D = a-z)
+        0x04..=0x1D => {
+            let letter = (b'a' + (code - 0x04) as u8) as char;
+            letter.to_string()
+        }
+        // Numbers (0x1E-0x27 = 1-9, 0)
+        0x1E..=0x26 => {
+            let num = ((code - 0x1E + 1) % 10) as u8 + b'0';
+            (num as char).to_string()
+        }
+        0x27 => "0".to_string(),
+        // Special keys
+        0x28 => "enter".to_string(),
+        0x29 => "escape".to_string(),
+        0x2A => "backspace".to_string(),
+        0x2B => "tab".to_string(),
+        0x2C => " ".to_string(),
+        0x2D => "-".to_string(),
+        0x2E => "=".to_string(),
+        0x2F => "[".to_string(),
+        0x30 => "]".to_string(),
+        0x31 => "\\".to_string(),
+        0x33 => ";".to_string(),
+        0x34 => "'".to_string(),
+        0x35 => "`".to_string(),
+        0x36 => ",".to_string(),
+        0x37 => ".".to_string(),
+        0x38 => "/".to_string(),
+        // Arrow keys
+        0x4F => "right".to_string(),
+        0x50 => "left".to_string(),
+        0x51 => "down".to_string(),
+        0x52 => "up".to_string(),
+        // Function keys
+        0x3A => "f1".to_string(),
+        0x3B => "f2".to_string(),
+        0x3C => "f3".to_string(),
+        0x3D => "f4".to_string(),
+        0x3E => "f5".to_string(),
+        0x3F => "f6".to_string(),
+        0x40 => "f7".to_string(),
+        0x41 => "f8".to_string(),
+        0x42 => "f9".to_string(),
+        0x43 => "f10".to_string(),
+        0x44 => "f11".to_string(),
+        0x45 => "f12".to_string(),
+        // Other special keys
+        0x49 => "insert".to_string(),
+        0x4A => "home".to_string(),
+        0x4B => "pageup".to_string(),
+        0x4C => "delete".to_string(),
+        0x4D => "end".to_string(),
+        0x4E => "pagedown".to_string(),
+        // Default
+        _ => format!("unknown-{:02x}", code),
+    }
+}
+
+/// Convert UIKeyModifierFlags to GPUI Modifiers.
+///
+/// UIKeyModifierFlags:
+/// - alphaShift (caps lock): 1 << 16
+/// - shift: 1 << 17
+/// - control: 1 << 18
+/// - alternate (option): 1 << 19
+/// - command: 1 << 20
+/// - numericPad: 1 << 21
+pub fn modifier_flags_to_modifiers(flags: u32) -> Modifiers {
+    const SHIFT: u32 = 1 << 17;
+    const CONTROL: u32 = 1 << 18;
+    const ALT: u32 = 1 << 19;
+    const COMMAND: u32 = 1 << 20;
+
+    Modifiers {
+        control: flags & CONTROL != 0,
+        alt: flags & ALT != 0,
+        shift: flags & SHIFT != 0,
+        platform: flags & COMMAND != 0,
+        function: false,
+    }
+}
+
+/// Create a key down event from a character.
+pub fn character_to_key_down(c: char) -> PlatformInput {
+    let keystroke = Keystroke {
+        modifiers: Modifiers::default(),
+        key: c.to_string(),
+        key_char: Some(c.to_string()),
+    };
+
+    PlatformInput::KeyDown(KeyDownEvent {
+        keystroke,
+        is_held: false,
+        prefer_character_input: true,
+    })
+}
+
+/// Create a backspace key down event.
+pub fn backspace_key_down() -> PlatformInput {
+    let keystroke = Keystroke {
+        modifiers: Modifiers::default(),
+        key: "backspace".to_string(),
+        key_char: None,
+    };
+
+    PlatformInput::KeyDown(KeyDownEvent {
+        keystroke,
+        is_held: false,
+        prefer_character_input: false,
+    })
+}
+
+/// Create a key down event from a key code and modifiers.
+pub fn key_code_to_key_down(key_code: u32, modifier_flags: u32) -> PlatformInput {
+    let modifiers = modifier_flags_to_modifiers(modifier_flags);
+    let key = key_code_to_string(key_code);
+
+    let keystroke = Keystroke {
+        modifiers,
+        key: key.clone(),
+        key_char: if key.len() == 1 {
+            Some(key.clone())
+        } else {
+            None
+        },
+    };
+
+    PlatformInput::KeyDown(KeyDownEvent {
+        keystroke,
+        is_held: false,
+        prefer_character_input: false,
+    })
+}
+
+/// Create a key up event from a key code and modifiers.
+pub fn key_code_to_key_up(key_code: u32, modifier_flags: u32) -> PlatformInput {
+    let modifiers = modifier_flags_to_modifiers(modifier_flags);
+    let key = key_code_to_string(key_code);
+
+    let keystroke = Keystroke {
+        modifiers,
+        key: key.clone(),
+        key_char: if key.len() == 1 {
+            Some(key.clone())
+        } else {
+            None
+        },
+    };
+
+    PlatformInput::KeyUp(crate::KeyUpEvent { keystroke })
+}

--- a/crates/gpui/src/platform/ios/text_input.rs
+++ b/crates/gpui/src/platform/ios/text_input.rs
@@ -1,13 +1,239 @@
 //! iOS text input handling.
 //!
-//! This module provides keyboard input support for iOS.
-//! For now, we use a simple approach that handles software keyboard input
-//! through the window's text input view.
+//! This module provides keyboard input support for iOS, implementing the full
+//! UITextInput protocol for proper software keyboard and IME support.
 //!
-//! Full UITextInput protocol support (for IME, marked text, etc.) can be
-//! added later if needed.
+//! Key components:
+//! - GPUITextPosition: UITextPosition subclass wrapping a UTF-16 index
+//! - GPUITextRange: UITextRange subclass wrapping start/end positions
+//! - Key code mapping for hardware keyboards
+//! - UITextInput protocol method implementations (in window.rs)
 
 use crate::{KeyDownEvent, Keystroke, Modifiers, PlatformInput};
+use objc::{
+    class,
+    declare::ClassDecl,
+    msg_send,
+    runtime::{Class, Object, Sel, BOOL, NO, YES},
+    sel, sel_impl,
+};
+use std::sync::Once;
+
+// Ivar names for GPUITextPosition
+const GPUI_POSITION_INDEX_IVAR: &str = "index";
+
+// Ivar names for GPUITextRange
+const GPUI_RANGE_START_IVAR: &str = "start";
+const GPUI_RANGE_END_IVAR: &str = "end";
+
+static TEXT_POSITION_CLASS_REGISTERED: Once = Once::new();
+static TEXT_RANGE_CLASS_REGISTERED: Once = Once::new();
+
+// Cache the registered classes to avoid repeated class!() lookups.
+// This avoids potential race conditions where class!() is called before
+// registration is complete.
+static mut TEXT_POSITION_CLASS: Option<&'static Class> = None;
+static mut TEXT_RANGE_CLASS: Option<&'static Class> = None;
+
+/// Register GPUITextPosition - a UITextPosition subclass that wraps a UTF-16 index.
+///
+/// iOS requires UITextPosition subclasses for the UITextInput protocol.
+/// Raw integers cannot be used directly.
+///
+/// This function caches the class reference to avoid repeated class!() lookups,
+/// which could fail if called during registration.
+pub fn register_text_position_class() -> &'static Class {
+    TEXT_POSITION_CLASS_REGISTERED.call_once(|| {
+        let superclass = class!(UITextPosition);
+        let mut decl = ClassDecl::new("GPUITextPosition", superclass).unwrap();
+
+        // Store UTF-16 index
+        decl.add_ivar::<usize>(GPUI_POSITION_INDEX_IVAR);
+
+        // Equality check - required for proper position comparison
+        extern "C" fn is_equal(this: &Object, _sel: Sel, other: *mut Object) -> BOOL {
+            unsafe {
+                if other.is_null() {
+                    return NO;
+                }
+                // Check if other is a GPUITextPosition - use cached class
+                let other_class: *const Class = msg_send![other, class];
+                let our_class = register_text_position_class();
+                if other_class as *const _ != our_class as *const _ {
+                    return NO;
+                }
+                let this_index: usize = *this.get_ivar(GPUI_POSITION_INDEX_IVAR);
+                let other_index: usize = *(&*other).get_ivar(GPUI_POSITION_INDEX_IVAR);
+                if this_index == other_index {
+                    YES
+                } else {
+                    NO
+                }
+            }
+        }
+
+        // Hash method for dictionary keys
+        extern "C" fn hash(this: &Object, _sel: Sel) -> usize {
+            unsafe {
+                let index: usize = *this.get_ivar(GPUI_POSITION_INDEX_IVAR);
+                index
+            }
+        }
+
+        unsafe {
+            decl.add_method(
+                sel!(isEqual:),
+                is_equal as extern "C" fn(&Object, Sel, *mut Object) -> BOOL,
+            );
+            decl.add_method(sel!(hash), hash as extern "C" fn(&Object, Sel) -> usize);
+        }
+
+        let registered_class = decl.register();
+        // Cache the class pointer - safe because registration happens only once
+        // and the class lives for the entire program lifetime.
+        unsafe {
+            TEXT_POSITION_CLASS = Some(registered_class);
+        }
+    });
+
+    // Return cached class - safe because Once::call_once guarantees
+    // the closure has completed before we reach this point.
+    unsafe {
+        TEXT_POSITION_CLASS.expect("GPUITextPosition class should be registered")
+    }
+}
+
+/// Create a GPUITextPosition with the given UTF-16 index.
+pub fn create_text_position(index: usize) -> *mut Object {
+    unsafe {
+        let class = register_text_position_class();
+        let position: *mut Object = msg_send![class, alloc];
+        let position: *mut Object = msg_send![position, init];
+        (*position).set_ivar(GPUI_POSITION_INDEX_IVAR, index);
+        position
+    }
+}
+
+/// Get the UTF-16 index from a GPUITextPosition.
+pub fn get_position_index(position: *mut Object) -> Option<usize> {
+    if position.is_null() {
+        return None;
+    }
+    unsafe {
+        let index: usize = *(&*position).get_ivar(GPUI_POSITION_INDEX_IVAR);
+        Some(index)
+    }
+}
+
+/// Register GPUITextRange - a UITextRange subclass wrapping start/end UTF-16 indices.
+///
+/// iOS requires UITextRange subclasses for the UITextInput protocol.
+///
+/// This function caches the class reference to avoid repeated class!() lookups,
+/// which could fail if called during registration.
+pub fn register_text_range_class() -> &'static Class {
+    // Ensure position class is registered first
+    register_text_position_class();
+
+    TEXT_RANGE_CLASS_REGISTERED.call_once(|| {
+        let superclass = class!(UITextRange);
+        let mut decl = ClassDecl::new("GPUITextRange", superclass).unwrap();
+
+        decl.add_ivar::<usize>(GPUI_RANGE_START_IVAR);
+        decl.add_ivar::<usize>(GPUI_RANGE_END_IVAR);
+
+        // start property - returns GPUITextPosition
+        extern "C" fn get_start(this: &Object, _sel: Sel) -> *mut Object {
+            unsafe {
+                let start: usize = *this.get_ivar(GPUI_RANGE_START_IVAR);
+                create_text_position(start)
+            }
+        }
+
+        // end property - returns GPUITextPosition
+        extern "C" fn get_end(this: &Object, _sel: Sel) -> *mut Object {
+            unsafe {
+                let end: usize = *this.get_ivar(GPUI_RANGE_END_IVAR);
+                create_text_position(end)
+            }
+        }
+
+        // isEmpty property - required by UITextRange
+        extern "C" fn is_empty(this: &Object, _sel: Sel) -> BOOL {
+            unsafe {
+                let start: usize = *this.get_ivar(GPUI_RANGE_START_IVAR);
+                let end: usize = *this.get_ivar(GPUI_RANGE_END_IVAR);
+                if start == end {
+                    YES
+                } else {
+                    NO
+                }
+            }
+        }
+
+        unsafe {
+            decl.add_method(
+                sel!(start),
+                get_start as extern "C" fn(&Object, Sel) -> *mut Object,
+            );
+            decl.add_method(
+                sel!(end),
+                get_end as extern "C" fn(&Object, Sel) -> *mut Object,
+            );
+            decl.add_method(
+                sel!(isEmpty),
+                is_empty as extern "C" fn(&Object, Sel) -> BOOL,
+            );
+        }
+
+        let registered_class = decl.register();
+        // Cache the class pointer - safe because registration happens only once
+        // and the class lives for the entire program lifetime.
+        unsafe {
+            TEXT_RANGE_CLASS = Some(registered_class);
+        }
+    });
+
+    // Return cached class - safe because Once::call_once guarantees
+    // the closure has completed before we reach this point.
+    unsafe {
+        TEXT_RANGE_CLASS.expect("GPUITextRange class should be registered")
+    }
+}
+
+/// Pre-register all text input classes.
+///
+/// Call this early during window initialization to ensure classes are registered
+/// before iOS tries to use them. This avoids race conditions where iOS queries
+/// UITextInput methods (like markedTextRange) before classes are ready.
+pub fn ensure_text_input_classes_registered() {
+    register_text_position_class();
+    register_text_range_class();
+}
+
+/// Create a GPUITextRange with start and end UTF-16 indices.
+pub fn create_text_range(start: usize, end: usize) -> *mut Object {
+    unsafe {
+        let class = register_text_range_class();
+        let range: *mut Object = msg_send![class, alloc];
+        let range: *mut Object = msg_send![range, init];
+        (*range).set_ivar(GPUI_RANGE_START_IVAR, start);
+        (*range).set_ivar(GPUI_RANGE_END_IVAR, end);
+        range
+    }
+}
+
+/// Get the start and end indices from a GPUITextRange.
+pub fn get_range_indices(range: *mut Object) -> Option<(usize, usize)> {
+    if range.is_null() {
+        return None;
+    }
+    unsafe {
+        let start: usize = *(&*range).get_ivar(GPUI_RANGE_START_IVAR);
+        let end: usize = *(&*range).get_ivar(GPUI_RANGE_END_IVAR);
+        Some((start, end))
+    }
+}
 
 /// Convert a key code from UIKeyboardHIDUsage to a GPUI key string.
 ///
@@ -131,14 +357,16 @@ pub fn key_code_to_key_down(key_code: u32, modifier_flags: u32) -> PlatformInput
     let modifiers = modifier_flags_to_modifiers(modifier_flags);
     let key = key_code_to_string(key_code);
 
+    let key_char = if key.len() == 1 {
+        Some(key.clone())
+    } else {
+        None
+    };
+
     let keystroke = Keystroke {
         modifiers,
-        key: key.clone(),
-        key_char: if key.len() == 1 {
-            Some(key.clone())
-        } else {
-            None
-        },
+        key,
+        key_char,
     };
 
     PlatformInput::KeyDown(KeyDownEvent {
@@ -153,14 +381,16 @@ pub fn key_code_to_key_up(key_code: u32, modifier_flags: u32) -> PlatformInput {
     let modifiers = modifier_flags_to_modifiers(modifier_flags);
     let key = key_code_to_string(key_code);
 
+    let key_char = if key.len() == 1 {
+        Some(key.clone())
+    } else {
+        None
+    };
+
     let keystroke = Keystroke {
         modifiers,
-        key: key.clone(),
-        key_char: if key.len() == 1 {
-            Some(key.clone())
-        } else {
-            None
-        },
+        key,
+        key_char,
     };
 
     PlatformInput::KeyUp(crate::KeyUpEvent { keystroke })

--- a/crates/gpui/src/platform/ios/text_system.rs
+++ b/crates/gpui/src/platform/ios/text_system.rs
@@ -1,0 +1,801 @@
+//! iOS text system using CoreText.
+//!
+//! This is adapted from the macOS text system since both platforms share
+//! the CoreText framework for text rendering.
+
+use crate::{
+    Bounds, DevicePixels, Font, FontFallbacks, FontFeatures, FontId, FontMetrics, FontRun,
+    FontStyle, FontWeight, GlyphId, LineLayout, Pixels, PlatformTextSystem, Point,
+    RenderGlyphParams, Result, SUBPIXEL_VARIANTS_X, ShapedGlyph, ShapedRun, SharedString, Size,
+    point, px, size, swap_rgba_pa_to_bgra,
+};
+use anyhow::anyhow;
+use collections::HashMap;
+use core_foundation::{
+    attributed_string::CFMutableAttributedString,
+    base::{CFRange, TCFType},
+    number::CFNumber,
+    string::CFString,
+};
+use core_graphics::{
+    base::{CGFloat, CGGlyph, kCGImageAlphaPremultipliedLast},
+    color_space::CGColorSpace,
+    context::{CGContext, CGTextDrawingMode},
+    geometry::CGPoint,
+};
+use core_text::{
+    font::CTFont,
+    font_descriptor::{
+        kCTFontSlantTrait, kCTFontSymbolicTrait, kCTFontWeightTrait, kCTFontWidthTrait,
+    },
+    line::CTLine,
+    string_attributes::kCTFontAttributeName,
+};
+use font_kit::{
+    font::Font as FontKitFont,
+    handle::Handle,
+    hinting::HintingOptions,
+    metrics::Metrics,
+    properties::{Style as FontkitStyle, Weight as FontkitWeight},
+    source::SystemSource,
+    sources::mem::MemSource,
+};
+use parking_lot::{RwLock, RwLockUpgradableReadGuard};
+use pathfinder_geometry::{
+    rect::{RectF, RectI},
+    transform2d::Transform2F,
+    vector::{Vector2F, Vector2I},
+};
+use smallvec::SmallVec;
+use std::{borrow::Cow, char, convert::TryFrom, sync::Arc};
+
+#[allow(non_upper_case_globals)]
+const kCGImageAlphaOnly: u32 = 7;
+
+/// iOS text system using CoreText for text shaping and rendering.
+///
+/// This provides full text rendering support on iOS using the same
+/// CoreText framework that macOS uses, adapted for the iOS platform.
+pub struct IosTextSystem(RwLock<IosTextSystemState>);
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct FontKey {
+    font_family: SharedString,
+    font_features: FontFeatures,
+    font_fallbacks: Option<FontFallbacks>,
+}
+
+struct IosTextSystemState {
+    memory_source: MemSource,
+    system_source: SystemSource,
+    fonts: Vec<FontKitFont>,
+    font_selections: HashMap<Font, FontId>,
+    font_ids_by_postscript_name: HashMap<String, FontId>,
+    font_ids_by_font_key: HashMap<FontKey, SmallVec<[FontId; 4]>>,
+    postscript_names_by_font_id: HashMap<FontId, String>,
+}
+
+impl IosTextSystem {
+    pub fn new() -> Self {
+        Self(RwLock::new(IosTextSystemState {
+            memory_source: MemSource::empty(),
+            system_source: SystemSource::new(),
+            fonts: Vec::new(),
+            font_selections: HashMap::default(),
+            font_ids_by_postscript_name: HashMap::default(),
+            font_ids_by_font_key: HashMap::default(),
+            postscript_names_by_font_id: HashMap::default(),
+        }))
+    }
+}
+
+impl Default for IosTextSystem {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PlatformTextSystem for IosTextSystem {
+    fn add_fonts(&self, fonts: Vec<Cow<'static, [u8]>>) -> Result<()> {
+        self.0.write().add_fonts(fonts)
+    }
+
+    fn all_font_names(&self) -> Vec<String> {
+        let mut names = Vec::new();
+        let collection = core_text::font_collection::create_for_all_families();
+        let Some(descriptors) = collection.get_descriptors() else {
+            return names;
+        };
+        for descriptor in descriptors.into_iter() {
+            names.extend(lenient_font_attributes::family_name(&descriptor));
+        }
+        if let Ok(fonts_in_memory) = self.0.read().memory_source.all_families() {
+            names.extend(fonts_in_memory);
+        }
+        names
+    }
+
+    fn font_id(&self, font: &Font) -> Result<FontId> {
+        let lock = self.0.upgradable_read();
+        if let Some(font_id) = lock.font_selections.get(font) {
+            Ok(*font_id)
+        } else {
+            let mut lock = RwLockUpgradableReadGuard::upgrade(lock);
+            let font_key = FontKey {
+                font_family: font.family.clone(),
+                font_features: font.features.clone(),
+                font_fallbacks: font.fallbacks.clone(),
+            };
+            let candidates = if let Some(font_ids) = lock.font_ids_by_font_key.get(&font_key) {
+                font_ids.as_slice()
+            } else {
+                let font_ids =
+                    lock.load_family(&font.family, &font.features, font.fallbacks.as_ref())?;
+                lock.font_ids_by_font_key.insert(font_key.clone(), font_ids);
+                lock.font_ids_by_font_key[&font_key].as_ref()
+            };
+
+            let candidate_properties = candidates
+                .iter()
+                .map(|font_id| lock.fonts[font_id.0].properties())
+                .collect::<SmallVec<[_; 4]>>();
+
+            let ix = font_kit::matching::find_best_match(
+                &candidate_properties,
+                &font_kit::properties::Properties {
+                    style: font.style.into(),
+                    weight: font.weight.into(),
+                    stretch: Default::default(),
+                },
+            )?;
+
+            let font_id = candidates[ix];
+            lock.font_selections.insert(font.clone(), font_id);
+            Ok(font_id)
+        }
+    }
+
+    fn font_metrics(&self, font_id: FontId) -> FontMetrics {
+        self.0.read().fonts[font_id.0].metrics().into()
+    }
+
+    fn typographic_bounds(&self, font_id: FontId, glyph_id: GlyphId) -> Result<Bounds<f32>> {
+        Ok(self.0.read().fonts[font_id.0]
+            .typographic_bounds(glyph_id.0)?
+            .into())
+    }
+
+    fn advance(&self, font_id: FontId, glyph_id: GlyphId) -> Result<Size<f32>> {
+        self.0.read().advance(font_id, glyph_id)
+    }
+
+    fn glyph_for_char(&self, font_id: FontId, ch: char) -> Option<GlyphId> {
+        self.0.read().glyph_for_char(font_id, ch)
+    }
+
+    fn glyph_raster_bounds(&self, params: &RenderGlyphParams) -> Result<Bounds<DevicePixels>> {
+        self.0.read().raster_bounds(params)
+    }
+
+    fn rasterize_glyph(
+        &self,
+        glyph_id: &RenderGlyphParams,
+        raster_bounds: Bounds<DevicePixels>,
+    ) -> Result<(Size<DevicePixels>, Vec<u8>)> {
+        self.0.read().rasterize_glyph(glyph_id, raster_bounds)
+    }
+
+    fn layout_line(&self, text: &str, font_size: Pixels, font_runs: &[FontRun]) -> LineLayout {
+        self.0.write().layout_line(text, font_size, font_runs)
+    }
+}
+
+impl IosTextSystemState {
+    fn add_fonts(&mut self, fonts: Vec<Cow<'static, [u8]>>) -> Result<()> {
+        let fonts = fonts
+            .into_iter()
+            .map(|bytes| match bytes {
+                Cow::Borrowed(embedded_font) => {
+                    let data_provider = unsafe {
+                        core_graphics::data_provider::CGDataProvider::from_slice(embedded_font)
+                    };
+                    let font = core_graphics::font::CGFont::from_data_provider(data_provider)
+                        .map_err(|()| anyhow!("Could not load an embedded font."))?;
+                    let font = font_kit::loaders::core_text::Font::from_core_graphics_font(font);
+                    Ok(Handle::from_native(&font))
+                }
+                Cow::Owned(bytes) => Ok(Handle::from_memory(Arc::new(bytes), 0)),
+            })
+            .collect::<Result<Vec<_>>>()?;
+        self.memory_source.add_fonts(fonts.into_iter())?;
+        Ok(())
+    }
+
+    fn load_family(
+        &mut self,
+        name: &str,
+        features: &FontFeatures,
+        fallbacks: Option<&FontFallbacks>,
+    ) -> Result<SmallVec<[FontId; 4]>> {
+        // On iOS, the system UI font is accessed via ".AppleSystemUIFont"
+        // but we also support direct font names
+        let name = crate::text_system::font_name_with_fallbacks(name, ".AppleSystemUIFont");
+
+        let mut font_ids = SmallVec::new();
+        let family = self
+            .memory_source
+            .select_family_by_name(name)
+            .or_else(|_| self.system_source.select_family_by_name(name))?;
+        for font in family.fonts() {
+            let mut font = font.load()?;
+
+            apply_features_and_fallbacks(&mut font, features, fallbacks)?;
+            // This block contains a precautionary fix to guard against loading fonts
+            // that might cause panics due to `.unwrap()`s up the chain.
+            {
+                // We use the 'm' character for text measurements in various spots
+                // (e.g., the editor). However, at time of writing some of those usages
+                // will panic if the font has no 'm' glyph.
+                //
+                // Therefore, we check up front that the font has the necessary glyph.
+                let has_m_glyph = font.glyph_for_char('m').is_some();
+
+                // HACK: The 'Segoe Fluent Icons' font does not have an 'm' glyph,
+                // but we need to be able to load it for rendering Windows icons in
+                // the Storybook (on macOS).
+                let is_segoe_fluent_icons = font.full_name() == "Segoe Fluent Icons";
+
+                if !has_m_glyph && !is_segoe_fluent_icons {
+                    log::warn!(
+                        "font '{}' has no 'm' character and was not loaded",
+                        font.full_name()
+                    );
+                    continue;
+                }
+            }
+
+            // Validate font traits to avoid panics from malformed fonts
+            let traits = font.native_font().all_traits();
+            if unsafe {
+                !(traits
+                    .get(kCTFontSymbolicTrait)
+                    .downcast::<CFNumber>()
+                    .is_some()
+                    && traits
+                        .get(kCTFontWidthTrait)
+                        .downcast::<CFNumber>()
+                        .is_some()
+                    && traits
+                        .get(kCTFontWeightTrait)
+                        .downcast::<CFNumber>()
+                        .is_some()
+                    && traits
+                        .get(kCTFontSlantTrait)
+                        .downcast::<CFNumber>()
+                        .is_some())
+            } {
+                log::error!(
+                    "Failed to read traits for font {:?}",
+                    font.postscript_name().unwrap()
+                );
+                continue;
+            }
+
+            let font_id = FontId(self.fonts.len());
+            font_ids.push(font_id);
+            let postscript_name = font.postscript_name().unwrap();
+            self.font_ids_by_postscript_name
+                .insert(postscript_name.clone(), font_id);
+            self.postscript_names_by_font_id
+                .insert(font_id, postscript_name);
+            self.fonts.push(font);
+        }
+        Ok(font_ids)
+    }
+
+    fn advance(&self, font_id: FontId, glyph_id: GlyphId) -> Result<Size<f32>> {
+        Ok(self.fonts[font_id.0].advance(glyph_id.0)?.into())
+    }
+
+    fn glyph_for_char(&self, font_id: FontId, ch: char) -> Option<GlyphId> {
+        self.fonts[font_id.0].glyph_for_char(ch).map(GlyphId)
+    }
+
+    fn id_for_native_font(&mut self, requested_font: CTFont) -> FontId {
+        let postscript_name = requested_font.postscript_name();
+        if let Some(font_id) = self.font_ids_by_postscript_name.get(&postscript_name) {
+            *font_id
+        } else {
+            let font_id = FontId(self.fonts.len());
+            self.font_ids_by_postscript_name
+                .insert(postscript_name.clone(), font_id);
+            self.postscript_names_by_font_id
+                .insert(font_id, postscript_name);
+            self.fonts
+                .push(font_kit::font::Font::from_core_graphics_font(
+                    requested_font.copy_to_CGFont(),
+                ));
+            font_id
+        }
+    }
+
+    fn is_emoji(&self, font_id: FontId) -> bool {
+        self.postscript_names_by_font_id
+            .get(&font_id)
+            .is_some_and(|postscript_name| {
+                postscript_name == "AppleColorEmoji" || postscript_name == ".AppleColorEmojiUI"
+            })
+    }
+
+    fn raster_bounds(&self, params: &RenderGlyphParams) -> Result<Bounds<DevicePixels>> {
+        let font = &self.fonts[params.font_id.0];
+        let scale = Transform2F::from_scale(params.scale_factor);
+        Ok(font
+            .raster_bounds(
+                params.glyph_id.0,
+                params.font_size.into(),
+                scale,
+                HintingOptions::None,
+                font_kit::canvas::RasterizationOptions::GrayscaleAa,
+            )?
+            .into())
+    }
+
+    fn rasterize_glyph(
+        &self,
+        params: &RenderGlyphParams,
+        glyph_bounds: Bounds<DevicePixels>,
+    ) -> Result<(Size<DevicePixels>, Vec<u8>)> {
+        if glyph_bounds.size.width.0 == 0 || glyph_bounds.size.height.0 == 0 {
+            anyhow::bail!("glyph bounds are empty");
+        } else {
+            // Add an extra pixel when the subpixel variant isn't zero to make room for anti-aliasing.
+            let mut bitmap_size = glyph_bounds.size;
+            if params.subpixel_variant.x > 0 {
+                bitmap_size.width += DevicePixels(1);
+            }
+            if params.subpixel_variant.y > 0 {
+                bitmap_size.height += DevicePixels(1);
+            }
+            let bitmap_size = bitmap_size;
+
+            let mut bytes;
+            let cx;
+            if params.is_emoji {
+                bytes = vec![0; bitmap_size.width.0 as usize * 4 * bitmap_size.height.0 as usize];
+                cx = CGContext::create_bitmap_context(
+                    Some(bytes.as_mut_ptr() as *mut _),
+                    bitmap_size.width.0 as usize,
+                    bitmap_size.height.0 as usize,
+                    8,
+                    bitmap_size.width.0 as usize * 4,
+                    &CGColorSpace::create_device_rgb(),
+                    kCGImageAlphaPremultipliedLast,
+                );
+            } else {
+                bytes = vec![0; bitmap_size.width.0 as usize * bitmap_size.height.0 as usize];
+                cx = CGContext::create_bitmap_context(
+                    Some(bytes.as_mut_ptr() as *mut _),
+                    bitmap_size.width.0 as usize,
+                    bitmap_size.height.0 as usize,
+                    8,
+                    bitmap_size.width.0 as usize,
+                    &CGColorSpace::create_device_gray(),
+                    kCGImageAlphaOnly,
+                );
+            }
+
+            // Move the origin to bottom left and account for scaling, this
+            // makes drawing text consistent with the font-kit's raster_bounds.
+            cx.translate(
+                -glyph_bounds.origin.x.0 as CGFloat,
+                (glyph_bounds.origin.y.0 + glyph_bounds.size.height.0) as CGFloat,
+            );
+            cx.scale(
+                params.scale_factor as CGFloat,
+                params.scale_factor as CGFloat,
+            );
+
+            let subpixel_shift = params
+                .subpixel_variant
+                .map(|v| v as f32 / SUBPIXEL_VARIANTS_X as f32);
+            cx.set_text_drawing_mode(CGTextDrawingMode::CGTextFill);
+            cx.set_gray_fill_color(0.0, 1.0);
+            cx.set_allows_antialiasing(true);
+            cx.set_should_antialias(true);
+            cx.set_allows_font_subpixel_positioning(true);
+            cx.set_should_subpixel_position_fonts(true);
+            cx.set_allows_font_subpixel_quantization(false);
+            cx.set_should_subpixel_quantize_fonts(false);
+            self.fonts[params.font_id.0]
+                .native_font()
+                .clone_with_font_size(f32::from(params.font_size) as CGFloat)
+                .draw_glyphs(
+                    &[params.glyph_id.0 as CGGlyph],
+                    &[CGPoint::new(
+                        (subpixel_shift.x / params.scale_factor) as CGFloat,
+                        (subpixel_shift.y / params.scale_factor) as CGFloat,
+                    )],
+                    cx,
+                );
+
+            if params.is_emoji {
+                // Convert from RGBA with premultiplied alpha to BGRA with straight alpha.
+                for pixel in bytes.chunks_exact_mut(4) {
+                    swap_rgba_pa_to_bgra(pixel);
+                }
+            }
+
+            Ok((bitmap_size, bytes))
+        }
+    }
+
+    fn layout_line(&mut self, text: &str, font_size: Pixels, font_runs: &[FontRun]) -> LineLayout {
+        // Construct the attributed string, converting UTF8 ranges to UTF16 ranges.
+        let mut string = CFMutableAttributedString::new();
+        let mut max_ascent = 0.0f32;
+        let mut max_descent = 0.0f32;
+
+        {
+            let mut text = text;
+            let mut break_ligature = true;
+            for run in font_runs {
+                let text_run;
+                (text_run, text) = text.split_at(run.len);
+
+                let utf16_start = string.char_len(); // insert at end of string
+                // note: replace_str may silently ignore codepoints it dislikes (e.g., BOM at start of string)
+                string.replace_str(&CFString::new(text_run), CFRange::init(utf16_start, 0));
+                let utf16_end = string.char_len();
+
+                let length = utf16_end - utf16_start;
+                let cf_range = CFRange::init(utf16_start, length);
+                let font = &self.fonts[run.font_id.0];
+
+                let font_metrics = font.metrics();
+                let font_scale = font_size.0 / font_metrics.units_per_em as f32;
+                max_ascent = max_ascent.max(font_metrics.ascent * font_scale);
+                max_descent = max_descent.max(-font_metrics.descent * font_scale);
+
+                let font_size = if break_ligature {
+                    px(font_size.0.next_up())
+                } else {
+                    font_size
+                };
+                unsafe {
+                    string.set_attribute(
+                        cf_range,
+                        kCTFontAttributeName,
+                        &font.native_font().clone_with_font_size(font_size.into()),
+                    );
+                }
+                break_ligature = !break_ligature;
+            }
+        }
+        // Retrieve the glyphs from the shaped line, converting UTF16 offsets to UTF8 offsets.
+        let line = CTLine::new_with_attributed_string(string.as_concrete_TypeRef());
+        let glyph_runs = line.glyph_runs();
+        let mut runs = <Vec<ShapedRun>>::with_capacity(glyph_runs.len() as usize);
+        let mut ix_converter = StringIndexConverter::new(text);
+        for run in glyph_runs.into_iter() {
+            let attributes = run.attributes().unwrap();
+            let font = unsafe {
+                attributes
+                    .get(kCTFontAttributeName)
+                    .downcast::<CTFont>()
+                    .unwrap()
+            };
+            let font_id = self.id_for_native_font(font);
+
+            let glyphs = match runs.last_mut() {
+                Some(run) if run.font_id == font_id => &mut run.glyphs,
+                _ => {
+                    runs.push(ShapedRun {
+                        font_id,
+                        glyphs: Vec::with_capacity(run.glyph_count().try_into().unwrap_or(0)),
+                    });
+                    &mut runs.last_mut().unwrap().glyphs
+                }
+            };
+            for ((&glyph_id, position), &glyph_utf16_ix) in run
+                .glyphs()
+                .iter()
+                .zip(run.positions().iter())
+                .zip(run.string_indices().iter())
+            {
+                let glyph_utf16_ix = usize::try_from(glyph_utf16_ix).unwrap();
+                if ix_converter.utf16_ix > glyph_utf16_ix {
+                    // We cannot reuse current index converter, as it can only seek forward. Restart the search.
+                    ix_converter = StringIndexConverter::new(text);
+                }
+                ix_converter.advance_to_utf16_ix(glyph_utf16_ix);
+                glyphs.push(ShapedGlyph {
+                    id: GlyphId(glyph_id as u32),
+                    position: point(position.x as f32, position.y as f32).map(px),
+                    index: ix_converter.utf8_ix,
+                    is_emoji: self.is_emoji(font_id),
+                });
+            }
+        }
+        let typographic_bounds = line.get_typographic_bounds();
+        LineLayout {
+            runs,
+            font_size,
+            width: typographic_bounds.width.into(),
+            ascent: max_ascent.into(),
+            descent: max_descent.into(),
+            len: text.len(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct StringIndexConverter<'a> {
+    text: &'a str,
+    /// Index in UTF-8 bytes
+    utf8_ix: usize,
+    /// Index in UTF-16 code units
+    utf16_ix: usize,
+}
+
+impl<'a> StringIndexConverter<'a> {
+    fn new(text: &'a str) -> Self {
+        Self {
+            text,
+            utf8_ix: 0,
+            utf16_ix: 0,
+        }
+    }
+
+    fn advance_to_utf16_ix(&mut self, utf16_target: usize) {
+        for (ix, c) in self.text[self.utf8_ix..].char_indices() {
+            if self.utf16_ix >= utf16_target {
+                self.utf8_ix += ix;
+                return;
+            }
+            self.utf16_ix += c.len_utf16();
+        }
+        self.utf8_ix = self.text.len();
+    }
+}
+
+// Type conversions
+
+impl From<Metrics> for FontMetrics {
+    fn from(metrics: Metrics) -> Self {
+        FontMetrics {
+            units_per_em: metrics.units_per_em,
+            ascent: metrics.ascent,
+            descent: metrics.descent,
+            line_gap: metrics.line_gap,
+            underline_position: metrics.underline_position,
+            underline_thickness: metrics.underline_thickness,
+            cap_height: metrics.cap_height,
+            x_height: metrics.x_height,
+            bounding_box: metrics.bounding_box.into(),
+        }
+    }
+}
+
+impl From<RectF> for Bounds<f32> {
+    fn from(rect: RectF) -> Self {
+        Bounds {
+            origin: point(rect.origin_x(), rect.origin_y()),
+            size: size(rect.width(), rect.height()),
+        }
+    }
+}
+
+impl From<RectI> for Bounds<DevicePixels> {
+    fn from(rect: RectI) -> Self {
+        Bounds {
+            origin: point(DevicePixels(rect.origin_x()), DevicePixels(rect.origin_y())),
+            size: size(DevicePixels(rect.width()), DevicePixels(rect.height())),
+        }
+    }
+}
+
+impl From<Vector2I> for Size<DevicePixels> {
+    fn from(value: Vector2I) -> Self {
+        size(value.x().into(), value.y().into())
+    }
+}
+
+impl From<RectI> for Bounds<i32> {
+    fn from(rect: RectI) -> Self {
+        Bounds {
+            origin: point(rect.origin_x(), rect.origin_y()),
+            size: size(rect.width(), rect.height()),
+        }
+    }
+}
+
+impl From<Point<u32>> for Vector2I {
+    fn from(size: Point<u32>) -> Self {
+        Vector2I::new(size.x as i32, size.y as i32)
+    }
+}
+
+impl From<Vector2F> for Size<f32> {
+    fn from(vec: Vector2F) -> Self {
+        size(vec.x(), vec.y())
+    }
+}
+
+impl From<FontWeight> for FontkitWeight {
+    fn from(value: FontWeight) -> Self {
+        FontkitWeight(value.0)
+    }
+}
+
+impl From<FontStyle> for FontkitStyle {
+    fn from(style: FontStyle) -> Self {
+        match style {
+            FontStyle::Normal => FontkitStyle::Normal,
+            FontStyle::Italic => FontkitStyle::Italic,
+            FontStyle::Oblique => FontkitStyle::Oblique,
+        }
+    }
+}
+
+// OpenType feature application for iOS
+// This is adapted from the macOS open_type.rs module
+
+fn apply_features_and_fallbacks(
+    font: &mut FontKitFont,
+    features: &FontFeatures,
+    fallbacks: Option<&FontFallbacks>,
+) -> anyhow::Result<()> {
+    use core_foundation::{
+        array::{CFArrayAppendValue, CFArrayCreateMutable, CFArrayRef, kCFTypeArrayCallBacks},
+        base::{CFRelease, kCFAllocatorDefault},
+        dictionary::{
+            CFDictionaryCreate, kCFTypeDictionaryKeyCallBacks, kCFTypeDictionaryValueCallBacks,
+        },
+        string::CFStringRef,
+    };
+    use core_text::font_descriptor::{
+        CTFontDescriptor, CTFontDescriptorCreateWithAttributes,
+        CTFontDescriptorCreateWithNameAndSize, CTFontDescriptorRef, kCTFontCascadeListAttribute,
+        kCTFontFeatureSettingsAttribute,
+    };
+
+    #[link(name = "CoreText", kind = "framework")]
+    unsafe extern "C" {
+        static kCTFontOpenTypeFeatureTag: CFStringRef;
+        static kCTFontOpenTypeFeatureValue: CFStringRef;
+
+        fn CTFontCreateCopyWithAttributes(
+            font: core_text::font::CTFontRef,
+            size: CGFloat,
+            matrix: *const core_graphics::geometry::CGAffineTransform,
+            attributes: CTFontDescriptorRef,
+        ) -> core_text::font::CTFontRef;
+        fn CTFontCopyDefaultCascadeListForLanguages(
+            font: core_text::font::CTFontRef,
+            languagePrefList: CFArrayRef,
+        ) -> CFArrayRef;
+    }
+
+    unsafe {
+        // Generate feature array
+        let feature_array = CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+        for (tag, value) in features.tag_value_list() {
+            let keys = [kCTFontOpenTypeFeatureTag, kCTFontOpenTypeFeatureValue];
+            let values = [
+                CFString::new(tag).as_CFTypeRef(),
+                CFNumber::from(*value as i32).as_CFTypeRef(),
+            ];
+            let dict = CFDictionaryCreate(
+                kCFAllocatorDefault,
+                &keys as *const _ as _,
+                &values as *const _ as _,
+                2,
+                &kCFTypeDictionaryKeyCallBacks,
+                &kCFTypeDictionaryValueCallBacks,
+            );
+            values.into_iter().for_each(|value| CFRelease(value));
+            CFArrayAppendValue(feature_array, dict as _);
+            CFRelease(dict as _);
+        }
+
+        let mut keys = vec![kCTFontFeatureSettingsAttribute];
+        let mut values = vec![feature_array as *const _];
+
+        // Generate fallback array if needed
+        if let Some(fallbacks) = fallbacks {
+            if !fallbacks.fallback_list().is_empty() {
+                let fallback_array =
+                    CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+                for user_fallback in fallbacks.fallback_list() {
+                    let name = CFString::from(user_fallback.as_str());
+                    let fallback_desc =
+                        CTFontDescriptorCreateWithNameAndSize(name.as_concrete_TypeRef(), 0.0);
+                    CFArrayAppendValue(fallback_array, fallback_desc as _);
+                    CFRelease(fallback_desc as _);
+                }
+                // Append system fallbacks
+                let preferred_languages: core_foundation::array::CFArray<CFString> =
+                    core_foundation::array::CFArray::wrap_under_create_rule(
+                        core_foundation_sys::locale::CFLocaleCopyPreferredLanguages(),
+                    );
+                let default_fallbacks = CTFontCopyDefaultCascadeListForLanguages(
+                    font.native_font().as_concrete_TypeRef(),
+                    preferred_languages.as_concrete_TypeRef(),
+                );
+                let default_fallbacks: core_foundation::array::CFArray<CTFontDescriptor> =
+                    core_foundation::array::CFArray::wrap_under_create_rule(default_fallbacks);
+                for desc in default_fallbacks.iter() {
+                    if desc.font_path().is_some() {
+                        CFArrayAppendValue(fallback_array, desc.as_concrete_TypeRef() as _);
+                    }
+                }
+
+                keys.push(kCTFontCascadeListAttribute);
+                values.push(fallback_array as *const _);
+            }
+        }
+
+        let attrs = CFDictionaryCreate(
+            kCFAllocatorDefault,
+            keys.as_ptr() as _,
+            values.as_ptr() as _,
+            keys.len() as isize,
+            &kCFTypeDictionaryKeyCallBacks,
+            &kCFTypeDictionaryValueCallBacks,
+        );
+        let new_descriptor = CTFontDescriptorCreateWithAttributes(attrs);
+        CFRelease(attrs as _);
+        let new_descriptor = CTFontDescriptor::wrap_under_create_rule(new_descriptor);
+        let new_font = CTFontCreateCopyWithAttributes(
+            font.native_font().as_concrete_TypeRef(),
+            0.0,
+            std::ptr::null(),
+            new_descriptor.as_concrete_TypeRef(),
+        );
+        let new_font = CTFont::wrap_under_create_rule(new_font);
+        *font = font_kit::font::Font::from_native_font(&new_font);
+
+        Ok(())
+    }
+}
+
+// Font attribute helpers that handle missing attributes gracefully
+mod lenient_font_attributes {
+    use core_foundation::{
+        base::{CFRetain, CFType, TCFType},
+        string::{CFString, CFStringRef},
+    };
+    use core_text::font_descriptor::{
+        CTFontDescriptor, CTFontDescriptorCopyAttribute, kCTFontFamilyNameAttribute,
+    };
+
+    pub fn family_name(descriptor: &CTFontDescriptor) -> Option<String> {
+        unsafe { get_string_attribute(descriptor, kCTFontFamilyNameAttribute) }
+    }
+
+    fn get_string_attribute(
+        descriptor: &CTFontDescriptor,
+        attribute: CFStringRef,
+    ) -> Option<String> {
+        unsafe {
+            let value = CTFontDescriptorCopyAttribute(descriptor.as_concrete_TypeRef(), attribute);
+            if value.is_null() {
+                return None;
+            }
+
+            let value = CFType::wrap_under_create_rule(value);
+            assert!(value.instance_of::<CFString>());
+            let s = wrap_under_get_rule(value.as_CFTypeRef() as CFStringRef);
+            Some(s.to_string())
+        }
+    }
+
+    unsafe fn wrap_under_get_rule(reference: CFStringRef) -> CFString {
+        unsafe {
+            assert!(!reference.is_null(), "Attempted to create a NULL object.");
+            let reference = CFRetain(reference as *const ::std::os::raw::c_void) as CFStringRef;
+            TCFType::wrap_under_create_rule(reference)
+        }
+    }
+}

--- a/crates/gpui/src/platform/ios/window.rs
+++ b/crates/gpui/src/platform/ios/window.rs
@@ -1,0 +1,747 @@
+//! iOS Window implementation using UIWindow and UIViewController.
+//!
+//! iOS windows are fundamentally different from desktop windows:
+//! - Always fullscreen (or split-screen on iPad)
+//! - No title bar or window chrome
+//! - Touch-based input
+//! - Safe area insets for notch/home indicator
+//!
+//! The window is backed by a UIWindow containing a UIViewController
+//! whose view hosts the Metal rendering layer.
+
+use super::{IosDisplay, events::*};
+use crate::platform::blade;
+use crate::{
+    AnyWindowHandle, Bounds, DispatchEventResult, GpuSpecs, Modifiers, Pixels, PlatformAtlas,
+    PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PromptButton,
+    PromptLevel, RequestFrameOptions, Scene, Size, WindowAppearance, WindowBackgroundAppearance,
+    WindowBounds, WindowControlArea, WindowParams,
+};
+use anyhow::{Result, anyhow};
+use core_graphics::{
+    base::CGFloat,
+    geometry::{CGPoint, CGRect, CGSize},
+};
+use objc::{
+    class,
+    declare::ClassDecl,
+    msg_send,
+    runtime::{BOOL, Class, NO, Object, Sel, YES},
+    sel, sel_impl,
+};
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle, UiKitDisplayHandle, UiKitWindowHandle};
+use std::{
+    cell::{Cell, RefCell},
+    ffi::c_void,
+    ptr::{self, NonNull},
+    rc::Rc,
+    sync::Arc,
+};
+
+const GPUI_VIEW_IVAR: &str = "gpui_view";
+const GPUI_WINDOW_IVAR: &str = "gpui_window_ptr";
+
+static METAL_VIEW_CLASS_REGISTERED: std::sync::Once = std::sync::Once::new();
+
+/// Register a custom UIView subclass that uses CAMetalLayer as its backing layer.
+/// This is required for Metal rendering on iOS.
+fn register_metal_view_class() -> &'static Class {
+    METAL_VIEW_CLASS_REGISTERED.call_once(|| {
+        let superclass = class!(UIView);
+        let mut decl = ClassDecl::new("GPUIMetalView", superclass).unwrap();
+
+        // Add ivar to store window pointer for touch handling
+        decl.add_ivar::<*mut std::ffi::c_void>(GPUI_WINDOW_IVAR);
+
+        // Override layerClass to return CAMetalLayer
+        extern "C" fn layer_class(_self: &Class, _sel: Sel) -> *const Class {
+            class!(CAMetalLayer) as *const Class
+        }
+
+        // Touch handling methods
+        extern "C" fn touches_began(
+            this: &mut Object,
+            _sel: Sel,
+            touches: *mut Object,
+            event: *mut Object,
+        ) {
+            handle_touches(this, touches, event);
+        }
+
+        extern "C" fn touches_moved(
+            this: &mut Object,
+            _sel: Sel,
+            touches: *mut Object,
+            event: *mut Object,
+        ) {
+            handle_touches(this, touches, event);
+        }
+
+        extern "C" fn touches_ended(
+            this: &mut Object,
+            _sel: Sel,
+            touches: *mut Object,
+            event: *mut Object,
+        ) {
+            handle_touches(this, touches, event);
+        }
+
+        extern "C" fn touches_cancelled(
+            this: &mut Object,
+            _sel: Sel,
+            touches: *mut Object,
+            event: *mut Object,
+        ) {
+            handle_touches(this, touches, event);
+        }
+
+        unsafe {
+            // Add class method for layerClass
+            decl.add_class_method(
+                sel!(layerClass),
+                layer_class as extern "C" fn(&Class, Sel) -> *const Class,
+            );
+
+            // Add touch handling instance methods
+            decl.add_method(
+                sel!(touchesBegan:withEvent:),
+                touches_began as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object),
+            );
+            decl.add_method(
+                sel!(touchesMoved:withEvent:),
+                touches_moved as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object),
+            );
+            decl.add_method(
+                sel!(touchesEnded:withEvent:),
+                touches_ended as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object),
+            );
+            decl.add_method(
+                sel!(touchesCancelled:withEvent:),
+                touches_cancelled as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object),
+            );
+        }
+
+        decl.register();
+    });
+
+    class!(GPUIMetalView)
+}
+
+/// Handle touch events from the GPUIMetalView
+fn handle_touches(view: &mut Object, touches: *mut Object, event: *mut Object) {
+    unsafe {
+        // Get the window pointer from the view's ivar
+        let window_ptr: *mut std::ffi::c_void = *view.get_ivar(GPUI_WINDOW_IVAR);
+        if window_ptr.is_null() {
+            log::warn!("GPUI iOS: Touch event but no window pointer set");
+            return;
+        }
+
+        let window = &*(window_ptr as *const IosWindow);
+
+        // Get all touches from the set
+        let all_touches: *mut Object = msg_send![touches, allObjects];
+        let count: usize = msg_send![all_touches, count];
+
+        for i in 0..count {
+            let touch: *mut Object = msg_send![all_touches, objectAtIndex: i];
+            window.handle_touch(touch, event);
+        }
+    }
+}
+
+/// iOS Window backed by UIWindow + UIViewController.
+pub(crate) struct IosWindow {
+    /// Handle used by GPUI to identify this window
+    handle: AnyWindowHandle,
+    /// The UIWindow object
+    window: *mut Object,
+    /// The UIViewController
+    view_controller: *mut Object,
+    /// The Metal-backed UIView
+    view: *mut Object,
+    /// The hidden text input view for keyboard input
+    text_input_view: *mut Object,
+    /// Current bounds in pixels
+    bounds: Cell<Bounds<Pixels>>,
+    /// Scale factor
+    scale_factor: Cell<f32>,
+    /// Appearance (light/dark mode)
+    appearance: Cell<WindowAppearance>,
+    /// Input handler for text input
+    input_handler: RefCell<Option<PlatformInputHandler>>,
+    /// Callback for frame requests
+    /// Note: pub(super) to allow ffi.rs to access this for the display link callback
+    pub(super) request_frame_callback: RefCell<Option<Box<dyn FnMut(RequestFrameOptions)>>>,
+    /// Callback for input events
+    input_callback: RefCell<Option<Box<dyn FnMut(PlatformInput) -> DispatchEventResult>>>,
+    /// Callback for active status changes
+    active_status_callback: RefCell<Option<Box<dyn FnMut(bool)>>>,
+    /// Callback for hover status changes (not really applicable on iOS)
+    hover_status_callback: RefCell<Option<Box<dyn FnMut(bool)>>>,
+    /// Callback for resize events
+    resize_callback: RefCell<Option<Box<dyn FnMut(Size<Pixels>, f32)>>>,
+    /// Callback for move events (not applicable on iOS)
+    moved_callback: RefCell<Option<Box<dyn FnMut()>>>,
+    /// Callback for should close
+    should_close_callback: RefCell<Option<Box<dyn FnMut() -> bool>>>,
+    /// Callback for hit test
+    hit_test_callback: RefCell<Option<Box<dyn FnMut() -> Option<WindowControlArea>>>>,
+    /// Callback for close
+    close_callback: RefCell<Option<Box<dyn FnOnce()>>>,
+    /// Callback for appearance changes
+    appearance_changed_callback: RefCell<Option<Box<dyn FnMut()>>>,
+    /// Current mouse position (from touch)
+    mouse_position: Cell<Point<Pixels>>,
+    /// Current modifiers
+    modifiers: Cell<Modifiers>,
+    /// Blade renderer for GPU rendering
+    renderer: RefCell<blade::Renderer>,
+    /// Track if a touch is currently pressed
+    touch_pressed: Cell<bool>,
+}
+
+// Required for raw_window_handle
+unsafe impl Send for IosWindow {}
+unsafe impl Sync for IosWindow {}
+
+impl IosWindow {
+    pub fn new(
+        handle: AnyWindowHandle,
+        _params: WindowParams,
+        renderer_context: blade::Context,
+    ) -> Result<Self> {
+        // Create the window on the main screen
+        let screen = IosDisplay::main();
+        let screen_bounds = screen.bounds();
+        let scale_factor = screen.scale();
+
+        unsafe {
+            // Create UIWindow
+            let screen_obj: *mut Object = msg_send![class!(UIScreen), mainScreen];
+            let screen_bounds_cg: CGRect = msg_send![screen_obj, bounds];
+            let window: *mut Object = msg_send![class!(UIWindow), alloc];
+            let window: *mut Object = msg_send![window, initWithFrame: screen_bounds_cg];
+
+            // Create UIViewController
+            let view_controller: *mut Object = msg_send![class!(UIViewController), alloc];
+            let view_controller: *mut Object = msg_send![view_controller, init];
+
+            // Create our custom Metal view using the registered class
+            let metal_view_class = register_metal_view_class();
+            let view: *mut Object = msg_send![metal_view_class, alloc];
+            let view: *mut Object = msg_send![view, initWithFrame: screen_bounds_cg];
+
+            // Configure the Metal layer
+            let layer: *mut Object = msg_send![view, layer];
+
+            // Get the Metal device using the Metal framework function
+            #[link(name = "Metal", kind = "framework")]
+            unsafe extern "C" {
+                fn MTLCreateSystemDefaultDevice() -> *mut Object;
+            }
+            let device = MTLCreateSystemDefaultDevice();
+            if !device.is_null() {
+                let _: () = msg_send![layer, setDevice: device];
+            }
+            let _: () = msg_send![layer, setPixelFormat: 80_u64]; // MTLPixelFormatBGRA8Unorm
+            let _: () = msg_send![layer, setFramebufferOnly: NO];
+            let scale: CGFloat = msg_send![screen_obj, scale];
+            let _: () = msg_send![layer, setContentsScale: scale];
+            let drawable_size = CGSize {
+                width: screen_bounds_cg.size.width * scale,
+                height: screen_bounds_cg.size.height * scale,
+            };
+            let _: () = msg_send![layer, setDrawableSize: drawable_size];
+
+            // Enable user interaction on the Metal view for touch handling
+            let _: () = msg_send![view, setUserInteractionEnabled: YES];
+            let _: () = msg_send![view, setMultipleTouchEnabled: YES];
+
+            // Set the view as the view controller's view
+            let _: () = msg_send![view_controller, setView: view];
+
+            // Set the root view controller
+            let _: () = msg_send![window, setRootViewController: view_controller];
+
+            // Make the window visible
+            let _: () = msg_send![window, makeKeyAndVisible];
+
+            // Create a hidden text input view for keyboard handling
+            // This view conforms to UIKeyInput and handles keyboard events
+            let text_input_view: *mut Object = msg_send![class!(UIView), alloc];
+            let text_input_frame = CGRect {
+                origin: CGPoint { x: 0.0, y: 0.0 },
+                size: CGSize {
+                    width: 1.0,
+                    height: 1.0,
+                },
+            };
+            let text_input_view: *mut Object =
+                msg_send![text_input_view, initWithFrame: text_input_frame];
+            // Make it invisible but still able to become first responder
+            let _: () = msg_send![text_input_view, setAlpha: 0.01_f64];
+            let _: () = msg_send![text_input_view, setUserInteractionEnabled: YES];
+            let _: () = msg_send![view, addSubview: text_input_view];
+
+            // Create the blade renderer
+            // Note: Blade expects size in pixels (device pixels), not points
+            let renderer = blade::new_renderer(
+                renderer_context,
+                window as *mut c_void,
+                view as *mut c_void,
+                crate::Size {
+                    width: drawable_size.width as f32,
+                    height: drawable_size.height as f32,
+                },
+                false, // not transparent
+            );
+
+            let ios_window = Self {
+                handle,
+                window,
+                view_controller,
+                view,
+                text_input_view,
+                bounds: Cell::new(screen_bounds),
+                scale_factor: Cell::new(scale_factor),
+                appearance: Cell::new(WindowAppearance::Light),
+                input_handler: RefCell::new(None),
+                request_frame_callback: RefCell::new(None),
+                input_callback: RefCell::new(None),
+                active_status_callback: RefCell::new(None),
+                hover_status_callback: RefCell::new(None),
+                resize_callback: RefCell::new(None),
+                moved_callback: RefCell::new(None),
+                should_close_callback: RefCell::new(None),
+                hit_test_callback: RefCell::new(None),
+                close_callback: RefCell::new(None),
+                appearance_changed_callback: RefCell::new(None),
+                mouse_position: Cell::new(Point::default()),
+                modifiers: Cell::new(Modifiers::default()),
+                renderer: RefCell::new(renderer),
+                touch_pressed: Cell::new(false),
+            };
+
+            Ok(ios_window)
+        }
+    }
+
+    /// Register this window with the FFI layer after it's been stored.
+    /// This must be called after the window is placed at a stable address
+    /// (e.g., in a Box or Arc).
+    pub(crate) fn register_with_ffi(&self) {
+        super::ffi::register_window(self as *const Self);
+
+        // Set the window pointer on the view so touch events can find us
+        unsafe {
+            let window_ptr = self as *const Self as *mut std::ffi::c_void;
+            (*self.view).set_ivar(GPUI_WINDOW_IVAR, window_ptr);
+            log::info!(
+                "GPUI iOS: Set window pointer {:p} on view {:p}",
+                window_ptr,
+                self.view
+            );
+        }
+    }
+
+    /// Handle a touch event from UIKit
+    pub fn handle_touch(&self, touch: *mut Object, _event: *mut Object) {
+        let position = touch_location_in_view(touch, self.view);
+        let phase = touch_phase(touch);
+        let tap_count = touch_tap_count(touch);
+        let modifiers = self.modifiers.get();
+
+        self.mouse_position.set(position);
+
+        let platform_input = match phase {
+            UITouchPhase::Began => {
+                self.touch_pressed.set(true);
+                touch_began_to_mouse_down(position, tap_count, modifiers)
+            }
+            UITouchPhase::Moved => {
+                touch_moved_to_mouse_move(position, modifiers, Some(crate::MouseButton::Left))
+            }
+            UITouchPhase::Ended | UITouchPhase::Cancelled => {
+                self.touch_pressed.set(false);
+                touch_ended_to_mouse_up(position, tap_count, modifiers)
+            }
+            UITouchPhase::Stationary => return,
+        };
+
+        if let Some(callback) = self.input_callback.borrow_mut().as_mut() {
+            callback(platform_input);
+        }
+    }
+
+    /// Get the safe area insets
+    pub fn safe_area_insets(&self) -> (f32, f32, f32, f32) {
+        unsafe {
+            // UIEdgeInsets struct
+            #[repr(C)]
+            struct UIEdgeInsets {
+                top: f64,
+                left: f64,
+                bottom: f64,
+                right: f64,
+            }
+
+            let insets: UIEdgeInsets = msg_send![self.view, safeAreaInsets];
+            (
+                insets.top as f32,
+                insets.left as f32,
+                insets.bottom as f32,
+                insets.right as f32,
+            )
+        }
+    }
+
+    /// Show the software keyboard
+    pub fn show_keyboard(&self) {
+        log::info!("GPUI iOS: Showing keyboard");
+        unsafe {
+            // Make the text input view become first responder to show keyboard
+            let _: BOOL = msg_send![self.text_input_view, becomeFirstResponder];
+        }
+    }
+
+    /// Hide the software keyboard
+    pub fn hide_keyboard(&self) {
+        log::info!("GPUI iOS: Hiding keyboard");
+        unsafe {
+            // Resign first responder to hide keyboard
+            let _: BOOL = msg_send![self.text_input_view, resignFirstResponder];
+        }
+    }
+
+    /// Handle text input from the software keyboard
+    pub fn handle_text_input(&self, text: *mut Object) {
+        if text.is_null() {
+            return;
+        }
+
+        unsafe {
+            // Convert NSString to Rust String
+            let utf8: *const i8 = msg_send![text, UTF8String];
+            if utf8.is_null() {
+                return;
+            }
+
+            let text_str = std::ffi::CStr::from_ptr(utf8)
+                .to_string_lossy()
+                .into_owned();
+
+            log::info!("GPUI iOS: Text input: {:?}", text_str);
+
+            // First try the input handler (for text fields)
+            if let Some(handler) = self.input_handler.borrow_mut().as_mut() {
+                handler.replace_text_in_range(None, &text_str);
+                return;
+            }
+
+            // Otherwise, send as key events
+            for c in text_str.chars() {
+                let keystroke = crate::Keystroke {
+                    modifiers: Modifiers::default(),
+                    key: c.to_string(),
+                    key_char: Some(c.to_string()),
+                };
+
+                let event = PlatformInput::KeyDown(crate::KeyDownEvent {
+                    keystroke,
+                    is_held: false,
+                    prefer_character_input: true,
+                });
+
+                if let Some(callback) = self.input_callback.borrow_mut().as_mut() {
+                    callback(event);
+                }
+            }
+        }
+    }
+
+    /// Handle a key event from an external keyboard
+    pub fn handle_key_event(&self, key_code: u32, modifier_flags: u32, is_key_down: bool) {
+        use super::text_input::{
+            key_code_to_key_down, key_code_to_key_up, key_code_to_string,
+            modifier_flags_to_modifiers,
+        };
+
+        let key = key_code_to_string(key_code);
+        let modifiers = modifier_flags_to_modifiers(modifier_flags);
+
+        log::info!(
+            "GPUI iOS: Key event - key: {:?}, modifiers: {:?}, down: {}",
+            key,
+            modifiers,
+            is_key_down
+        );
+
+        let event = if is_key_down {
+            key_code_to_key_down(key_code, modifier_flags)
+        } else {
+            key_code_to_key_up(key_code, modifier_flags)
+        };
+
+        if let Some(callback) = self.input_callback.borrow_mut().as_mut() {
+            callback(event);
+        }
+    }
+
+    /// Notify the window of active status changes (foreground/background).
+    ///
+    /// This is called by the FFI layer when the app transitions between
+    /// foreground and background states.
+    pub fn notify_active_status_change(&self, is_active: bool) {
+        log::info!("GPUI iOS: Window active status changed to: {}", is_active);
+
+        if let Some(callback) = self.active_status_callback.borrow_mut().as_mut() {
+            callback(is_active);
+        }
+    }
+}
+
+impl HasWindowHandle for IosWindow {
+    fn window_handle(
+        &self,
+    ) -> std::result::Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError>
+    {
+        let view = NonNull::new(self.view as *mut c_void)
+            .ok_or(raw_window_handle::HandleError::Unavailable)?;
+        let handle = UiKitWindowHandle::new(view);
+        Ok(unsafe { raw_window_handle::WindowHandle::borrow_raw(handle.into()) })
+    }
+}
+
+impl HasDisplayHandle for IosWindow {
+    fn display_handle(
+        &self,
+    ) -> std::result::Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError>
+    {
+        let handle = UiKitDisplayHandle::new();
+        Ok(unsafe { raw_window_handle::DisplayHandle::borrow_raw(handle.into()) })
+    }
+}
+
+impl PlatformWindow for IosWindow {
+    fn bounds(&self) -> Bounds<Pixels> {
+        self.bounds.get()
+    }
+
+    fn is_maximized(&self) -> bool {
+        true // iOS windows are always "maximized"
+    }
+
+    fn window_bounds(&self) -> WindowBounds {
+        WindowBounds::Fullscreen(self.bounds.get())
+    }
+
+    fn content_size(&self) -> Size<Pixels> {
+        self.bounds.get().size
+    }
+
+    fn resize(&mut self, _size: Size<Pixels>) {
+        // iOS windows cannot be resized programmatically
+    }
+
+    fn scale_factor(&self) -> f32 {
+        self.scale_factor.get()
+    }
+
+    fn appearance(&self) -> WindowAppearance {
+        unsafe {
+            let trait_collection: *mut Object = msg_send![self.view, traitCollection];
+            let style: i64 = msg_send![trait_collection, userInterfaceStyle];
+            match style {
+                2 => WindowAppearance::Dark,
+                _ => WindowAppearance::Light,
+            }
+        }
+    }
+
+    fn display(&self) -> Option<Rc<dyn PlatformDisplay>> {
+        Some(Rc::new(IosDisplay::main()))
+    }
+
+    fn mouse_position(&self) -> Point<Pixels> {
+        self.mouse_position.get()
+    }
+
+    fn modifiers(&self) -> Modifiers {
+        self.modifiers.get()
+    }
+
+    fn capslock(&self) -> crate::Capslock {
+        // Would need to check UIKeyModifierFlags
+        crate::Capslock { on: false }
+    }
+
+    fn set_input_handler(&mut self, input_handler: PlatformInputHandler) {
+        *self.input_handler.borrow_mut() = Some(input_handler);
+    }
+
+    fn take_input_handler(&mut self) -> Option<PlatformInputHandler> {
+        self.input_handler.borrow_mut().take()
+    }
+
+    fn prompt(
+        &self,
+        _level: PromptLevel,
+        msg: &str,
+        detail: Option<&str>,
+        answers: &[PromptButton],
+    ) -> Option<futures::channel::oneshot::Receiver<usize>> {
+        // Would use UIAlertController
+        let (_tx, rx) = futures::channel::oneshot::channel();
+
+        unsafe {
+            // Create UIAlertController
+            let title = msg;
+            let message = detail.unwrap_or("");
+
+            let alert_style: i64 = 1; // UIAlertControllerStyleAlert
+
+            let title_str: *mut Object =
+                msg_send![class!(NSString), stringWithUTF8String: title.as_ptr()];
+            let message_str: *mut Object =
+                msg_send![class!(NSString), stringWithUTF8String: message.as_ptr()];
+
+            let alert: *mut Object = msg_send![
+                class!(UIAlertController),
+                alertControllerWithTitle: title_str
+                message: message_str
+                preferredStyle: alert_style
+            ];
+
+            // Add buttons
+            for (_index, button) in answers.iter().enumerate() {
+                let button_title: *mut Object = msg_send![
+                    class!(NSString),
+                    stringWithUTF8String: button.label().as_str().as_ptr()
+                ];
+
+                let action_style: i64 = if button.is_cancel() { 1 } else { 0 }; // UIAlertActionStyleCancel or Default
+
+                // Note: In production, this would need a block that calls tx.send(index)
+                let action: *mut Object = msg_send![
+                    class!(UIAlertAction),
+                    actionWithTitle: button_title
+                    style: action_style
+                    handler: ptr::null::<Object>()
+                ];
+
+                let _: () = msg_send![alert, addAction: action];
+            }
+
+            // Present the alert
+            let _: () = msg_send![
+                self.view_controller,
+                presentViewController: alert
+                animated: YES
+                completion: ptr::null::<Object>()
+            ];
+        }
+
+        Some(rx)
+    }
+
+    fn activate(&self) {
+        unsafe {
+            let _: () = msg_send![self.window, makeKeyAndVisible];
+        }
+    }
+
+    fn is_active(&self) -> bool {
+        unsafe {
+            let app: *mut Object = msg_send![class!(UIApplication), sharedApplication];
+            let key_window: *mut Object = msg_send![app, keyWindow];
+            self.window == key_window
+        }
+    }
+
+    fn is_hovered(&self) -> bool {
+        // Hover isn't really applicable on iOS
+        false
+    }
+
+    fn set_title(&mut self, _title: &str) {
+        // iOS apps don't have window titles
+    }
+
+    fn set_background_appearance(&self, _background_appearance: WindowBackgroundAppearance) {
+        // Could adjust view background color
+    }
+
+    fn minimize(&self) {
+        // iOS apps cannot be minimized
+    }
+
+    fn zoom(&self) {
+        // iOS apps cannot be zoomed
+    }
+
+    fn toggle_fullscreen(&self) {
+        // iOS apps are always fullscreen
+    }
+
+    fn is_fullscreen(&self) -> bool {
+        true
+    }
+
+    fn on_request_frame(&self, callback: Box<dyn FnMut(RequestFrameOptions)>) {
+        *self.request_frame_callback.borrow_mut() = Some(callback);
+    }
+
+    fn on_input(&self, callback: Box<dyn FnMut(PlatformInput) -> DispatchEventResult>) {
+        *self.input_callback.borrow_mut() = Some(callback);
+    }
+
+    fn on_active_status_change(&self, callback: Box<dyn FnMut(bool)>) {
+        *self.active_status_callback.borrow_mut() = Some(callback);
+    }
+
+    fn on_hover_status_change(&self, callback: Box<dyn FnMut(bool)>) {
+        *self.hover_status_callback.borrow_mut() = Some(callback);
+    }
+
+    fn on_resize(&self, callback: Box<dyn FnMut(Size<Pixels>, f32)>) {
+        *self.resize_callback.borrow_mut() = Some(callback);
+    }
+
+    fn on_moved(&self, callback: Box<dyn FnMut()>) {
+        *self.moved_callback.borrow_mut() = Some(callback);
+    }
+
+    fn on_should_close(&self, callback: Box<dyn FnMut() -> bool>) {
+        *self.should_close_callback.borrow_mut() = Some(callback);
+    }
+
+    fn on_hit_test_window_control(&self, callback: Box<dyn FnMut() -> Option<WindowControlArea>>) {
+        *self.hit_test_callback.borrow_mut() = Some(callback);
+    }
+
+    fn on_close(&self, callback: Box<dyn FnOnce()>) {
+        *self.close_callback.borrow_mut() = Some(callback);
+    }
+
+    fn on_appearance_changed(&self, callback: Box<dyn FnMut()>) {
+        *self.appearance_changed_callback.borrow_mut() = Some(callback);
+    }
+
+    fn draw(&self, scene: &Scene) {
+        self.renderer.borrow_mut().draw(scene);
+    }
+
+    fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {
+        self.renderer.borrow().sprite_atlas().clone()
+    }
+
+    fn gpu_specs(&self) -> Option<GpuSpecs> {
+        // Would query Metal device capabilities
+        None
+    }
+
+    fn update_ime_position(&self, _bounds: Bounds<Pixels>) {
+        // iOS handles IME positioning automatically
+    }
+}

--- a/crates/gpui/src/platform/ios/window.rs
+++ b/crates/gpui/src/platform/ios/window.rs
@@ -9,15 +9,15 @@
 //! The window is backed by a UIWindow containing a UIViewController
 //! whose view hosts the Metal rendering layer.
 
-use super::{IosDisplay, events::*};
+use super::{IosDisplay, events::*, text_input, text_input::{create_text_position, create_text_range, get_position_index, get_range_indices}};
 use crate::platform::blade;
 use crate::{
     AnyWindowHandle, Bounds, DispatchEventResult, GpuSpecs, Modifiers, Pixels, PlatformAtlas,
     PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PromptButton,
     PromptLevel, RequestFrameOptions, Scene, Size, WindowAppearance, WindowBackgroundAppearance,
-    WindowBounds, WindowControlArea, WindowParams,
+    WindowBounds, WindowControlArea, WindowParams, px,
 };
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use core_graphics::{
     base::CGFloat,
     geometry::{CGPoint, CGRect, CGSize},
@@ -25,7 +25,7 @@ use core_graphics::{
 use objc::{
     class,
     declare::ClassDecl,
-    msg_send,
+    msg_send, Encode, Encoding,
     runtime::{BOOL, Class, NO, Object, Sel, YES},
     sel, sel_impl,
 };
@@ -33,6 +33,7 @@ use raw_window_handle::{HasDisplayHandle, HasWindowHandle, UiKitDisplayHandle, U
 use std::{
     cell::{Cell, RefCell},
     ffi::c_void,
+    panic::{self, AssertUnwindSafe},
     ptr::{self, NonNull},
     rc::Rc,
     sync::Arc,
@@ -41,7 +42,191 @@ use std::{
 const GPUI_VIEW_IVAR: &str = "gpui_view";
 const GPUI_WINDOW_IVAR: &str = "gpui_window_ptr";
 
+/// NSRange structure for Objective-C interop
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct NSRange {
+    location: u64,
+    length: u64,
+}
+
+// Implement Encode for NSRange to allow it to be used in Objective-C method signatures
+unsafe impl Encode for NSRange {
+    fn encode() -> Encoding {
+        // NSRange is a struct with two unsigned longs: {_NSRange=QQ}
+        unsafe { Encoding::from_str("{_NSRange=QQ}") }
+    }
+}
+
+/// Our own CGRect struct for use in Objective-C method signatures (implements Encode)
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct IOSCGRect {
+    origin: IOSCGPoint,
+    size: IOSCGSize,
+}
+
+impl IOSCGRect {
+    fn new(origin: IOSCGPoint, size: IOSCGSize) -> Self {
+        Self { origin, size }
+    }
+}
+
+unsafe impl Encode for IOSCGRect {
+    fn encode() -> Encoding {
+        // CGRect is a struct with origin (CGPoint) and size (CGSize): {CGRect={CGPoint=dd}{CGSize=dd}}
+        unsafe { Encoding::from_str("{CGRect={CGPoint=dd}{CGSize=dd}}") }
+    }
+}
+
+/// Our own CGPoint struct for use in Objective-C method signatures (implements Encode)
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct IOSCGPoint {
+    x: f64,
+    y: f64,
+}
+
+impl IOSCGPoint {
+    fn new(x: f64, y: f64) -> Self {
+        Self { x, y }
+    }
+}
+
+unsafe impl Encode for IOSCGPoint {
+    fn encode() -> Encoding {
+        // CGPoint is a struct with x and y doubles: {CGPoint=dd}
+        unsafe { Encoding::from_str("{CGPoint=dd}") }
+    }
+}
+
+/// Our own CGSize struct for use in Objective-C method signatures (implements Encode)
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct IOSCGSize {
+    width: f64,
+    height: f64,
+}
+
+impl IOSCGSize {
+    fn new(width: f64, height: f64) -> Self {
+        Self { width, height }
+    }
+}
+
+unsafe impl Encode for IOSCGSize {
+    fn encode() -> Encoding {
+        // CGSize is a struct with width and height doubles: {CGSize=dd}
+        unsafe { Encoding::from_str("{CGSize=dd}") }
+    }
+}
+
+/// NSNotFound constant (max value indicates "not found")
+const NS_NOT_FOUND: u64 = u64::MAX;
+
 static METAL_VIEW_CLASS_REGISTERED: std::sync::Once = std::sync::Once::new();
+
+// Declare NSLog extern once at module level
+unsafe extern "C" {
+    fn NSLog(format: *mut Object, ...);
+}
+
+/// Helper to log to iOS system log via NSLog.
+/// This ensures messages show up in `xcrun simctl spawn ... log stream`.
+#[allow(unused)]
+fn ios_log(message: &str) {
+    unsafe {
+        // Create NSString from our message
+        let ns_string: *mut Object = msg_send![class!(NSString), alloc];
+        let format: *mut Object = msg_send![ns_string, initWithUTF8String: message.as_ptr() as *const std::os::raw::c_char];
+
+        NSLog(format);
+
+        // Release the string
+        let _: () = msg_send![format, release];
+    }
+}
+
+/// Helper to log to iOS system log with a C string literal.
+/// This is simpler and doesn't require allocation.
+fn ios_log_cstr(message: &std::ffi::CStr) {
+    unsafe {
+        let ns_string: *mut Object = msg_send![class!(NSString), stringWithUTF8String: message.as_ptr()];
+        NSLog(ns_string);
+    }
+}
+
+/// Helper to log a formatted string to iOS system log.
+/// Creates a proper null-terminated C string.
+fn ios_log_format(message: &str) {
+    let c_string = std::ffi::CString::new(message).unwrap_or_else(|_| std::ffi::CString::new("GPUI iOS: <invalid log message>").unwrap());
+    unsafe {
+        let ns_string: *mut Object = msg_send![class!(NSString), stringWithUTF8String: c_string.as_ptr()];
+        NSLog(ns_string);
+    }
+}
+
+/// Safely access the input handler for a view.
+///
+/// IMPORTANT: This function takes the handler OUT of the RefCell before
+/// executing the callback, then restores it afterward. This matches the
+/// macOS pattern (see mac/window.rs:2492-2506) and prevents borrow conflicts
+/// when iOS calls multiple UITextInput methods simultaneously during
+/// keyboard initialization.
+///
+/// The pattern is:
+/// 1. Borrow the RefCell and take() the handler out (leaving None)
+/// 2. Drop the borrow (releasing the RefCell)
+/// 3. Execute callback with exclusive access to the handler
+/// 4. Re-borrow and restore the handler
+///
+/// This ensures no borrow is held during callback execution, allowing
+/// re-entrant calls to succeed.
+fn with_input_handler<F, R>(view: &Object, f: F) -> Option<R>
+where
+    F: FnOnce(&mut PlatformInputHandler) -> R,
+{
+    unsafe {
+        let window_ptr: *mut std::ffi::c_void = *view.get_ivar(GPUI_WINDOW_IVAR);
+        if window_ptr.is_null() {
+            ios_log_cstr(c"GPUI iOS: with_input_handler - window_ptr is null");
+            return None;
+        }
+
+        let window = &*(window_ptr as *const IosWindow);
+
+        // Take the handler out of the RefCell in a scoped block.
+        // This releases the borrow before callback execution.
+        let mut handler = {
+            let Ok(mut borrow) = window.input_handler.try_borrow_mut() else {
+                ios_log_cstr(c"GPUI iOS: with_input_handler - BORROW CONFLICT during take!");
+                return None;
+            };
+            let taken = borrow.take();
+            if taken.is_none() {
+                ios_log_cstr(c"GPUI iOS: with_input_handler - no handler set (None)");
+            }
+            taken
+        }?;
+        // Borrow is now released - handler is owned, not borrowed
+
+        // Execute callback with exclusive access to handler
+        let result = f(&mut handler);
+
+        // Restore handler back into RefCell
+        {
+            let Ok(mut borrow) = window.input_handler.try_borrow_mut() else {
+                // This should never happen since we released the borrow above,
+                // but log an error if it does
+                ios_log_cstr(c"GPUI iOS: with_input_handler - BORROW CONFLICT during restore!");
+                return Some(result);
+            };
+            *borrow = Some(handler);
+        }
+
+        Some(result)
+    }
+}
 
 /// Register a custom UIView subclass that uses CAMetalLayer as its backing layer.
 /// This is required for Metal rendering on iOS.
@@ -52,6 +237,22 @@ fn register_metal_view_class() -> &'static Class {
 
         // Add ivar to store window pointer for touch handling
         decl.add_ivar::<*mut std::ffi::c_void>(GPUI_WINDOW_IVAR);
+
+        // CRITICAL: Declare protocol conformance for text input
+        // Without this, iOS won't recognize the view as a text input view
+        // and won't show the keyboard or send text input events
+        // Note: UITextInput inherits from UIKeyInput and UITextInputTraits,
+        // so we only need to add UITextInput
+        unsafe {
+            use objc::runtime::Protocol;
+            // UITextInput includes UIKeyInput and UITextInputTraits
+            if let Some(protocol) = Protocol::get("UITextInput") {
+                decl.add_protocol(protocol);
+                println!("GPUI iOS: Added UITextInput protocol to GPUIMetalView");
+            } else {
+                println!("GPUI iOS: Failed to get UITextInput protocol!");
+            }
+        }
 
         // Override layerClass to return CAMetalLayer
         extern "C" fn layer_class(_self: &Class, _sel: Sel) -> *const Class {
@@ -95,6 +296,874 @@ fn register_metal_view_class() -> &'static Class {
             handle_touches(this, touches, event);
         }
 
+        // Make view focusable for keyboard input
+        extern "C" fn can_become_first_responder(_this: &Object, _sel: Sel) -> bool {
+            true
+        }
+
+        // UITextInputTraits - keyboard type (default)
+        extern "C" fn keyboard_type(_this: &Object, _sel: Sel) -> i64 {
+            0 // UIKeyboardTypeDefault
+        }
+
+        // UITextInputTraits - return key type
+        extern "C" fn return_key_type(_this: &Object, _sel: Sel) -> i64 {
+            0 // UIReturnKeyDefault
+        }
+
+        // UITextInputTraits - autocapitalization type
+        extern "C" fn autocapitalization_type(_this: &Object, _sel: Sel) -> i64 {
+            0 // UITextAutocapitalizationTypeNone
+        }
+
+        // UITextInputTraits - autocorrection type
+        extern "C" fn autocorrection_type(_this: &Object, _sel: Sel) -> i64 {
+            1 // UITextAutocorrectionTypeNo
+        }
+
+        // UITextInputTraits - smart quotes type (disable smart quotes)
+        // UITextSmartQuotesType: 0=Default, 1=No, 2=Yes
+        extern "C" fn smart_quotes_type(_this: &Object, _sel: Sel) -> i64 {
+            1 // UITextSmartQuotesTypeNo
+        }
+
+        // UITextInputTraits - smart dashes type (disable smart dashes)
+        // UITextSmartDashesType: 0=Default, 1=No, 2=Yes
+        extern "C" fn smart_dashes_type(_this: &Object, _sel: Sel) -> i64 {
+            1 // UITextSmartDashesTypeNo
+        }
+
+        // UITextInputTraits - smart insert delete type (disable double-space to period)
+        // UITextSmartInsertDeleteType: 0=Default, 1=No, 2=Yes
+        extern "C" fn smart_insert_delete_type(_this: &Object, _sel: Sel) -> i64 {
+            1 // UITextSmartInsertDeleteTypeNo
+        }
+
+        // UITextInputTraits - spell checking type (disable spell checking)
+        // UITextSpellCheckingType: 0=Default, 1=No, 2=Yes
+        extern "C" fn spell_checking_type(_this: &Object, _sel: Sel) -> i64 {
+            1 // UITextSpellCheckingTypeNo
+        }
+
+        // Tell iOS we want to receive keyboard input
+        extern "C" fn is_user_interaction_enabled(_this: &Object, _sel: Sel) -> bool {
+            true
+        }
+
+        // UIKeyInput protocol - hasText
+        extern "C" fn has_text(_this: &Object, _sel: Sel) -> bool {
+            ios_log_cstr(c"GPUI iOS: hasText called - returning true");
+            true // Always return true to receive text input
+        }
+
+        // UIKeyInput protocol - insertText:
+        // IMPORTANT: Uses catch_unwind because panics cannot unwind through extern "C"
+        // Note: iOS sends printable characters ONLY through insertText, not pressesBegan,
+        // so we always process insertText (no hardware key blocking needed here).
+        extern "C" fn insert_text(this: &mut Object, _sel: Sel, text: *mut Object) {
+            let _ = panic::catch_unwind(AssertUnwindSafe(|| {
+                ios_log_cstr(c"GPUI iOS: insertText called");
+                unsafe {
+                    // Get the string from the NSString first (before any handler access)
+                    let utf8: *const std::os::raw::c_char = msg_send![text, UTF8String];
+                    if utf8.is_null() {
+                        ios_log_cstr(c"GPUI iOS: insertText - UTF8String is null!");
+                        return;
+                    }
+
+                    let text_str = std::ffi::CStr::from_ptr(utf8).to_string_lossy();
+                    ios_log_format(&format!("GPUI iOS: insertText - got text: {:?}", text_str));
+
+                    // First try the input handler directly (for text fields)
+                    // This is the preferred path for software keyboard input.
+                    // Uses with_input_handler which releases the borrow during callback
+                    // to prevent conflicts when iOS queries multiple UITextInput methods.
+                    if with_input_handler(this, |handler| {
+                        ios_log_cstr(c"GPUI iOS: insertText - handler found, calling replace_text_in_range");
+                        handler.replace_text_in_range(None, &text_str);
+                    }).is_some() {
+                        ios_log_cstr(c"GPUI iOS: insertText - SUCCESS via input handler");
+                        return;
+                    }
+
+                    ios_log_cstr(c"GPUI iOS: insertText - no handler, using key event fallback");
+                    // Fallback: with_input_handler returned None (no handler set)
+                    // Send as key events for non-input-handler scenarios
+                    let window_ptr: *mut std::ffi::c_void = *this.get_ivar(GPUI_WINDOW_IVAR);
+                    if window_ptr.is_null() {
+                        ios_log_cstr(c"GPUI iOS: insertText - window pointer is null for fallback!");
+                        return;
+                    }
+                    let window = &*(window_ptr as *const IosWindow);
+
+                    for ch in text_str.chars() {
+                        match ch {
+                            '\n' | '\r' => {
+                                window.handle_key_event(40, 0, true); // Return key code
+                            }
+                            _ => {
+                                // Send as individual character key event
+                                let keystroke = crate::Keystroke {
+                                    modifiers: Modifiers::default(),
+                                    key: ch.to_string(),
+                                    key_char: Some(ch.to_string()),
+                                };
+
+                                let event = PlatformInput::KeyDown(crate::KeyDownEvent {
+                                    keystroke,
+                                    is_held: false,
+                                    prefer_character_input: true,
+                                });
+
+                                if let Some(callback) = window.input_callback.borrow_mut().as_mut() {
+                                    callback(event);
+                                }
+                            }
+                        }
+                    }
+                    ios_log_cstr(c"GPUI iOS: insertText - sent via key event fallback");
+                }
+            }));
+        }
+
+        // UIKeyInput protocol - deleteBackward
+        // This is the ONLY path for backspace deletion - we skip backspace in pressesBegan
+        // to avoid duplicate handling.
+        //
+        // iOS sometimes calls deleteBackward twice in rapid succession for a single key press.
+        // We use a debounce mechanism to ignore duplicate calls within a short time window.
+        extern "C" fn delete_backward(this: &mut Object, _sel: Sel) {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            use std::time::{SystemTime, UNIX_EPOCH};
+
+            // Use a static counter to track how many times deleteBackward is called
+            static CALL_COUNT: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+            let call_id = CALL_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+            // Debounce: track last deletion time to ignore rapid duplicate calls
+            // This is necessary because iOS sometimes calls deleteBackward twice per key press.
+            static LAST_DELETE_TIME: AtomicU64 = AtomicU64::new(0);
+            const DEBOUNCE_MS: u64 = 100; // Ignore calls within 100ms of each other
+
+            let _ = panic::catch_unwind(AssertUnwindSafe(|| {
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_millis() as u64)
+                    .unwrap_or(0);
+
+                let last_time = LAST_DELETE_TIME.load(Ordering::SeqCst);
+                let elapsed = now.saturating_sub(last_time);
+
+                ios_log_format(&format!(
+                    "GPUI iOS: deleteBackward [#{}] ENTRY - elapsed={}ms since last",
+                    call_id, elapsed
+                ));
+
+                if elapsed < DEBOUNCE_MS && last_time > 0 {
+                    ios_log_format(&format!(
+                        "GPUI iOS: deleteBackward [#{}] SKIPPED - debounce ({}ms < {}ms)",
+                        call_id, elapsed, DEBOUNCE_MS
+                    ));
+                    return;
+                }
+
+                // Track whether we actually performed a deletion
+                let mut did_delete = false;
+
+                // First try the input handler directly
+                // This is the preferred path for software keyboard input.
+                // Uses with_input_handler which releases the borrow during callback
+                // to prevent conflicts when iOS queries multiple UITextInput methods.
+                let handler_result = with_input_handler(this, |handler| {
+                    ios_log_format(&format!("GPUI iOS: deleteBackward [#{}] - handler found", call_id));
+                    // Get current selection
+                    if let Some(selection) = handler.selected_text_range(false) {
+                        ios_log_format(&format!(
+                            "GPUI iOS: deleteBackward [#{}] - selection: {:?}, empty: {}",
+                            call_id, selection.range, selection.range.is_empty()
+                        ));
+                        if selection.range.is_empty() {
+                            // No selection - delete one character before cursor
+                            if selection.range.start > 0 {
+                                let delete_range = selection.range.start - 1..selection.range.start;
+                                ios_log_format(&format!(
+                                    "GPUI iOS: deleteBackward [#{}] - deleting range {:?} (UTF-16)",
+                                    call_id, delete_range
+                                ));
+                                handler.replace_text_in_range(Some(delete_range), "");
+                                ios_log_format(&format!("GPUI iOS: deleteBackward [#{}] - deleted one char", call_id));
+                                return true; // Performed deletion
+                            } else {
+                                ios_log_format(&format!("GPUI iOS: deleteBackward [#{}] - at start, nothing to delete", call_id));
+                            }
+                        } else {
+                            // Has selection - delete the selection
+                            ios_log_format(&format!(
+                                "GPUI iOS: deleteBackward [#{}] - deleting selection {:?}",
+                                call_id, selection.range
+                            ));
+                            handler.replace_text_in_range(Some(selection.range), "");
+                            ios_log_format(&format!("GPUI iOS: deleteBackward [#{}] - deleted selection", call_id));
+                            return true; // Performed deletion
+                        }
+                    } else {
+                        ios_log_format(&format!("GPUI iOS: deleteBackward [#{}] - no selection available", call_id));
+                    }
+                    false // No deletion performed
+                });
+
+                match handler_result {
+                    Some(true) => {
+                        did_delete = true;
+                        ios_log_format(&format!("GPUI iOS: deleteBackward [#{}] - SUCCESS via input handler", call_id));
+                    }
+                    Some(false) => {
+                        ios_log_format(&format!("GPUI iOS: deleteBackward [#{}] - handler found but no deletion needed", call_id));
+                    }
+                    None => {
+                        ios_log_format(&format!("GPUI iOS: deleteBackward [#{}] - no handler, using key event fallback", call_id));
+                        // Fallback: with_input_handler returned None (no handler set)
+                        // Send as key event
+                        unsafe {
+                            let window_ptr: *mut std::ffi::c_void = *this.get_ivar(GPUI_WINDOW_IVAR);
+                            if window_ptr.is_null() {
+                                ios_log_format(&format!("GPUI iOS: deleteBackward [#{}] - window pointer is null for fallback!", call_id));
+                                return;
+                            }
+                            let window = &*(window_ptr as *const IosWindow);
+                            ios_log_format(&format!("GPUI iOS: deleteBackward [#{}] - sending backspace key event", call_id));
+                            window.handle_key_event(0x2A, 0, true); // Backspace key code
+                            did_delete = true;
+                        }
+                    }
+                }
+
+                // Update the last delete time after a successful deletion
+                if did_delete {
+                    LAST_DELETE_TIME.store(now, Ordering::SeqCst);
+                    ios_log_format(&format!("GPUI iOS: deleteBackward [#{}] - updated last_delete_time to {}", call_id, now));
+                }
+            }));
+        }
+
+        // Hardware keyboard handling
+        extern "C" fn presses_began(
+            this: &mut Object,
+            _sel: Sel,
+            presses: *mut Object,
+            event: *mut Object,
+        ) {
+            ios_log_cstr(c"GPUI iOS: pressesBegan - hardware key pressed");
+            let _ = panic::catch_unwind(AssertUnwindSafe(|| {
+                handle_presses(this, presses, true);
+            }));
+            // Call super
+            unsafe {
+                let superclass = class!(UIView);
+                let _: () = msg_send![super(this, superclass), pressesBegan: presses withEvent: event];
+            }
+        }
+
+        extern "C" fn presses_ended(
+            this: &mut Object,
+            _sel: Sel,
+            presses: *mut Object,
+            event: *mut Object,
+        ) {
+            ios_log_cstr(c"GPUI iOS: pressesEnded - hardware key released");
+            let _ = panic::catch_unwind(AssertUnwindSafe(|| {
+                handle_presses(this, presses, false);
+            }));
+            // Call super
+            unsafe {
+                let superclass = class!(UIView);
+                let _: () = msg_send![super(this, superclass), pressesEnded: presses withEvent: event];
+            }
+        }
+
+        // ============================================
+        // UITextInput Protocol - Core Properties
+        // ============================================
+
+        // UITextInput - beginningOfDocument
+        extern "C" fn beginning_of_document(_this: &Object, _sel: Sel) -> *mut Object {
+            create_text_position(0)
+        }
+
+        // UITextInput - endOfDocument
+        // IMPORTANT: Uses catch_unwind because panics cannot unwind through extern "C"
+        extern "C" fn end_of_document(this: &Object, _sel: Sel) -> *mut Object {
+            let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                let len = with_input_handler(this, |handler| {
+                    let mut adjusted = None;
+                    handler.text_for_range(0..usize::MAX, &mut adjusted)
+                        .map(|s| s.encode_utf16().count())
+                        .unwrap_or(0)
+                }).unwrap_or(0);
+                create_text_position(len)
+            }));
+
+            match result {
+                Ok(ptr) => ptr,
+                Err(_) => create_text_position(0), // Return position 0 on panic
+            }
+        }
+
+        // UITextInput - selectedTextRange (CRITICAL - must not return nil!)
+        // IMPORTANT: Uses catch_unwind because panics cannot unwind through extern "C"
+        extern "C" fn selected_text_range(this: &Object, _sel: Sel) -> *mut Object {
+            let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                let range = with_input_handler(this, |handler| {
+                    handler.selected_text_range(false)
+                }).flatten();
+
+                match range {
+                    Some(selection) => create_text_range(
+                        selection.range.start,
+                        selection.range.end
+                    ),
+                    // Return empty range at start, never nil!
+                    None => create_text_range(0, 0),
+                }
+            }));
+
+            match result {
+                Ok(ptr) => ptr,
+                Err(_) => create_text_range(0, 0), // Return empty range at start on panic
+            }
+        }
+
+        // UITextInput - setSelectedTextRange:
+        // iOS calls this to sync the cursor/selection position.
+        // We need to be careful here:
+        // - After deleteBackward: iOS sends the OLD position which would cause double-delete
+        // - After insertText: iOS sends the NEW position which we need to track
+        //
+        // Solution: Only process if this is setting a cursor position (empty range),
+        // and track it as a "pending" selection that we verify matches our internal state.
+        extern "C" fn set_selected_text_range(_this: &mut Object, _sel: Sel, range: *mut Object) {
+            let _ = panic::catch_unwind(AssertUnwindSafe(|| {
+                if let Some((start, end)) = get_range_indices(range) {
+                    ios_log_format(&format!(
+                        "GPUI iOS: setSelectedTextRange called with {}..{} (ignored - cursor managed internally)",
+                        start, end
+                    ));
+                    // We intentionally ignore this call.
+                    // Our text operations (insertText, deleteBackward) already update the cursor.
+                    // Calling replace_text_in_range here interferes with the deduplication logic
+                    // and can cause issues with subsequent text insertions.
+                } else {
+                    ios_log_cstr(c"GPUI iOS: setSelectedTextRange called with nil range (ignored)");
+                }
+            }));
+        }
+
+        // UITextInput - markedTextRange (returns nil when no marked text)
+        // IMPORTANT: Uses catch_unwind because panics cannot unwind through extern "C"
+        extern "C" fn marked_text_range(this: &Object, _sel: Sel) -> *mut Object {
+            // Wrap in catch_unwind to prevent panics from unwinding through FFI boundary
+            let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                let range = with_input_handler(this, |handler| {
+                    handler.marked_text_range()
+                }).flatten();
+
+                match range {
+                    Some(r) => create_text_range(r.start, r.end),
+                    None => std::ptr::null_mut(),
+                }
+            }));
+
+            match result {
+                Ok(ptr) => ptr,
+                Err(_) => std::ptr::null_mut(), // Return nil on panic
+            }
+        }
+
+        // UITextInput - markedTextStyle (not used, return nil)
+        extern "C" fn marked_text_style(_this: &Object, _sel: Sel) -> *mut Object {
+            std::ptr::null_mut()
+        }
+
+        // UITextInput - setMarkedTextStyle: (not used)
+        extern "C" fn set_marked_text_style(_this: &mut Object, _sel: Sel, _style: *mut Object) {
+            // No-op
+        }
+
+        // UITextInput - inputDelegate (store reference to delegate)
+        extern "C" fn input_delegate(_this: &Object, _sel: Sel) -> *mut Object {
+            std::ptr::null_mut()
+        }
+
+        // UITextInput - setInputDelegate:
+        extern "C" fn set_input_delegate(_this: &mut Object, _sel: Sel, _delegate: *mut Object) {
+            // Could store delegate for notifications if needed
+        }
+
+        // UITextInput - tokenizer (use default string tokenizer)
+        extern "C" fn tokenizer(this: &Object, _sel: Sel) -> *mut Object {
+            unsafe {
+                // Use UITextInputStringTokenizer as default
+                let tokenizer: *mut Object = msg_send![class!(UITextInputStringTokenizer), alloc];
+                let tokenizer: *mut Object = msg_send![tokenizer, initWithTextInput: this];
+                tokenizer
+            }
+        }
+
+        // ============================================
+        // UITextInput Protocol - Text Manipulation
+        // ============================================
+
+        // UITextInput - textInRange:
+        // IMPORTANT: Uses catch_unwind because panics cannot unwind through extern "C"
+        extern "C" fn text_in_range(this: &Object, _sel: Sel, range: *mut Object) -> *mut Object {
+            let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                let Some((start, end)) = get_range_indices(range) else {
+                    return std::ptr::null_mut();
+                };
+
+                let text = with_input_handler(this, |handler| {
+                    let mut adjusted = None;
+                    handler.text_for_range(start..end, &mut adjusted)
+                }).flatten();
+
+                match text {
+                    Some(s) => unsafe {
+                        let c_str = std::ffi::CString::new(s).unwrap_or_default();
+                        let ns_string: *mut Object = msg_send![class!(NSString), stringWithUTF8String: c_str.as_ptr()];
+                        ns_string
+                    },
+                    None => std::ptr::null_mut(),
+                }
+            }));
+
+            match result {
+                Ok(ptr) => ptr,
+                Err(_) => std::ptr::null_mut(),
+            }
+        }
+
+        // UITextInput - replaceRange:withText:
+        // This is called by iOS for smart punctuation and autocorrect
+        // IMPORTANT: Uses catch_unwind because panics cannot unwind through extern "C"
+        extern "C" fn replace_range_with_text(this: &mut Object, _sel: Sel, range: *mut Object, text: *mut Object) {
+            let _ = panic::catch_unwind(AssertUnwindSafe(|| {
+                let Some((start, end)) = get_range_indices(range) else {
+                    ios_log_cstr(c"GPUI iOS: replaceRange:withText: - no valid range");
+                    return;
+                };
+
+                unsafe {
+                    let utf8: *const std::os::raw::c_char = msg_send![text, UTF8String];
+                    if utf8.is_null() {
+                        ios_log_cstr(c"GPUI iOS: replaceRange:withText: - null text");
+                        return;
+                    }
+                    let text_str = std::ffi::CStr::from_ptr(utf8).to_string_lossy();
+
+                    ios_log_format(&format!(
+                        "GPUI iOS: replaceRange:withText: range={}..{}, text={:?}",
+                        start, end, text_str
+                    ));
+
+                    with_input_handler(this, |handler| {
+                        handler.replace_text_in_range(Some(start..end), &text_str);
+                    });
+                }
+            }));
+        }
+
+        // UITextInput - setMarkedText:selectedRange:
+        // IMPORTANT: Uses catch_unwind because panics cannot unwind through extern "C"
+        extern "C" fn set_marked_text(
+            this: &mut Object,
+            _sel: Sel,
+            marked_text: *mut Object,
+            selected_range: NSRange,
+        ) {
+            let _ = panic::catch_unwind(AssertUnwindSafe(|| {
+                unsafe {
+                    if marked_text.is_null() {
+                        ios_log_cstr(c"GPUI iOS: setMarkedText - unmarking (null text)");
+                        // Unmark text
+                        with_input_handler(this, |handler| {
+                            handler.unmark_text();
+                        });
+                        return;
+                    }
+
+                    // Check if it's NSAttributedString
+                    let is_attributed: BOOL = msg_send![marked_text, isKindOfClass: class!(NSAttributedString)];
+                    let text_obj: *mut Object = if is_attributed == YES {
+                        msg_send![marked_text, string]
+                    } else {
+                        marked_text
+                    };
+
+                    let utf8: *const std::os::raw::c_char = msg_send![text_obj, UTF8String];
+                    if utf8.is_null() {
+                        ios_log_cstr(c"GPUI iOS: setMarkedText - null UTF8 string");
+                        return;
+                    }
+                    let text_str = std::ffi::CStr::from_ptr(utf8).to_string_lossy();
+
+                    ios_log_format(&format!(
+                        "GPUI iOS: setMarkedText - text={:?}, selected_range={}..{}",
+                        text_str, selected_range.location, selected_range.location + selected_range.length
+                    ));
+
+                    let selected = if selected_range.location != NS_NOT_FOUND {
+                        Some(selected_range.location as usize..(selected_range.location + selected_range.length) as usize)
+                    } else {
+                        None
+                    };
+
+                    with_input_handler(this, |handler| {
+                        handler.replace_and_mark_text_in_range(None, &text_str, selected);
+                    });
+                }
+            }));
+        }
+
+        // UITextInput - unmarkText
+        // IMPORTANT: Uses catch_unwind because panics cannot unwind through extern "C"
+        extern "C" fn unmark_text(this: &mut Object, _sel: Sel) {
+            let _ = panic::catch_unwind(AssertUnwindSafe(|| {
+                with_input_handler(this, |handler| {
+                    handler.unmark_text();
+                });
+            }));
+        }
+
+        // UITextInput - attributedSubstringFromRange: (for copy/paste preview)
+        // IMPORTANT: Uses catch_unwind because panics cannot unwind through extern "C"
+        extern "C" fn attributed_substring_from_range(this: &Object, _sel: Sel, range: *mut Object) -> *mut Object {
+            let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                let Some((start, end)) = get_range_indices(range) else {
+                    return std::ptr::null_mut();
+                };
+
+                let text = with_input_handler(this, |handler| {
+                    let mut adjusted = None;
+                    handler.text_for_range(start..end, &mut adjusted)
+                }).flatten();
+
+                match text {
+                    Some(s) => unsafe {
+                        let c_str = std::ffi::CString::new(s).unwrap_or_default();
+                        let ns_string: *mut Object = msg_send![class!(NSString), stringWithUTF8String: c_str.as_ptr()];
+                        let attributed: *mut Object = msg_send![class!(NSAttributedString), alloc];
+                        let attributed: *mut Object = msg_send![attributed, initWithString: ns_string];
+                        attributed
+                    },
+                    None => std::ptr::null_mut(),
+                }
+            }));
+
+            match result {
+                Ok(ptr) => ptr,
+                Err(_) => std::ptr::null_mut(),
+            }
+        }
+
+        // ============================================
+        // UITextInput Protocol - Position/Range Calculation
+        // ============================================
+
+        // UITextInput - positionFromPosition:offset:
+        extern "C" fn position_from_position_offset(
+            _this: &Object,
+            _sel: Sel,
+            position: *mut Object,
+            offset: isize,
+        ) -> *mut Object {
+            let Some(index) = get_position_index(position) else {
+                return std::ptr::null_mut();
+            };
+
+            let new_index = if offset >= 0 {
+                index.saturating_add(offset as usize)
+            } else {
+                index.saturating_sub((-offset) as usize)
+            };
+
+            create_text_position(new_index)
+        }
+
+        // UITextInput - positionFromPosition:inDirection:offset:
+        extern "C" fn position_from_position_in_direction(
+            _this: &Object,
+            _sel: Sel,
+            position: *mut Object,
+            direction: i64, // UITextLayoutDirection
+            offset: isize,
+        ) -> *mut Object {
+            let Some(index) = get_position_index(position) else {
+                return std::ptr::null_mut();
+            };
+
+            // Direction: 0=right, 1=left, 2=up, 3=down
+            // For now, treat up/down same as left/right (simplified)
+            let effective_offset = match direction {
+                1 | 2 => -offset.abs(), // left/up = negative
+                _ => offset.abs(),      // right/down = positive
+            };
+
+            let new_index = if effective_offset >= 0 {
+                index.saturating_add(effective_offset as usize)
+            } else {
+                index.saturating_sub((-effective_offset) as usize)
+            };
+
+            create_text_position(new_index)
+        }
+
+        // UITextInput - textRangeFromPosition:toPosition:
+        extern "C" fn text_range_from_position_to_position(
+            _this: &Object,
+            _sel: Sel,
+            from: *mut Object,
+            to: *mut Object,
+        ) -> *mut Object {
+            let Some(start) = get_position_index(from) else {
+                return std::ptr::null_mut();
+            };
+            let Some(end) = get_position_index(to) else {
+                return std::ptr::null_mut();
+            };
+
+            create_text_range(start.min(end), start.max(end))
+        }
+
+        // UITextInput - comparePosition:toPosition:
+        extern "C" fn compare_position(
+            _this: &Object,
+            _sel: Sel,
+            position: *mut Object,
+            other: *mut Object,
+        ) -> i64 { // NSComparisonResult
+            let Some(a) = get_position_index(position) else {
+                return 0; // NSOrderedSame
+            };
+            let Some(b) = get_position_index(other) else {
+                return 0;
+            };
+
+            match a.cmp(&b) {
+                std::cmp::Ordering::Less => -1,    // NSOrderedAscending
+                std::cmp::Ordering::Equal => 0,    // NSOrderedSame
+                std::cmp::Ordering::Greater => 1,  // NSOrderedDescending
+            }
+        }
+
+        // UITextInput - offsetFromPosition:toPosition:
+        extern "C" fn offset_from_position(
+            _this: &Object,
+            _sel: Sel,
+            from: *mut Object,
+            to: *mut Object,
+        ) -> isize {
+            let Some(start) = get_position_index(from) else {
+                return 0;
+            };
+            let Some(end) = get_position_index(to) else {
+                return 0;
+            };
+
+            (end as isize) - (start as isize)
+        }
+
+        // UITextInput - positionWithinRange:farthestInDirection:
+        extern "C" fn position_within_range_farthest(
+            _this: &Object,
+            _sel: Sel,
+            range: *mut Object,
+            direction: i64,
+        ) -> *mut Object {
+            let Some((start, end)) = get_range_indices(range) else {
+                return std::ptr::null_mut();
+            };
+
+            // Direction: 0=right, 1=left, 2=up, 3=down
+            let index = match direction {
+                1 | 2 => start, // left/up = start
+                _ => end,       // right/down = end
+            };
+
+            create_text_position(index)
+        }
+
+        // UITextInput - characterRangeByExtendingPosition:inDirection:
+        // IMPORTANT: Uses catch_unwind because panics cannot unwind through extern "C"
+        extern "C" fn character_range_by_extending(
+            this: &Object,
+            _sel: Sel,
+            position: *mut Object,
+            direction: i64,
+        ) -> *mut Object {
+            let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                let Some(index) = get_position_index(position) else {
+                    return std::ptr::null_mut();
+                };
+
+                // Get document length
+                let doc_end = with_input_handler(this, |handler| {
+                    let mut adjusted = None;
+                    handler.text_for_range(0..usize::MAX, &mut adjusted)
+                        .map(|s| s.encode_utf16().count())
+                        .unwrap_or(0)
+                }).unwrap_or(0);
+
+                match direction {
+                    1 | 2 => create_text_range(0, index),           // left/up - to beginning
+                    _ => create_text_range(index, doc_end),         // right/down - to end
+                }
+            }));
+
+            match result {
+                Ok(ptr) => ptr,
+                Err(_) => std::ptr::null_mut(),
+            }
+        }
+
+        // ============================================
+        // UITextInput Protocol - Geometry Methods
+        // ============================================
+
+        // UITextInput - caretRectForPosition: (CRITICAL for keyboard to appear!)
+        // IMPORTANT: Uses catch_unwind because panics cannot unwind through extern "C"
+        extern "C" fn caret_rect_for_position(this: &Object, _sel: Sel, position: *mut Object) -> IOSCGRect {
+            let default_rect = IOSCGRect::new(IOSCGPoint::new(20.0, 100.0), IOSCGSize::new(2.0, 20.0));
+
+            let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                let Some(index) = get_position_index(position) else {
+                    return default_rect;
+                };
+
+                let bounds = with_input_handler(this, |handler| {
+                    handler.bounds_for_range(index..index)
+                }).flatten();
+
+                match bounds {
+                    Some(b) => IOSCGRect::new(
+                        IOSCGPoint::new(b.origin.x.0 as f64, b.origin.y.0 as f64),
+                        IOSCGSize::new(2.0, b.size.height.0 as f64), // 2px wide caret
+                    ),
+                    None => default_rect,
+                }
+            }));
+
+            match result {
+                Ok(rect) => rect,
+                Err(_) => default_rect,
+            }
+        }
+
+        // UITextInput - firstRectForRange:
+        // IMPORTANT: Uses catch_unwind because panics cannot unwind through extern "C"
+        extern "C" fn first_rect_for_range(this: &Object, _sel: Sel, range: *mut Object) -> IOSCGRect {
+            let default_rect = IOSCGRect::new(IOSCGPoint::new(20.0, 100.0), IOSCGSize::new(100.0, 20.0));
+
+            let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                let Some((start, end)) = get_range_indices(range) else {
+                    return default_rect;
+                };
+
+                let bounds = with_input_handler(this, |handler| {
+                    handler.bounds_for_range(start..end)
+                }).flatten();
+
+                match bounds {
+                    Some(b) => IOSCGRect::new(
+                        IOSCGPoint::new(b.origin.x.0 as f64, b.origin.y.0 as f64),
+                        IOSCGSize::new(b.size.width.0 as f64, b.size.height.0 as f64),
+                    ),
+                    None => default_rect,
+                }
+            }));
+
+            match result {
+                Ok(rect) => rect,
+                Err(_) => default_rect,
+            }
+        }
+
+        // UITextInput - selectionRectsForRange: (for selection handles)
+        extern "C" fn selection_rects_for_range(_this: &Object, _sel: Sel, _range: *mut Object) -> *mut Object {
+            // Return empty array - we handle selection rendering ourselves
+            unsafe {
+                msg_send![class!(NSArray), array]
+            }
+        }
+
+        // UITextInput - closestPositionToPoint:
+        // IMPORTANT: Uses catch_unwind because panics cannot unwind through extern "C"
+        extern "C" fn closest_position_to_point(this: &Object, _sel: Sel, point: IOSCGPoint) -> *mut Object {
+            let result = panic::catch_unwind(AssertUnwindSafe(|| {
+                let index = with_input_handler(this, |handler| {
+                    handler.character_index_for_point(Point::new(
+                        px(point.x as f32),
+                        px(point.y as f32),
+                    ))
+                }).flatten();
+
+                create_text_position(index.unwrap_or(0))
+            }));
+
+            match result {
+                Ok(ptr) => ptr,
+                Err(_) => create_text_position(0),
+            }
+        }
+
+        // UITextInput - closestPositionToPoint:withinRange:
+        extern "C" fn closest_position_to_point_within_range(
+            this: &Object,
+            _sel: Sel,
+            point: IOSCGPoint,
+            range: *mut Object,
+        ) -> *mut Object {
+            let pos = closest_position_to_point(this, _sel, point);
+
+            // Clamp to range if valid
+            if let (Some(index), Some((start, end))) = (get_position_index(pos), get_range_indices(range)) {
+                let clamped = index.clamp(start, end);
+                return create_text_position(clamped);
+            }
+
+            pos
+        }
+
+        // UITextInput - characterRangeAtPoint:
+        extern "C" fn character_range_at_point(this: &Object, _sel: Sel, point: IOSCGPoint) -> *mut Object {
+            let pos = closest_position_to_point(this, _sel, point);
+            let Some(index) = get_position_index(pos) else {
+                return std::ptr::null_mut();
+            };
+
+            // Return single character range
+            create_text_range(index, index.saturating_add(1))
+        }
+
+        // UITextInput - baseWritingDirectionForPosition:inDirection:
+        extern "C" fn base_writing_direction(
+            _this: &Object,
+            _sel: Sel,
+            _position: *mut Object,
+            _direction: i64,
+        ) -> i64 {
+            0 // UITextWritingDirectionNatural / LeftToRight
+        }
+
+        // UITextInput - setBaseWritingDirection:forRange:
+        extern "C" fn set_base_writing_direction(
+            _this: &mut Object,
+            _sel: Sel,
+            _direction: i64,
+            _range: *mut Object,
+        ) {
+            // No-op - we only support LTR for now
+        }
+
         unsafe {
             // Add class method for layerClass
             decl.add_class_method(
@@ -118,6 +1187,206 @@ fn register_metal_view_class() -> &'static Class {
             decl.add_method(
                 sel!(touchesCancelled:withEvent:),
                 touches_cancelled as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object),
+            );
+
+            // Add keyboard handling methods
+            decl.add_method(
+                sel!(canBecomeFirstResponder),
+                can_become_first_responder as extern "C" fn(&Object, Sel) -> bool,
+            );
+
+            // Add UITextInputTraits protocol methods
+            decl.add_method(
+                sel!(keyboardType),
+                keyboard_type as extern "C" fn(&Object, Sel) -> i64,
+            );
+            decl.add_method(
+                sel!(returnKeyType),
+                return_key_type as extern "C" fn(&Object, Sel) -> i64,
+            );
+            decl.add_method(
+                sel!(autocapitalizationType),
+                autocapitalization_type as extern "C" fn(&Object, Sel) -> i64,
+            );
+            decl.add_method(
+                sel!(autocorrectionType),
+                autocorrection_type as extern "C" fn(&Object, Sel) -> i64,
+            );
+            decl.add_method(
+                sel!(smartQuotesType),
+                smart_quotes_type as extern "C" fn(&Object, Sel) -> i64,
+            );
+            decl.add_method(
+                sel!(smartDashesType),
+                smart_dashes_type as extern "C" fn(&Object, Sel) -> i64,
+            );
+            decl.add_method(
+                sel!(smartInsertDeleteType),
+                smart_insert_delete_type as extern "C" fn(&Object, Sel) -> i64,
+            );
+            decl.add_method(
+                sel!(spellCheckingType),
+                spell_checking_type as extern "C" fn(&Object, Sel) -> i64,
+            );
+
+            // Add UIKeyInput protocol methods for text input
+            decl.add_method(
+                sel!(hasText),
+                has_text as extern "C" fn(&Object, Sel) -> bool,
+            );
+            decl.add_method(
+                sel!(insertText:),
+                insert_text as extern "C" fn(&mut Object, Sel, *mut Object),
+            );
+            decl.add_method(
+                sel!(deleteBackward),
+                delete_backward as extern "C" fn(&mut Object, Sel),
+            );
+
+            // Add hardware keyboard press handling
+            decl.add_method(
+                sel!(pressesBegan:withEvent:),
+                presses_began as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object),
+            );
+            decl.add_method(
+                sel!(pressesEnded:withEvent:),
+                presses_ended as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object),
+            );
+
+            // ============================================
+            // UITextInput Protocol - Core Properties
+            // ============================================
+            decl.add_method(
+                sel!(beginningOfDocument),
+                beginning_of_document as extern "C" fn(&Object, Sel) -> *mut Object,
+            );
+            decl.add_method(
+                sel!(endOfDocument),
+                end_of_document as extern "C" fn(&Object, Sel) -> *mut Object,
+            );
+            decl.add_method(
+                sel!(selectedTextRange),
+                selected_text_range as extern "C" fn(&Object, Sel) -> *mut Object,
+            );
+            decl.add_method(
+                sel!(setSelectedTextRange:),
+                set_selected_text_range as extern "C" fn(&mut Object, Sel, *mut Object),
+            );
+            decl.add_method(
+                sel!(markedTextRange),
+                marked_text_range as extern "C" fn(&Object, Sel) -> *mut Object,
+            );
+            decl.add_method(
+                sel!(markedTextStyle),
+                marked_text_style as extern "C" fn(&Object, Sel) -> *mut Object,
+            );
+            decl.add_method(
+                sel!(setMarkedTextStyle:),
+                set_marked_text_style as extern "C" fn(&mut Object, Sel, *mut Object),
+            );
+            decl.add_method(
+                sel!(inputDelegate),
+                input_delegate as extern "C" fn(&Object, Sel) -> *mut Object,
+            );
+            decl.add_method(
+                sel!(setInputDelegate:),
+                set_input_delegate as extern "C" fn(&mut Object, Sel, *mut Object),
+            );
+            decl.add_method(
+                sel!(tokenizer),
+                tokenizer as extern "C" fn(&Object, Sel) -> *mut Object,
+            );
+
+            // ============================================
+            // UITextInput Protocol - Text Manipulation
+            // ============================================
+            decl.add_method(
+                sel!(textInRange:),
+                text_in_range as extern "C" fn(&Object, Sel, *mut Object) -> *mut Object,
+            );
+            decl.add_method(
+                sel!(replaceRange:withText:),
+                replace_range_with_text as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object),
+            );
+            decl.add_method(
+                sel!(setMarkedText:selectedRange:),
+                set_marked_text as extern "C" fn(&mut Object, Sel, *mut Object, NSRange),
+            );
+            decl.add_method(
+                sel!(unmarkText),
+                unmark_text as extern "C" fn(&mut Object, Sel),
+            );
+            decl.add_method(
+                sel!(attributedSubstringFromRange:),
+                attributed_substring_from_range as extern "C" fn(&Object, Sel, *mut Object) -> *mut Object,
+            );
+
+            // ============================================
+            // UITextInput Protocol - Position/Range Calculation
+            // ============================================
+            decl.add_method(
+                sel!(positionFromPosition:offset:),
+                position_from_position_offset as extern "C" fn(&Object, Sel, *mut Object, isize) -> *mut Object,
+            );
+            decl.add_method(
+                sel!(positionFromPosition:inDirection:offset:),
+                position_from_position_in_direction as extern "C" fn(&Object, Sel, *mut Object, i64, isize) -> *mut Object,
+            );
+            decl.add_method(
+                sel!(textRangeFromPosition:toPosition:),
+                text_range_from_position_to_position as extern "C" fn(&Object, Sel, *mut Object, *mut Object) -> *mut Object,
+            );
+            decl.add_method(
+                sel!(comparePosition:toPosition:),
+                compare_position as extern "C" fn(&Object, Sel, *mut Object, *mut Object) -> i64,
+            );
+            decl.add_method(
+                sel!(offsetFromPosition:toPosition:),
+                offset_from_position as extern "C" fn(&Object, Sel, *mut Object, *mut Object) -> isize,
+            );
+            decl.add_method(
+                sel!(positionWithinRange:farthestInDirection:),
+                position_within_range_farthest as extern "C" fn(&Object, Sel, *mut Object, i64) -> *mut Object,
+            );
+            decl.add_method(
+                sel!(characterRangeByExtendingPosition:inDirection:),
+                character_range_by_extending as extern "C" fn(&Object, Sel, *mut Object, i64) -> *mut Object,
+            );
+
+            // ============================================
+            // UITextInput Protocol - Geometry Methods
+            // ============================================
+            decl.add_method(
+                sel!(caretRectForPosition:),
+                caret_rect_for_position as extern "C" fn(&Object, Sel, *mut Object) -> IOSCGRect,
+            );
+            decl.add_method(
+                sel!(firstRectForRange:),
+                first_rect_for_range as extern "C" fn(&Object, Sel, *mut Object) -> IOSCGRect,
+            );
+            decl.add_method(
+                sel!(selectionRectsForRange:),
+                selection_rects_for_range as extern "C" fn(&Object, Sel, *mut Object) -> *mut Object,
+            );
+            decl.add_method(
+                sel!(closestPositionToPoint:),
+                closest_position_to_point as extern "C" fn(&Object, Sel, IOSCGPoint) -> *mut Object,
+            );
+            decl.add_method(
+                sel!(closestPositionToPoint:withinRange:),
+                closest_position_to_point_within_range as extern "C" fn(&Object, Sel, IOSCGPoint, *mut Object) -> *mut Object,
+            );
+            decl.add_method(
+                sel!(characterRangeAtPoint:),
+                character_range_at_point as extern "C" fn(&Object, Sel, IOSCGPoint) -> *mut Object,
+            );
+            decl.add_method(
+                sel!(baseWritingDirectionForPosition:inDirection:),
+                base_writing_direction as extern "C" fn(&Object, Sel, *mut Object, i64) -> i64,
+            );
+            decl.add_method(
+                sel!(setBaseWritingDirection:forRange:),
+                set_base_writing_direction as extern "C" fn(&mut Object, Sel, i64, *mut Object),
             );
         }
 
@@ -150,6 +1419,68 @@ fn handle_touches(view: &mut Object, touches: *mut Object, event: *mut Object) {
     }
 }
 
+/// Handle hardware keyboard press events from the GPUIMetalView
+fn handle_presses(view: &mut Object, presses: *mut Object, is_key_down: bool) {
+    unsafe {
+        // Get the window pointer from the view's ivar
+        let window_ptr: *mut std::ffi::c_void = *view.get_ivar(GPUI_WINDOW_IVAR);
+        if window_ptr.is_null() {
+            return;
+        }
+
+        let window = &*(window_ptr as *const IosWindow);
+
+        // Get all presses from the set
+        let all_presses: *mut Object = msg_send![presses, allObjects];
+        let count: usize = msg_send![all_presses, count];
+
+        for i in 0..count {
+            let press: *mut Object = msg_send![all_presses, objectAtIndex: i];
+
+            // Get the UIKey from the press
+            let key: *mut Object = msg_send![press, key];
+            if key.is_null() {
+                continue;
+            }
+
+            // Get key code
+            let key_code: i64 = msg_send![key, keyCode];
+
+            // Get modifier flags
+            let modifier_flags: u64 = msg_send![key, modifierFlags];
+
+            ios_log_format(&format!(
+                "GPUI iOS: handle_presses - key_code=0x{:02X} ({}), modifiers=0x{:X}, is_down={}",
+                key_code, key_code, modifier_flags, is_key_down
+            ));
+
+            // Convert modifier flags to our format
+            let mut modifiers: u32 = 0;
+            if modifier_flags & (1 << 17) != 0 {
+                modifiers |= 1 << 0;
+            } // Shift
+            if modifier_flags & (1 << 18) != 0 {
+                modifiers |= 1 << 1;
+            } // Control
+            if modifier_flags & (1 << 19) != 0 {
+                modifiers |= 1 << 2;
+            } // Alt/Option
+            if modifier_flags & (1 << 20) != 0 {
+                modifiers |= 1 << 3;
+            } // Command
+
+            // Skip backspace (0x2A) and delete (0x4C) - let iOS handle them entirely
+            // through deleteBackward. This prevents duplicate deletion.
+            if key_code == 0x2A || key_code == 0x4C {
+                ios_log_cstr(c"GPUI iOS: handle_presses - skipping backspace/delete, handled by deleteBackward");
+                continue;
+            }
+
+            window.handle_key_event(key_code as u32, modifiers, is_key_down);
+        }
+    }
+}
+
 /// iOS Window backed by UIWindow + UIViewController.
 pub(crate) struct IosWindow {
     /// Handle used by GPUI to identify this window
@@ -158,10 +1489,8 @@ pub(crate) struct IosWindow {
     window: *mut Object,
     /// The UIViewController
     view_controller: *mut Object,
-    /// The Metal-backed UIView
+    /// The Metal-backed UIView (also handles UITextInput)
     view: *mut Object,
-    /// The hidden text input view for keyboard input
-    text_input_view: *mut Object,
     /// Current bounds in pixels
     bounds: Cell<Bounds<Pixels>>,
     /// Scale factor
@@ -170,6 +1499,8 @@ pub(crate) struct IosWindow {
     appearance: Cell<WindowAppearance>,
     /// Input handler for text input
     input_handler: RefCell<Option<PlatformInputHandler>>,
+    /// Whether the keyboard is currently shown (tracked to avoid show/hide flicker)
+    keyboard_shown: Cell<bool>,
     /// Callback for frame requests
     /// Note: pub(super) to allow ffi.rs to access this for the display link callback
     pub(super) request_frame_callback: RefCell<Option<Box<dyn FnMut(RequestFrameOptions)>>>,
@@ -211,6 +1542,11 @@ impl IosWindow {
         _params: WindowParams,
         renderer_context: blade::Context,
     ) -> Result<Self> {
+        // Pre-register text input classes early to avoid race conditions.
+        // iOS may query UITextInput methods (markedTextRange, selectedTextRange)
+        // immediately when the keyboard is shown, before our classes are ready.
+        text_input::ensure_text_input_classes_registered();
+
         // Create the window on the main screen
         let screen = IosDisplay::main();
         let screen_bounds = screen.bounds();
@@ -267,22 +1603,9 @@ impl IosWindow {
             // Make the window visible
             let _: () = msg_send![window, makeKeyAndVisible];
 
-            // Create a hidden text input view for keyboard handling
-            // This view conforms to UIKeyInput and handles keyboard events
-            let text_input_view: *mut Object = msg_send![class!(UIView), alloc];
-            let text_input_frame = CGRect {
-                origin: CGPoint { x: 0.0, y: 0.0 },
-                size: CGSize {
-                    width: 1.0,
-                    height: 1.0,
-                },
-            };
-            let text_input_view: *mut Object =
-                msg_send![text_input_view, initWithFrame: text_input_frame];
-            // Make it invisible but still able to become first responder
-            let _: () = msg_send![text_input_view, setAlpha: 0.01_f64];
-            let _: () = msg_send![text_input_view, setUserInteractionEnabled: YES];
-            let _: () = msg_send![view, addSubview: text_input_view];
+            // Make the Metal view first responder for keyboard input
+            // The GPUIMetalView implements UITextInput protocol for text input
+            let _: () = msg_send![view, becomeFirstResponder];
 
             // Create the blade renderer
             // Note: Blade expects size in pixels (device pixels), not points
@@ -302,11 +1625,11 @@ impl IosWindow {
                 window,
                 view_controller,
                 view,
-                text_input_view,
                 bounds: Cell::new(screen_bounds),
                 scale_factor: Cell::new(scale_factor),
                 appearance: Cell::new(WindowAppearance::Light),
                 input_handler: RefCell::new(None),
+                keyboard_shown: Cell::new(false),
                 request_frame_callback: RefCell::new(None),
                 input_callback: RefCell::new(None),
                 active_status_callback: RefCell::new(None),
@@ -346,6 +1669,11 @@ impl IosWindow {
     }
 
     /// Handle a touch event from UIKit
+    /// Get the UIWindow pointer for this window.
+    pub fn ui_window(&self) -> *mut Object {
+        self.window
+    }
+
     pub fn handle_touch(&self, touch: *mut Object, _event: *mut Object) {
         let position = touch_location_in_view(touch, self.view);
         let phase = touch_phase(touch);
@@ -398,10 +1726,21 @@ impl IosWindow {
 
     /// Show the software keyboard
     pub fn show_keyboard(&self) {
-        log::info!("GPUI iOS: Showing keyboard");
         unsafe {
-            // Make the text input view become first responder to show keyboard
-            let _: BOOL = msg_send![self.text_input_view, becomeFirstResponder];
+            // Log using NSLog so it shows in Xcode console
+            let msg = objc::runtime::Sel::register("UTF8String");
+            let log_str = "GPUI iOS: show_keyboard called, calling becomeFirstResponder";
+            let ns_str: *mut Object = msg_send![class!(NSString), stringWithUTF8String: log_str.as_ptr() as *const std::ffi::c_char];
+            let _: () = msg_send![class!(NSObject), performSelector: objc::runtime::Sel::register("class") withObject: std::ptr::null::<Object>()];
+
+            // Make the Metal view (which implements UITextInput) become first responder
+            // This will trigger iOS to show the software keyboard
+            let is_first_responder: BOOL = msg_send![self.view, isFirstResponder];
+            let can_become: BOOL = msg_send![self.view, canBecomeFirstResponder];
+            println!("GPUI iOS: show_keyboard - isFirstResponder={}, canBecomeFirstResponder={}", is_first_responder != NO, can_become != NO);
+
+            let result: BOOL = msg_send![self.view, becomeFirstResponder];
+            println!("GPUI iOS: becomeFirstResponder returned: {}", result != NO);
         }
     }
 
@@ -410,18 +1749,18 @@ impl IosWindow {
         log::info!("GPUI iOS: Hiding keyboard");
         unsafe {
             // Resign first responder to hide keyboard
-            let _: BOOL = msg_send![self.text_input_view, resignFirstResponder];
+            let _: BOOL = msg_send![self.view, resignFirstResponder];
         }
     }
 
     /// Handle text input from the software keyboard
+    /// Note: This is a fallback path. Primary text input goes through insert_text.
     pub fn handle_text_input(&self, text: *mut Object) {
         if text.is_null() {
             return;
         }
 
         unsafe {
-            // Convert NSString to Rust String
             let utf8: *const i8 = msg_send![text, UTF8String];
             if utf8.is_null() {
                 return;
@@ -431,15 +1770,9 @@ impl IosWindow {
                 .to_string_lossy()
                 .into_owned();
 
-            log::info!("GPUI iOS: Text input: {:?}", text_str);
+            log::info!("GPUI iOS: handle_text_input (fallback): {:?}", text_str);
 
-            // First try the input handler (for text fields)
-            if let Some(handler) = self.input_handler.borrow_mut().as_mut() {
-                handler.replace_text_in_range(None, &text_str);
-                return;
-            }
-
-            // Otherwise, send as key events
+            // Send as key events
             for c in text_str.chars() {
                 let keystroke = crate::Keystroke {
                     modifiers: Modifiers::default(),
@@ -470,12 +1803,21 @@ impl IosWindow {
         let key = key_code_to_string(key_code);
         let modifiers = modifier_flags_to_modifiers(modifier_flags);
 
-        log::info!(
-            "GPUI iOS: Key event - key: {:?}, modifiers: {:?}, down: {}",
-            key,
-            modifiers,
-            is_key_down
-        );
+        // Enhanced logging for debugging arrow key and other key mapping issues
+        ios_log_format(&format!(
+            "GPUI iOS: handle_key_event - code=0x{:02X}, key={}, modifiers={:?}, down={}",
+            key_code, key, modifiers, is_key_down
+        ));
+
+        // Handle arrow keys directly via input handler for cursor navigation
+        // This bypasses GPUI's key event dispatch which may not work correctly on iOS
+        if is_key_down {
+            let handled = self.handle_arrow_key(&key, modifiers.shift);
+            if handled {
+                ios_log_format(&format!("GPUI iOS: handle_key_event - arrow key '{}' handled directly", key));
+                return;
+            }
+        }
 
         let event = if is_key_down {
             key_code_to_key_down(key_code, modifier_flags)
@@ -484,7 +1826,69 @@ impl IosWindow {
         };
 
         if let Some(callback) = self.input_callback.borrow_mut().as_mut() {
+            ios_log_format(&format!("GPUI iOS: handle_key_event - calling input_callback with key={}", key));
             callback(event);
+            ios_log_cstr(c"GPUI iOS: handle_key_event - callback returned");
+        } else {
+            ios_log_cstr(c"GPUI iOS: handle_key_event - NO input_callback set!");
+        }
+    }
+
+    /// Handle arrow key navigation directly via the input handler.
+    /// Returns true if the key was handled, false otherwise.
+    fn handle_arrow_key(&self, key: &str, _shift: bool) -> bool {
+        // Only handle arrow keys
+        let delta: i64 = match key {
+            "left" => -1,
+            "right" => 1,
+            "up" => -1,   // For now, up/down also move by 1 char (proper line nav needs layout info)
+            "down" => 1,
+            _ => return false,
+        };
+
+        // Use with_input_handler via the view, just like insertText does
+        // This properly takes/restores the handler from the RefCell
+        unsafe {
+            let view = &*(self.view as *const Object);
+
+            let handled = with_input_handler(view, |handler| {
+                // Get current selection
+                let Some(selection) = handler.selected_text_range(false) else {
+                    ios_log_cstr(c"GPUI iOS: handle_arrow_key - couldn't get selection");
+                    return false;
+                };
+
+                ios_log_format(&format!(
+                    "GPUI iOS: handle_arrow_key - selection: {:?}, delta: {}",
+                    selection.range, delta
+                ));
+
+                // Calculate new cursor position
+                let current_pos = if selection.reversed {
+                    selection.range.start
+                } else {
+                    selection.range.end
+                };
+
+                let new_pos = if delta < 0 {
+                    current_pos.saturating_sub((-delta) as usize)
+                } else {
+                    current_pos.saturating_add(delta as usize)
+                };
+
+                ios_log_format(&format!(
+                    "GPUI iOS: handle_arrow_key - moving from {} to {}",
+                    current_pos, new_pos
+                ));
+
+                // Set new cursor position using replace_text_in_range with empty text
+                handler.replace_text_in_range(Some(new_pos..new_pos), "");
+
+                ios_log_cstr(c"GPUI iOS: handle_arrow_key - cursor moved");
+                true
+            });
+
+            handled.unwrap_or(false)
         }
     }
 
@@ -578,10 +1982,24 @@ impl PlatformWindow for IosWindow {
 
     fn set_input_handler(&mut self, input_handler: PlatformInputHandler) {
         *self.input_handler.borrow_mut() = Some(input_handler);
+        // Only show keyboard if we haven't already shown it.
+        // Note: set_input_handler and take_input_handler are called every frame
+        // as part of GPUI's rendering cycle, so we use keyboard_shown flag to
+        // track state and avoid show/hide flicker.
+        if !self.keyboard_shown.get() {
+            ios_log_cstr(c"GPUI iOS: set_input_handler - showing keyboard (first time)");
+            self.keyboard_shown.set(true);
+            self.show_keyboard();
+        }
     }
 
     fn take_input_handler(&mut self) -> Option<PlatformInputHandler> {
-        self.input_handler.borrow_mut().take()
+        let handler = self.input_handler.borrow_mut().take();
+        // Note: Don't hide keyboard here! take_input_handler is called every frame
+        // as part of GPUI's rendering cycle (see window.rs line 2006).
+        // The keyboard should only be hidden when the view resigns first responder,
+        // not on every frame. The keyboard_shown flag stays true.
+        handler
     }
 
     fn prompt(


### PR DESCRIPTION
## Summary
Adds full iOS platform support to GPUI, enabling GPU-accelerated UI rendering on iOS/iPadOS.

This was originally PR #43655 on zed-industries/zed but was not merged upstream.

## Features
- **Metal rendering** via Blade graphics backend
- **UIWindow/UIViewController** window management  
- **Touch event handling** translated to GPUI mouse events
- **CoreText text rendering** (shared implementation with macOS)
- **UITextInput protocol** for software keyboard support
- **Interactive demos**: Animation Playground, Shader Showcase, Text Editor

## Key Files
- `crates/gpui/src/platform/ios/` - Platform implementation
- `crates/gpui/examples/ios_app/` - Example iOS app with build scripts

## Testing
- Tested on iOS 26.1 Simulator (iPhone 17 Pro Max)
- 60fps rendering verified via CADisplayLink

cc @turbolent @JudahZF - mentioned in zed-industries/zed#11889