### PR TITLE
fix: upgrade core-graphics to 0.25 for core-text 21.1.0 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,11 +144,11 @@ cocoa = "=0.26.0"
 cocoa-foundation = "=0.2.0"
 core-foundation = "=0.10.0"
 core-foundation-sys = "0.8.6"
-core-graphics = "0.24"
+core-graphics = "0.25"
 core-text = "21"
 core-video = { version = "0.4.3", features = ["metal"] }
 flume = "0.11"
-font-kit = { git = "https://github.com/zed-industries/font-kit", rev = "110523127440aefb11ce0cf280ae7c5071337ec5", package = "zed-font-kit", version = "0.14.1-zed", optional = true }
+font-kit = { git = "https://github.com/noeljackson/font-kit", branch = "zed-font-kit-fix", package = "zed-font-kit", optional = true }
 foreign-types = "0.5"
 mach2 = "0.5"
 media = { package = "gpui_media", version = "0.2.2" }
@@ -176,7 +176,7 @@ blade-macros = { version = "0.3.0", optional = true }
 blade-util = { version = "0.3.0", optional = true }
 bytemuck = { version = "1", optional = true }
 cosmic-text = { version = "0.14.0", optional = true }
-font-kit = { git = "https://github.com/zed-industries/font-kit", rev = "110523127440aefb11ce0cf280ae7c5071337ec5", package = "zed-font-kit", version = "0.14.1-zed", features = [
+font-kit = { git = "https://github.com/noeljackson/font-kit", branch = "zed-font-kit-fix", package = "zed-font-kit", features = [
     "source-fontconfig-dlopen",
 ], optional = true }
 


### PR DESCRIPTION
## Summary

core-text 21.1.0 (released 2026-01-15) upgraded its core-graphics dependency from 0.24 to 0.25. This caused build failures when gpui-ce was used as a dependency because it still specified core-graphics 0.24, resulting in two incompatible versions of core-graphics in the dependency tree.

## Problem

The symptom was type mismatches like:
```
expected `core_graphics::font::CGFont`, found a different `core_graphics::font::CGFont`
```

This is because Rust treats types from different versions of the same crate as distinct types.

## Solution

- Upgrade core-graphics from 0.24 to 0.25 to match what core-text 21.1.0 requires
- Update font-kit reference to use a fixed fork (PR pending at https://github.com/zed-industries/font-kit/pull/6)

## Testing

Build succeeds with this fix on a project using gpui-ce.

Related: https://github.com/zed-industries/zed/issues/47168