### PR TITLE
feat(mask): add overflow edge fade support for content clipping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -340,6 +340,10 @@ path = "examples/learn/animation.rs"
 name = "text"
 path = "examples/learn/text.rs"
 
+[[example]]
+name = "overflow_fade"
+path = "examples/learn/overflow_fade.rs"
+
 # ============================================================================
 # Bench Examples - Performance benchmarks
 # ============================================================================

--- a/examples/learn/overflow_fade.rs
+++ b/examples/learn/overflow_fade.rs
@@ -102,6 +102,7 @@ fn horizontal_chip(index: usize, colors: &Colors) -> impl IntoElement {
 
 fn horizontal_panel(colors: &Colors) -> impl IntoElement {
     div()
+        .w(px(680.))
         .flex()
         .flex_col()
         .gap_2()
@@ -116,12 +117,13 @@ fn horizontal_panel(colors: &Colors) -> impl IntoElement {
             div()
                 .id("horizontal-scroll")
                 .h(px(76.))
-                .overflow_scroll()
+                .overflow_x_scroll()
                 .overflow_fade_x(px(30.))
                 .rounded_lg()
                 .bg(colors.background)
                 .child(
                     div()
+                        .w(px(2200.))
                         .flex()
                         .items_center()
                         .gap_2()

--- a/examples/learn/overflow_fade.rs
+++ b/examples/learn/overflow_fade.rs
@@ -1,0 +1,197 @@
+//! Overflow Fade Example
+//!
+//! Shows how `overflow_fade_y(...)` and `overflow_fade_x(...)` soften
+//! clipped scroll edges.
+//!
+//! Run with:
+//! `cargo run --example overflow_fade`
+
+#[path = "../prelude.rs"]
+mod example_prelude;
+
+use example_prelude::init_example;
+use gpui::{
+    App, Application, Bounds, Colors, Context, FontWeight, Render, Window, WindowBounds,
+    WindowOptions, div, prelude::*, px, size,
+};
+
+struct OverflowFadeExample;
+
+fn chat_row(index: usize, colors: &Colors) -> impl IntoElement {
+    let bg = if index % 2 == 0 {
+        colors.surface
+    } else {
+        colors.surface_hover
+    };
+
+    div()
+        .h_8()
+        .px_3()
+        .flex()
+        .items_center()
+        .rounded_md()
+        .bg(bg)
+        .text_sm()
+        .text_color(colors.text)
+        .child(format!(
+            "Row {:02}  Overflow fade mask demo item",
+            index + 1
+        ))
+}
+
+fn vertical_panel(title: &'static str, use_fade: bool, colors: &Colors) -> impl IntoElement {
+    let scroll_id: u32 = if use_fade { 1 } else { 0 };
+    let scroll_area = div()
+        .id(("vertical-scroll", scroll_id))
+        .h(px(320.))
+        .overflow_scroll()
+        .rounded_lg()
+        .bg(colors.background)
+        .p_2()
+        .child(
+            div()
+                .flex()
+                .flex_col()
+                .gap_2()
+                .children((0..40).map(|index| chat_row(index, colors))),
+        );
+    let scroll_area = if use_fade {
+        scroll_area.overflow_fade_y(px(22.))
+    } else {
+        scroll_area
+    };
+
+    div()
+        .w(px(320.))
+        .flex()
+        .flex_col()
+        .gap_2()
+        .child(
+            div()
+                .text_sm()
+                .font_weight(FontWeight::BOLD)
+                .text_color(colors.text)
+                .child(title),
+        )
+        .child(scroll_area)
+        .child(
+            div()
+                .text_xs()
+                .text_color(colors.text_muted)
+                .child(if use_fade {
+                    "overflow_fade_y(px(22.0)) enabled"
+                } else {
+                    "No overflow_fade_y"
+                }),
+        )
+}
+
+fn horizontal_chip(index: usize, colors: &Colors) -> impl IntoElement {
+    div()
+        .h_8()
+        .flex_none()
+        .px_3()
+        .rounded_full()
+        .border_1()
+        .border_color(colors.border)
+        .bg(colors.surface)
+        .text_sm()
+        .text_color(colors.text)
+        .child(format!("Tag {:02}", index + 1))
+}
+
+fn horizontal_panel(colors: &Colors) -> impl IntoElement {
+    div()
+        .flex()
+        .flex_col()
+        .gap_2()
+        .child(
+            div()
+                .text_sm()
+                .font_weight(FontWeight::BOLD)
+                .text_color(colors.text)
+                .child("Horizontal overflow fade"),
+        )
+        .child(
+            div()
+                .id("horizontal-scroll")
+                .h(px(76.))
+                .overflow_scroll()
+                .overflow_fade_x(px(30.))
+                .rounded_lg()
+                .bg(colors.background)
+                .child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap_2()
+                        .px_2()
+                        .h_full()
+                        .children((0..50).map(|index| horizontal_chip(index, colors))),
+                ),
+        )
+        .child(
+            div()
+                .text_xs()
+                .text_color(colors.text_muted)
+                .child("overflow_fade_x(px(30.0)) enabled"),
+        )
+}
+
+impl Render for OverflowFadeExample {
+    fn render(&mut self, window: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        let colors = Colors::for_appearance(window);
+
+        div()
+            .id("app")
+            .size_full()
+            .p_6()
+            .gap_6()
+            .bg(colors.background)
+            .overflow_scroll()
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap_1()
+                    .child(
+                        div()
+                            .text_xl()
+                            .font_weight(FontWeight::BOLD)
+                            .text_color(colors.text)
+                            .child("Overflow Fade"),
+                    )
+                    .child(
+                        div()
+                            .text_sm()
+                            .text_color(colors.text_muted)
+                            .child("Compare no fade vs fade, then test horizontal fade."),
+                    ),
+            )
+            .child(
+                div()
+                    .flex()
+                    .gap_4()
+                    .items_start()
+                    .child(vertical_panel("Without edge fade", false, &colors))
+                    .child(vertical_panel("With edge fade", true, &colors)),
+            )
+            .child(horizontal_panel(&colors))
+    }
+}
+
+fn main() {
+    Application::new().run(|cx: &mut App| {
+        init_example(cx, "Overflow Fade");
+
+        let bounds = Bounds::centered(None, size(px(980.), px(760.)), cx);
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
+                ..Default::default()
+            },
+            |_, cx| cx.new(|_| OverflowFadeExample),
+        )
+        .unwrap();
+    });
+}

--- a/src/elements/list.rs
+++ b/src/elements/list.rs
@@ -812,9 +812,15 @@ impl StateInner {
                 let mut item_origin = bounds.origin + Point::new(px(0.), padding.top);
                 item_origin.y -= layout_response.scroll_top.offset_in_item;
                 for item in &mut layout_response.item_layouts {
-                    window.with_content_mask(Some(ContentMask { bounds }), |window| {
-                        item.element.prepaint_at(item_origin, window, cx);
-                    });
+                    window.with_content_mask(
+                        Some(ContentMask {
+                            bounds,
+                            ..Default::default()
+                        }),
+                        |window| {
+                            item.element.prepaint_at(item_origin, window, cx);
+                        },
+                    );
 
                     if let Some(autoscroll_bounds) = window.take_autoscroll()
                         && autoscroll
@@ -1067,11 +1073,17 @@ impl Element for List {
         cx: &mut App,
     ) {
         let current_view = window.current_view();
-        window.with_content_mask(Some(ContentMask { bounds }), |window| {
-            for item in &mut prepaint.layout.item_layouts {
-                item.element.paint(window, cx);
-            }
-        });
+        window.with_content_mask(
+            Some(ContentMask {
+                bounds,
+                ..Default::default()
+            }),
+            |window| {
+                for item in &mut prepaint.layout.item_layouts {
+                    item.element.paint(window, cx);
+                }
+            },
+        );
 
         let list_state = self.state.clone();
         let height = bounds.size.height;

--- a/src/elements/list.rs
+++ b/src/elements/list.rs
@@ -782,6 +782,7 @@ impl StateInner {
         &mut self,
         bounds: Bounds<Pixels>,
         padding: Edges<Pixels>,
+        content_mask: Option<ContentMask<Pixels>>,
         autoscroll: bool,
         render_item: &mut RenderItemFn,
         window: &mut Window,
@@ -812,15 +813,9 @@ impl StateInner {
                 let mut item_origin = bounds.origin + Point::new(px(0.), padding.top);
                 item_origin.y -= layout_response.scroll_top.offset_in_item;
                 for item in &mut layout_response.item_layouts {
-                    window.with_content_mask(
-                        Some(ContentMask {
-                            bounds,
-                            ..Default::default()
-                        }),
-                        |window| {
-                            item.element.prepaint_at(item_origin, window, cx);
-                        },
-                    );
+                    window.with_content_mask(content_mask.clone(), |window| {
+                        item.element.prepaint_at(item_origin, window, cx);
+                    });
 
                     if let Some(autoscroll_bounds) = window.take_autoscroll()
                         && autoscroll
@@ -1024,7 +1019,9 @@ impl Element for List {
         state.reset = false;
 
         let mut style = Style::default();
+        style.overflow.y = Overflow::Scroll;
         style.refine(&self.style);
+        let content_mask = style.overflow_mask(bounds, window.rem_size());
 
         let hitbox = window.insert_hitbox(bounds, HitboxBehavior::Normal);
 
@@ -1046,13 +1043,28 @@ impl Element for List {
         let padding = style
             .padding
             .to_pixels(bounds.size.into(), window.rem_size());
-        let layout =
-            match state.prepaint_items(bounds, padding, true, &mut self.render_item, window, cx) {
+        let layout = match state.prepaint_items(
+            bounds,
+            padding,
+            content_mask.clone(),
+            true,
+            &mut self.render_item,
+            window,
+            cx,
+        ) {
                 Ok(layout) => layout,
                 Err(autoscroll_request) => {
                     state.logical_scroll_top = Some(autoscroll_request);
                     state
-                        .prepaint_items(bounds, padding, false, &mut self.render_item, window, cx)
+                        .prepaint_items(
+                            bounds,
+                            padding,
+                            content_mask,
+                            false,
+                            &mut self.render_item,
+                            window,
+                            cx,
+                        )
                         .unwrap()
                 }
             };
@@ -1073,11 +1085,12 @@ impl Element for List {
         cx: &mut App,
     ) {
         let current_view = window.current_view();
+        let mut style = Style::default();
+        style.overflow.y = Overflow::Scroll;
+        style.refine(&self.style);
+        let content_mask = style.overflow_mask(bounds, window.rem_size());
         window.with_content_mask(
-            Some(ContentMask {
-                bounds,
-                ..Default::default()
-            }),
+            content_mask,
             |window| {
                 for item in &mut prepaint.layout.item_layouts {
                     item.element.paint(window, cx);

--- a/src/elements/uniform_list.rs
+++ b/src/elements/uniform_list.rs
@@ -477,7 +477,10 @@ impl Element for UniformList {
                         (self.render_items)(visible_range.clone(), window, cx)
                     };
 
-                    let content_mask = ContentMask { bounds };
+                    let content_mask = ContentMask {
+                        bounds,
+                        ..Default::default()
+                    };
                     window.with_content_mask(Some(content_mask), |window| {
                         for (mut item, ix) in items.into_iter().zip(visible_range.clone()) {
                             let item_origin = padded_bounds.origin

--- a/src/platform/blade/blade_renderer.rs
+++ b/src/platform/blade/blade_renderer.rs
@@ -3,8 +3,8 @@
 
 use super::{BladeAtlas, BladeContext};
 use crate::{
-    Background, Bounds, DevicePixels, GpuSpecs, MonochromeSprite, Path, Point, PolychromeSprite,
-    PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size, Underline,
+    Background, Bounds, ContentMask, DevicePixels, Edges, GpuSpecs, MonochromeSprite, Path, Point,
+    PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size, Underline,
     get_gamma_correction_ratios,
 };
 use blade_graphics as gpu;
@@ -44,9 +44,45 @@ impl From<Bounds<ScaledPixels>> for PodBounds {
 
 #[repr(C)]
 #[derive(Clone, Copy, Pod, Zeroable)]
+struct PodEdges {
+    top: f32,
+    right: f32,
+    bottom: f32,
+    left: f32,
+}
+
+impl From<Edges<ScaledPixels>> for PodEdges {
+    fn from(edges: Edges<ScaledPixels>) -> Self {
+        Self {
+            top: edges.top.0,
+            right: edges.right.0,
+            bottom: edges.bottom.0,
+            left: edges.left.0,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct PodContentMask {
+    bounds: PodBounds,
+    fade_out: PodEdges,
+}
+
+impl From<ContentMask<ScaledPixels>> for PodContentMask {
+    fn from(content_mask: ContentMask<ScaledPixels>) -> Self {
+        Self {
+            bounds: content_mask.bounds.into(),
+            fade_out: content_mask.fade_out.into(),
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
 struct SurfaceParams {
     bounds: PodBounds,
-    content_mask: PodBounds,
+    content_mask: PodContentMask,
 }
 
 #[derive(blade_macros::ShaderData)]
@@ -121,6 +157,7 @@ struct PathRasterizationVertex {
     st_position: Point<f32>,
     color: Background,
     bounds: Bounds<ScaledPixels>,
+    content_mask: PodContentMask,
 }
 
 struct BladePipelines {
@@ -608,6 +645,7 @@ impl BladeRenderer {
                     st_position: v.st_position,
                     color: path.color,
                     bounds: path.clipped_bounds(),
+                    content_mask: path.content_mask.into(),
                 }));
             }
             let vertex_buf = unsafe { self.instance_belt.alloc_typed(&vertices, &self.gpu) };
@@ -891,7 +929,7 @@ impl BladeRenderer {
                                     globals,
                                     surface_locals: SurfaceParams {
                                         bounds: surface.bounds.into(),
-                                        content_mask: surface.content_mask.bounds.into(),
+                                        content_mask: surface.content_mask.into(),
                                     },
                                     t_y,
                                     t_cb_cr,

--- a/src/platform/blade/shaders.wgsl
+++ b/src/platform/blade/shaders.wgsl
@@ -94,6 +94,11 @@ struct Edges {
     left: f32,
 }
 
+struct ContentMask {
+    bounds: Bounds,
+    fade_out: Edges,
+}
+
 struct Hsla {
     h: f32,
     s: f32,
@@ -179,6 +184,27 @@ fn distance_from_clip_rect_transformed(unit_vertex: vec2<f32>, bounds: Bounds, c
     let position = unit_vertex * vec2<f32>(bounds.size) + bounds.origin;
     let transformed = transpose(transform.rotation_scale) * position + transform.translation;
     return distance_from_clip_rect_impl(transformed, clip_bounds);
+}
+
+fn content_mask_alpha(position: vec2<f32>, content_mask: ContentMask) -> f32 {
+    var alpha = 1.0;
+    let bounds = content_mask.bounds;
+    let fade = content_mask.fade_out;
+
+    if (fade.left > 0.0) {
+        alpha *= saturate((position.x - bounds.origin.x) / fade.left);
+    }
+    if (fade.right > 0.0) {
+        alpha *= saturate((bounds.origin.x + bounds.size.x - position.x) / fade.right);
+    }
+    if (fade.top > 0.0) {
+        alpha *= saturate((position.y - bounds.origin.y) / fade.top);
+    }
+    if (fade.bottom > 0.0) {
+        alpha *= saturate((bounds.origin.y + bounds.size.y - position.y) / fade.bottom);
+    }
+
+    return alpha;
 }
 
 // https://gamedev.stackexchange.com/questions/92015/optimized-linear-to-srgb-glsl
@@ -482,7 +508,7 @@ struct Quad {
     order: u32,
     border_style: u32,
     bounds: Bounds,
-    content_mask: Bounds,
+    content_mask: ContentMask,
     background: Background,
     border_color: Hsla,
     corner_radii: Corners,
@@ -520,7 +546,7 @@ fn vs_quad(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) insta
     out.background_color1 = gradient.color1;
     out.border_color = hsla_to_rgba(quad.border_color);
     out.quad_id = instance_id;
-    out.clip_distances = distance_from_clip_rect(unit_vertex, quad.bounds, quad.content_mask);
+    out.clip_distances = distance_from_clip_rect(unit_vertex, quad.bounds, quad.content_mask.bounds);
     return out;
 }
 
@@ -532,6 +558,7 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
     }
 
     let quad = b_quads[input.quad_id];
+    let mask_alpha = content_mask_alpha(input.position.xy, quad.content_mask);
 
     let background_color = gradient_color(quad.background, input.position.xy, quad.bounds,
         input.background_solid, input.background_color0, input.background_color1);
@@ -547,7 +574,7 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
             quad.border_widths.right == 0.0 &&
             quad.border_widths.bottom == 0.0 &&
             unrounded) {
-        return blend_color(background_color, 1.0);
+        return blend_color(background_color, mask_alpha);
     }
 
     let size = quad.bounds.size;
@@ -852,7 +879,7 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
                     saturate(antialias_threshold - inner_sdf));
     }
 
-    return blend_color(color, saturate(antialias_threshold - outer_sdf));
+    return blend_color(color, saturate(antialias_threshold - outer_sdf) * mask_alpha);
 }
 
 // Returns the dash velocity of a corner given the dash velocity of the two
@@ -915,7 +942,7 @@ struct Shadow {
     blur_radius: f32,
     bounds: Bounds,
     corner_radii: Corners,
-    content_mask: Bounds,
+    content_mask: ContentMask,
     color: Hsla,
 }
 var<storage, read> b_shadows: array<Shadow>;
@@ -943,7 +970,7 @@ fn vs_shadow(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) ins
     out.position = to_device_position(unit_vertex, shadow.bounds);
     out.color = hsla_to_rgba(shadow.color);
     out.shadow_id = instance_id;
-    out.clip_distances = distance_from_clip_rect(unit_vertex, shadow.bounds, shadow.content_mask);
+    out.clip_distances = distance_from_clip_rect(unit_vertex, shadow.bounds, shadow.content_mask.bounds);
     return out;
 }
 
@@ -955,6 +982,7 @@ fn fs_shadow(input: ShadowVarying) -> @location(0) vec4<f32> {
     }
 
     let shadow = b_shadows[input.shadow_id];
+    let mask_alpha = content_mask_alpha(input.position.xy, shadow.content_mask);
     let half_size = shadow.bounds.size / 2.0;
     let center = shadow.bounds.origin + half_size;
     let center_to_point = input.position.xy - center;
@@ -978,7 +1006,7 @@ fn fs_shadow(input: ShadowVarying) -> @location(0) vec4<f32> {
         y += step;
     }
 
-    return blend_color(input.color, alpha);
+    return blend_color(input.color, alpha * mask_alpha);
 }
 
 // --- path rasterization --- //
@@ -988,6 +1016,7 @@ struct PathRasterizationVertex {
     st_position: vec2<f32>,
     color: Background,
     bounds: Bounds,
+    content_mask: ContentMask,
 }
 
 var<storage, read> b_path_vertices: array<PathRasterizationVertex>;
@@ -1021,6 +1050,7 @@ fn fs_path_rasterization(input: PathRasterizationVarying) -> @location(0) vec4<f
     }
 
     let v = b_path_vertices[input.vertex_id];
+    let mask_alpha = content_mask_alpha(input.position.xy, v.content_mask);
     let background = v.color;
     let bounds = v.bounds;
 
@@ -1042,7 +1072,7 @@ fn fs_path_rasterization(input: PathRasterizationVarying) -> @location(0) vec4<f
     );
     let color = gradient_color(background, input.position.xy, bounds,
         gradient_color.solid, gradient_color.color0, gradient_color.color1);
-    return vec4<f32>(color.rgb * color.a * alpha, color.a * alpha);
+    return vec4<f32>(color.rgb * color.a * alpha * mask_alpha, color.a * alpha * mask_alpha);
 }
 
 // --- paths --- //
@@ -1086,7 +1116,7 @@ struct Underline {
     order: u32,
     pad: u32,
     bounds: Bounds,
-    content_mask: Bounds,
+    content_mask: ContentMask,
     color: Hsla,
     thickness: f32,
     wavy: u32,
@@ -1110,7 +1140,7 @@ fn vs_underline(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) 
     out.position = to_device_position(unit_vertex, underline.bounds);
     out.color = hsla_to_rgba(underline.color);
     out.underline_id = instance_id;
-    out.clip_distances = distance_from_clip_rect(unit_vertex, underline.bounds, underline.content_mask);
+    out.clip_distances = distance_from_clip_rect(unit_vertex, underline.bounds, underline.content_mask.bounds);
     return out;
 }
 
@@ -1125,9 +1155,10 @@ fn fs_underline(input: UnderlineVarying) -> @location(0) vec4<f32> {
     }
 
     let underline = b_underlines[input.underline_id];
+    let mask_alpha = content_mask_alpha(input.position.xy, underline.content_mask);
     if ((underline.wavy & 0xFFu) == 0u)
     {
-        return blend_color(input.color, input.color.a);
+        return blend_color(input.color, input.color.a * mask_alpha);
     }
 
     let half_thickness = underline.thickness * 0.5;
@@ -1143,7 +1174,7 @@ fn fs_underline(input: UnderlineVarying) -> @location(0) vec4<f32> {
     let distance_from_top_border = distance_in_pixels - half_thickness;
     let distance_from_bottom_border = distance_in_pixels + half_thickness;
     let alpha = saturate(0.5 - max(-distance_from_bottom_border, distance_from_top_border));
-    return blend_color(input.color, alpha * input.color.a);
+    return blend_color(input.color, alpha * input.color.a * mask_alpha);
 }
 
 // --- monochrome sprites --- //
@@ -1152,7 +1183,7 @@ struct MonochromeSprite {
     order: u32,
     pad: u32,
     bounds: Bounds,
-    content_mask: Bounds,
+    content_mask: ContentMask,
     color: Hsla,
     tile: AtlasTile,
     transformation: TransformationMatrix,
@@ -1163,6 +1194,7 @@ struct MonoSpriteVarying {
     @builtin(position) position: vec4<f32>,
     @location(0) tile_position: vec2<f32>,
     @location(1) @interpolate(flat) color: vec4<f32>,
+    @location(2) @interpolate(flat) sprite_id: u32,
     @location(3) clip_distances: vec4<f32>,
 }
 
@@ -1176,7 +1208,8 @@ fn vs_mono_sprite(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index
 
     out.tile_position = to_tile_position(unit_vertex, sprite.tile);
     out.color = hsla_to_rgba(sprite.color);
-    out.clip_distances = distance_from_clip_rect_transformed(unit_vertex, sprite.bounds, sprite.content_mask, sprite.transformation);
+    out.sprite_id = instance_id;
+    out.clip_distances = distance_from_clip_rect_transformed(unit_vertex, sprite.bounds, sprite.content_mask.bounds, sprite.transformation);
     return out;
 }
 
@@ -1190,8 +1223,11 @@ fn fs_mono_sprite(input: MonoSpriteVarying) -> @location(0) vec4<f32> {
         return vec4<f32>(0.0);
     }
 
+    let sprite = b_mono_sprites[input.sprite_id];
+    let mask_alpha = content_mask_alpha(input.position.xy, sprite.content_mask);
+
     // convert to srgb space as the rest of the code (output swapchain) expects that
-    return blend_color(input.color, alpha_corrected);
+    return blend_color(input.color, alpha_corrected * mask_alpha);
 }
 
 // --- polychrome sprites --- //
@@ -1202,7 +1238,7 @@ struct PolychromeSprite {
     grayscale: u32,
     opacity: f32,
     bounds: Bounds,
-    content_mask: Bounds,
+    content_mask: ContentMask,
     corner_radii: Corners,
     tile: AtlasTile,
 }
@@ -1224,7 +1260,7 @@ fn vs_poly_sprite(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index
     out.position = to_device_position(unit_vertex, sprite.bounds);
     out.tile_position = to_tile_position(unit_vertex, sprite.tile);
     out.sprite_id = instance_id;
-    out.clip_distances = distance_from_clip_rect(unit_vertex, sprite.bounds, sprite.content_mask);
+    out.clip_distances = distance_from_clip_rect(unit_vertex, sprite.bounds, sprite.content_mask.bounds);
     return out;
 }
 
@@ -1238,20 +1274,21 @@ fn fs_poly_sprite(input: PolySpriteVarying) -> @location(0) vec4<f32> {
 
     let sprite = b_poly_sprites[input.sprite_id];
     let distance = quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
+    let mask_alpha = content_mask_alpha(input.position.xy, sprite.content_mask);
 
     var color = sample;
     if ((sprite.grayscale & 0xFFu) != 0u) {
         let grayscale = dot(color.rgb, GRAYSCALE_FACTORS);
         color = vec4<f32>(vec3<f32>(grayscale), sample.a);
     }
-    return blend_color(color, sprite.opacity * saturate(0.5 - distance));
+    return blend_color(color, sprite.opacity * saturate(0.5 - distance) * mask_alpha);
 }
 
 // --- surfaces --- //
 
 struct SurfaceParams {
     bounds: Bounds,
-    content_mask: Bounds,
+    content_mask: ContentMask,
 }
 
 var<uniform> surface_locals: SurfaceParams;
@@ -1279,7 +1316,7 @@ fn vs_surface(@builtin(vertex_index) vertex_id: u32) -> SurfaceVarying {
     var out = SurfaceVarying();
     out.position = to_device_position(unit_vertex, surface_locals.bounds);
     out.texture_position = unit_vertex;
-    out.clip_distances = distance_from_clip_rect(unit_vertex, surface_locals.bounds, surface_locals.content_mask);
+    out.clip_distances = distance_from_clip_rect(unit_vertex, surface_locals.bounds, surface_locals.content_mask.bounds);
     return out;
 }
 
@@ -1294,6 +1331,6 @@ fn fs_surface(input: SurfaceVarying) -> @location(0) vec4<f32> {
         textureSampleLevel(t_y, s_surface, input.texture_position, 0.0).r,
         textureSampleLevel(t_cb_cr, s_surface, input.texture_position, 0.0).rg,
         1.0);
-
-    return ycbcr_to_RGB * y_cb_cr;
+    let mask_alpha = content_mask_alpha(input.position.xy, surface_locals.content_mask);
+    return blend_color(ycbcr_to_RGB * y_cb_cr, mask_alpha);
 }

--- a/src/platform/mac/metal_renderer.rs
+++ b/src/platform/mac/metal_renderer.rs
@@ -125,6 +125,7 @@ pub struct PathRasterizationVertex {
     pub st_position: Point<f32>,
     pub color: Background,
     pub bounds: Bounds<ScaledPixels>,
+    pub content_mask: ContentMask<ScaledPixels>,
 }
 
 impl MetalRenderer {
@@ -600,6 +601,7 @@ impl MetalRenderer {
                 st_position: v.st_position,
                 color: path.color,
                 bounds: path.bounds.intersect(&path.content_mask.bounds),
+                content_mask: path.content_mask.clone(),
             }));
         }
         let vertices_bytes_len = mem::size_of_val(vertices.as_slice());

--- a/src/platform/mac/shaders.metal
+++ b/src/platform/mac/shaders.metal
@@ -101,6 +101,27 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
                               constant Quad *quads
                               [[buffer(QuadInputIndex_Quads)]]) {
   Quad quad = quads[input.quad_id];
+  float mask_alpha = 1.0;
+  if (quad.content_mask.fade_out.left > 0.0) {
+    mask_alpha *= saturate(
+      (input.position.x - quad.content_mask.bounds.origin.x) /
+      quad.content_mask.fade_out.left);
+  }
+  if (quad.content_mask.fade_out.right > 0.0) {
+    mask_alpha *= saturate(
+      (quad.content_mask.bounds.origin.x + quad.content_mask.bounds.size.width - input.position.x) /
+      quad.content_mask.fade_out.right);
+  }
+  if (quad.content_mask.fade_out.top > 0.0) {
+    mask_alpha *= saturate(
+      (input.position.y - quad.content_mask.bounds.origin.y) /
+      quad.content_mask.fade_out.top);
+  }
+  if (quad.content_mask.fade_out.bottom > 0.0) {
+    mask_alpha *= saturate(
+      (quad.content_mask.bounds.origin.y + quad.content_mask.bounds.size.height - input.position.y) /
+      quad.content_mask.fade_out.bottom);
+  }
   float4 background_color = fill_color(quad.background, input.position.xy, quad.bounds,
     input.background_solid, input.background_color0, input.background_color1);
 
@@ -115,7 +136,7 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
       quad.border_widths.right == 0.0 &&
       quad.border_widths.bottom == 0.0 &&
       unrounded) {
-    return background_color;
+    return background_color * float4(1.0, 1.0, 1.0, mask_alpha);
   }
 
   float2 size = float2(quad.bounds.size.width, quad.bounds.size.height);
@@ -175,7 +196,7 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
 
   // Fast path for points that must be part of the background
   if (is_within_inner_straight_border && !is_near_rounded_corner) {
-    return background_color;
+    return background_color * float4(1.0, 1.0, 1.0, mask_alpha);
   }
 
   // Signed distance of the point to the outside edge of the quad's border
@@ -393,7 +414,7 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
                 saturate(antialias_threshold - inner_sdf));
   }
 
-  return color * float4(1.0, 1.0, 1.0, saturate(antialias_threshold - outer_sdf));
+  return color * float4(1.0, 1.0, 1.0, saturate(antialias_threshold - outer_sdf) * mask_alpha);
 }
 
 // Returns the dash velocity of a corner given the dash velocity of the two
@@ -494,6 +515,27 @@ fragment float4 shadow_fragment(ShadowFragmentInput input [[stage_in]],
                                 constant Shadow *shadows
                                 [[buffer(ShadowInputIndex_Shadows)]]) {
   Shadow shadow = shadows[input.shadow_id];
+  float mask_alpha = 1.0;
+  if (shadow.content_mask.fade_out.left > 0.0) {
+    mask_alpha *= saturate(
+      (input.position.x - shadow.content_mask.bounds.origin.x) /
+      shadow.content_mask.fade_out.left);
+  }
+  if (shadow.content_mask.fade_out.right > 0.0) {
+    mask_alpha *= saturate(
+      (shadow.content_mask.bounds.origin.x + shadow.content_mask.bounds.size.width - input.position.x) /
+      shadow.content_mask.fade_out.right);
+  }
+  if (shadow.content_mask.fade_out.top > 0.0) {
+    mask_alpha *= saturate(
+      (input.position.y - shadow.content_mask.bounds.origin.y) /
+      shadow.content_mask.fade_out.top);
+  }
+  if (shadow.content_mask.fade_out.bottom > 0.0) {
+    mask_alpha *= saturate(
+      (shadow.content_mask.bounds.origin.y + shadow.content_mask.bounds.size.height - input.position.y) /
+      shadow.content_mask.fade_out.bottom);
+  }
 
   float2 origin = float2(shadow.bounds.origin.x, shadow.bounds.origin.y);
   float2 size = float2(shadow.bounds.size.width, shadow.bounds.size.height);
@@ -538,7 +580,7 @@ fragment float4 shadow_fragment(ShadowFragmentInput input [[stage_in]],
     }
   }
 
-  return input.color * float4(1., 1., 1., alpha);
+  return input.color * float4(1., 1., 1., alpha * mask_alpha);
 }
 
 struct UnderlineVertexOutput {
@@ -581,6 +623,27 @@ fragment float4 underline_fragment(UnderlineFragmentInput input [[stage_in]],
   const float WAVE_HEIGHT_RATIO = 0.8;
 
   Underline underline = underlines[input.underline_id];
+  float mask_alpha = 1.0;
+  if (underline.content_mask.fade_out.left > 0.0) {
+    mask_alpha *= saturate(
+      (input.position.x - underline.content_mask.bounds.origin.x) /
+      underline.content_mask.fade_out.left);
+  }
+  if (underline.content_mask.fade_out.right > 0.0) {
+    mask_alpha *= saturate(
+      (underline.content_mask.bounds.origin.x + underline.content_mask.bounds.size.width - input.position.x) /
+      underline.content_mask.fade_out.right);
+  }
+  if (underline.content_mask.fade_out.top > 0.0) {
+    mask_alpha *= saturate(
+      (input.position.y - underline.content_mask.bounds.origin.y) /
+      underline.content_mask.fade_out.top);
+  }
+  if (underline.content_mask.fade_out.bottom > 0.0) {
+    mask_alpha *= saturate(
+      (underline.content_mask.bounds.origin.y + underline.content_mask.bounds.size.height - input.position.y) /
+      underline.content_mask.fade_out.bottom);
+  }
   if (underline.wavy) {
     float half_thickness = underline.thickness * 0.5;
     float2 origin =
@@ -599,13 +662,14 @@ fragment float4 underline_fragment(UnderlineFragmentInput input [[stage_in]],
     float distance_from_bottom_border = distance_in_pixels + half_thickness;
     float alpha = saturate(
         0.5 - max(-distance_from_bottom_border, distance_from_top_border));
-    return input.color * float4(1., 1., 1., alpha);
+    return input.color * float4(1., 1., 1., alpha * mask_alpha);
   } else {
-    return input.color;
+    return input.color * float4(1., 1., 1., mask_alpha);
   }
 }
 
 struct MonochromeSpriteVertexOutput {
+  uint sprite_id [[flat]];
   float4 position [[position]];
   float2 tile_position;
   float4 color [[flat]];
@@ -613,6 +677,7 @@ struct MonochromeSpriteVertexOutput {
 };
 
 struct MonochromeSpriteFragmentInput {
+  uint sprite_id [[flat]];
   float4 position [[position]];
   float2 tile_position;
   float4 color [[flat]];
@@ -636,6 +701,7 @@ vertex MonochromeSpriteVertexOutput monochrome_sprite_vertex(
   float2 tile_position = to_tile_position(unit_vertex, sprite.tile, atlas_size);
   float4 color = hsla_to_rgba(sprite.color);
   return MonochromeSpriteVertexOutput{
+      sprite_id,
       device_position,
       tile_position,
       color,
@@ -655,7 +721,30 @@ fragment float4 monochrome_sprite_fragment(
   float4 sample =
       atlas_texture.sample(atlas_texture_sampler, input.tile_position);
   float4 color = input.color;
+  MonochromeSprite sprite = sprites[input.sprite_id];
+  float mask_alpha = 1.0;
+  if (sprite.content_mask.fade_out.left > 0.0) {
+    mask_alpha *= saturate(
+      (input.position.x - sprite.content_mask.bounds.origin.x) /
+      sprite.content_mask.fade_out.left);
+  }
+  if (sprite.content_mask.fade_out.right > 0.0) {
+    mask_alpha *= saturate(
+      (sprite.content_mask.bounds.origin.x + sprite.content_mask.bounds.size.width - input.position.x) /
+      sprite.content_mask.fade_out.right);
+  }
+  if (sprite.content_mask.fade_out.top > 0.0) {
+    mask_alpha *= saturate(
+      (input.position.y - sprite.content_mask.bounds.origin.y) /
+      sprite.content_mask.fade_out.top);
+  }
+  if (sprite.content_mask.fade_out.bottom > 0.0) {
+    mask_alpha *= saturate(
+      (sprite.content_mask.bounds.origin.y + sprite.content_mask.bounds.size.height - input.position.y) /
+      sprite.content_mask.fade_out.bottom);
+  }
   color.a *= sample.a;
+  color.a *= mask_alpha;
   return color;
 }
 
@@ -700,6 +789,27 @@ fragment float4 polychrome_sprite_fragment(
     constant PolychromeSprite *sprites [[buffer(SpriteInputIndex_Sprites)]],
     texture2d<float> atlas_texture [[texture(SpriteInputIndex_AtlasTexture)]]) {
   PolychromeSprite sprite = sprites[input.sprite_id];
+  float mask_alpha = 1.0;
+  if (sprite.content_mask.fade_out.left > 0.0) {
+    mask_alpha *= saturate(
+      (input.position.x - sprite.content_mask.bounds.origin.x) /
+      sprite.content_mask.fade_out.left);
+  }
+  if (sprite.content_mask.fade_out.right > 0.0) {
+    mask_alpha *= saturate(
+      (sprite.content_mask.bounds.origin.x + sprite.content_mask.bounds.size.width - input.position.x) /
+      sprite.content_mask.fade_out.right);
+  }
+  if (sprite.content_mask.fade_out.top > 0.0) {
+    mask_alpha *= saturate(
+      (input.position.y - sprite.content_mask.bounds.origin.y) /
+      sprite.content_mask.fade_out.top);
+  }
+  if (sprite.content_mask.fade_out.bottom > 0.0) {
+    mask_alpha *= saturate(
+      (sprite.content_mask.bounds.origin.y + sprite.content_mask.bounds.size.height - input.position.y) /
+      sprite.content_mask.fade_out.bottom);
+  }
   constexpr sampler atlas_texture_sampler(mag_filter::linear,
                                           min_filter::linear);
   float4 sample =
@@ -714,7 +824,7 @@ fragment float4 polychrome_sprite_fragment(
     color.g = grayscale;
     color.b = grayscale;
   }
-  color.a *= sprite.opacity * saturate(0.5 - distance);
+  color.a *= sprite.opacity * saturate(0.5 - distance) * mask_alpha;
   return color;
 }
 
@@ -764,6 +874,27 @@ fragment float4 path_rasterization_fragment(
   float2 dy = dfdy(input.st_position);
 
   PathRasterizationVertex v = vertices[input.vertex_id];
+  float mask_alpha = 1.0;
+  if (v.content_mask.fade_out.left > 0.0) {
+    mask_alpha *= saturate(
+      (input.position.x - v.content_mask.bounds.origin.x) /
+      v.content_mask.fade_out.left);
+  }
+  if (v.content_mask.fade_out.right > 0.0) {
+    mask_alpha *= saturate(
+      (v.content_mask.bounds.origin.x + v.content_mask.bounds.size.width - input.position.x) /
+      v.content_mask.fade_out.right);
+  }
+  if (v.content_mask.fade_out.top > 0.0) {
+    mask_alpha *= saturate(
+      (input.position.y - v.content_mask.bounds.origin.y) /
+      v.content_mask.fade_out.top);
+  }
+  if (v.content_mask.fade_out.bottom > 0.0) {
+    mask_alpha *= saturate(
+      (v.content_mask.bounds.origin.y + v.content_mask.bounds.size.height - input.position.y) /
+      v.content_mask.fade_out.bottom);
+  }
   Background background = v.color;
   Bounds_ScaledPixels path_bounds = v.bounds;
   float alpha;
@@ -795,7 +926,10 @@ fragment float4 path_rasterization_fragment(
     gradient_color.color0,
     gradient_color.color1
   );
-  return float4(color.rgb * color.a * alpha, alpha * color.a);
+  return float4(
+    color.rgb * color.a * alpha * mask_alpha,
+    alpha * color.a * mask_alpha
+  );
 }
 
 struct PathSpriteVertexOutput {
@@ -835,12 +969,14 @@ fragment float4 path_sprite_fragment(
 }
 
 struct SurfaceVertexOutput {
+  uint surface_id [[flat]];
   float4 position [[position]];
   float2 texture_position;
   float clip_distance [[clip_distance]][4];
 };
 
 struct SurfaceFragmentInput {
+  uint surface_id [[flat]];
   float4 position [[position]];
   float2 texture_position;
 };
@@ -863,12 +999,15 @@ vertex SurfaceVertexOutput surface_vertex(
   // to the current vertex of the unit triangle.
   float2 texture_position = unit_vertex;
   return SurfaceVertexOutput{
+      surface_id,
       device_position,
       texture_position,
       {clip_distance.x, clip_distance.y, clip_distance.z, clip_distance.w}};
 }
 
 fragment float4 surface_fragment(SurfaceFragmentInput input [[stage_in]],
+                                 constant SurfaceBounds *surfaces
+                                 [[buffer(SurfaceInputIndex_Surfaces)]],
                                  texture2d<float> y_texture
                                  [[texture(SurfaceInputIndex_YTexture)]],
                                  texture2d<float> cb_cr_texture
@@ -882,8 +1021,32 @@ fragment float4 surface_fragment(SurfaceFragmentInput input [[stage_in]],
   float4 ycbcr = float4(
       y_texture.sample(texture_sampler, input.texture_position).r,
       cb_cr_texture.sample(texture_sampler, input.texture_position).rg, 1.0);
+  SurfaceBounds surface = surfaces[input.surface_id];
+  float mask_alpha = 1.0;
+  if (surface.content_mask.fade_out.left > 0.0) {
+    mask_alpha *= saturate(
+      (input.position.x - surface.content_mask.bounds.origin.x) /
+      surface.content_mask.fade_out.left);
+  }
+  if (surface.content_mask.fade_out.right > 0.0) {
+    mask_alpha *= saturate(
+      (surface.content_mask.bounds.origin.x + surface.content_mask.bounds.size.width - input.position.x) /
+      surface.content_mask.fade_out.right);
+  }
+  if (surface.content_mask.fade_out.top > 0.0) {
+    mask_alpha *= saturate(
+      (input.position.y - surface.content_mask.bounds.origin.y) /
+      surface.content_mask.fade_out.top);
+  }
+  if (surface.content_mask.fade_out.bottom > 0.0) {
+    mask_alpha *= saturate(
+      (surface.content_mask.bounds.origin.y + surface.content_mask.bounds.size.height - input.position.y) /
+      surface.content_mask.fade_out.bottom);
+  }
 
-  return ycbcrToRGBTransform * ycbcr;
+  float4 color = ycbcrToRGBTransform * ycbcr;
+  color.a *= mask_alpha;
+  return color;
 }
 
 float4 hsla_to_rgba(Hsla hsla) {

--- a/src/platform/windows/directx_renderer.rs
+++ b/src/platform/windows/directx_renderer.rs
@@ -3,8 +3,8 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
-use ::util::ResultExt;
 use anyhow::{Context, Result};
+use util::ResultExt;
 use windows::{
     Win32::{
         Foundation::HWND,
@@ -465,6 +465,7 @@ impl DirectXRenderer {
                 st_position: v.st_position,
                 color: path.color,
                 bounds: path.clipped_bounds(),
+                content_mask: path.content_mask,
             }));
         }
 
@@ -1008,6 +1009,7 @@ struct PathRasterizationSprite {
     st_position: Point<f32>,
     color: Background,
     bounds: Bounds<ScaledPixels>,
+    content_mask: ContentMask<ScaledPixels>,
 }
 
 #[derive(Clone, Copy)]

--- a/src/platform/windows/shaders.hlsl
+++ b/src/platform/windows/shaders.hlsl
@@ -29,6 +29,11 @@ struct Edges {
     float left;
 };
 
+struct ContentMask {
+    Bounds bounds;
+    Edges fade_out;
+};
+
 struct Hsla {
     float h;
     float s;
@@ -111,6 +116,25 @@ float4 distance_from_clip_rect_transformed(float2 unit_vertex, Bounds bounds, Bo
     float2 position = unit_vertex * bounds.size + bounds.origin;
     float2 transformed = mul(position, transformation.rotation_scale) + transformation.translation;
     return distance_from_clip_rect_impl(transformed, clip_bounds);
+}
+
+float content_mask_alpha(float2 position, ContentMask content_mask) {
+    float alpha = 1.0;
+
+    if (content_mask.fade_out.left > 0.0) {
+        alpha *= saturate((position.x - content_mask.bounds.origin.x) / content_mask.fade_out.left);
+    }
+    if (content_mask.fade_out.right > 0.0) {
+        alpha *= saturate((content_mask.bounds.origin.x + content_mask.bounds.size.x - position.x) / content_mask.fade_out.right);
+    }
+    if (content_mask.fade_out.top > 0.0) {
+        alpha *= saturate((position.y - content_mask.bounds.origin.y) / content_mask.fade_out.top);
+    }
+    if (content_mask.fade_out.bottom > 0.0) {
+        alpha *= saturate((content_mask.bounds.origin.y + content_mask.bounds.size.y - position.y) / content_mask.fade_out.bottom);
+    }
+
+    return alpha;
 }
 
 // Convert linear RGB to sRGB
@@ -463,7 +487,7 @@ struct Quad {
     uint order;
     uint border_style;
     Bounds bounds;
-    Bounds content_mask;
+    ContentMask content_mask;
     Background background;
     Hsla border_color;
     Corners corner_radii;
@@ -502,7 +526,7 @@ QuadVertexOutput quad_vertex(uint vertex_id: SV_VertexID, uint quad_id: SV_Insta
         quad.background.solid,
         quad.background.colors
     );
-    float4 clip_distance = distance_from_clip_rect(unit_vertex, quad.bounds, quad.content_mask);
+    float4 clip_distance = distance_from_clip_rect(unit_vertex, quad.bounds, quad.content_mask.bounds);
     float4 border_color = hsla_to_rgba(quad.border_color);
 
     QuadVertexOutput output;
@@ -518,6 +542,7 @@ QuadVertexOutput quad_vertex(uint vertex_id: SV_VertexID, uint quad_id: SV_Insta
 
 float4 quad_fragment(QuadFragmentInput input): SV_Target {
     Quad quad = quads[input.quad_id];
+    float mask_alpha = content_mask_alpha(input.position.xy, quad.content_mask);
     float4 background_color = gradient_color(quad.background, input.position.xy, quad.bounds,
     input.background_solid, input.background_color0, input.background_color1);
 
@@ -532,7 +557,7 @@ float4 quad_fragment(QuadFragmentInput input): SV_Target {
         quad.border_widths.right == 0.0 &&
         quad.border_widths.bottom == 0.0 &&
         unrounded) {
-        return background_color;
+        return background_color * float4(1.0, 1.0, 1.0, mask_alpha);
     }
 
     float2 size = quad.bounds.size;
@@ -804,7 +829,7 @@ float4 quad_fragment(QuadFragmentInput input): SV_Target {
                     saturate(antialias_threshold - inner_sdf));
     }
 
-    return color * float4(1.0, 1.0, 1.0, saturate(antialias_threshold - outer_sdf));
+    return color * float4(1.0, 1.0, 1.0, saturate(antialias_threshold - outer_sdf) * mask_alpha);
 }
 
 /*
@@ -818,7 +843,7 @@ struct Shadow {
     float blur_radius;
     Bounds bounds;
     Corners corner_radii;
-    Bounds content_mask;
+    ContentMask content_mask;
     Hsla color;
 };
 
@@ -847,7 +872,7 @@ ShadowVertexOutput shadow_vertex(uint vertex_id: SV_VertexID, uint shadow_id: SV
     bounds.size += 2.0 * margin;
 
     float4 device_position = to_device_position(unit_vertex, bounds);
-    float4 clip_distance = distance_from_clip_rect(unit_vertex, bounds, shadow.content_mask);
+    float4 clip_distance = distance_from_clip_rect(unit_vertex, bounds, shadow.content_mask.bounds);
     float4 color = hsla_to_rgba(shadow.color);
 
     ShadowVertexOutput output;
@@ -861,6 +886,7 @@ ShadowVertexOutput shadow_vertex(uint vertex_id: SV_VertexID, uint shadow_id: SV
 
 float4 shadow_fragment(ShadowFragmentInput input): SV_TARGET {
     Shadow shadow = shadows[input.shadow_id];
+    float mask_alpha = content_mask_alpha(input.position.xy, shadow.content_mask);
 
     float2 half_size = shadow.bounds.size / 2.;
     float2 center = shadow.bounds.origin + half_size;
@@ -884,7 +910,7 @@ float4 shadow_fragment(ShadowFragmentInput input): SV_TARGET {
         y += step;
     }
 
-    return input.color * float4(1., 1., 1., alpha);
+    return input.color * float4(1., 1., 1., alpha * mask_alpha);
 }
 
 /*
@@ -898,6 +924,7 @@ struct PathRasterizationSprite {
     float2 st_position;
     Background color;
     Bounds bounds;
+    ContentMask content_mask;
 };
 
 StructuredBuffer<PathRasterizationSprite> path_rasterization_sprites: register(t1);
@@ -931,6 +958,7 @@ float4 path_rasterization_fragment(PathFragmentInput input): SV_Target {
     float2 dx = ddx(input.st_position);
     float2 dy = ddy(input.st_position);
     PathRasterizationSprite sprite = path_rasterization_sprites[input.vertex_id];
+    float mask_alpha = content_mask_alpha(input.position.xy, sprite.content_mask);
 
     Background background = sprite.color;
     Bounds bounds = sprite.bounds;
@@ -950,7 +978,10 @@ float4 path_rasterization_fragment(PathFragmentInput input): SV_Target {
 
     float4 color = gradient_color(background, input.position.xy, bounds,
         gradient.solid, gradient.color0, gradient.color1);
-    return float4(color.rgb * color.a * alpha, alpha * color.a);
+    return float4(
+        color.rgb * color.a * alpha * mask_alpha,
+        alpha * color.a * mask_alpha
+    );
 }
 
 /*
@@ -1000,7 +1031,7 @@ struct Underline {
     uint order;
     uint pad;
     Bounds bounds;
-    Bounds content_mask;
+    ContentMask content_mask;
     Hsla color;
     float thickness;
     uint wavy;
@@ -1026,7 +1057,7 @@ UnderlineVertexOutput underline_vertex(uint vertex_id: SV_VertexID, uint underli
     Underline underline = underlines[underline_id];
     float4 device_position = to_device_position(unit_vertex, underline.bounds);
     float4 clip_distance = distance_from_clip_rect(unit_vertex, underline.bounds,
-                                                    underline.content_mask);
+                                                    underline.content_mask.bounds);
     float4 color = hsla_to_rgba(underline.color);
 
     UnderlineVertexOutput output;
@@ -1042,6 +1073,7 @@ float4 underline_fragment(UnderlineFragmentInput input): SV_Target {
     const float WAVE_HEIGHT_RATIO = 0.8;
 
     Underline underline = underlines[input.underline_id];
+    float mask_alpha = content_mask_alpha(input.position.xy, underline.content_mask);
     if (underline.wavy) {
         float half_thickness = underline.thickness * 0.5;
         float2 origin = underline.bounds.origin;
@@ -1058,9 +1090,9 @@ float4 underline_fragment(UnderlineFragmentInput input): SV_Target {
         float distance_from_bottom_border = distance_in_pixels + half_thickness;
         float alpha = saturate(
             0.5 - max(-distance_from_bottom_border, distance_from_top_border));
-        return input.color * float4(1., 1., 1., alpha);
+        return input.color * float4(1., 1., 1., alpha * mask_alpha);
     } else {
-        return input.color;
+        return input.color * float4(1., 1., 1., mask_alpha);
     }
 }
 
@@ -1074,13 +1106,14 @@ struct MonochromeSprite {
     uint order;
     uint pad;
     Bounds bounds;
-    Bounds content_mask;
+    ContentMask content_mask;
     Hsla color;
     AtlasTile tile;
     TransformationMatrix transformation;
 };
 
 struct MonochromeSpriteVertexOutput {
+    nointerpolation uint sprite_id: TEXCOORD0;
     float4 position: SV_Position;
     float2 tile_position: POSITION;
     nointerpolation float4 color: COLOR;
@@ -1088,6 +1121,7 @@ struct MonochromeSpriteVertexOutput {
 };
 
 struct MonochromeSpriteFragmentInput {
+    nointerpolation uint sprite_id: TEXCOORD0;
     float4 position: SV_Position;
     float2 tile_position: POSITION;
     nointerpolation float4 color: COLOR;
@@ -1101,11 +1135,12 @@ MonochromeSpriteVertexOutput monochrome_sprite_vertex(uint vertex_id: SV_VertexI
     MonochromeSprite sprite = mono_sprites[sprite_id];
     float4 device_position =
         to_device_position_transformed(unit_vertex, sprite.bounds, sprite.transformation);
-    float4 clip_distance = distance_from_clip_rect_transformed(unit_vertex, sprite.bounds, sprite.content_mask, sprite.transformation);
+    float4 clip_distance = distance_from_clip_rect_transformed(unit_vertex, sprite.bounds, sprite.content_mask.bounds, sprite.transformation);
     float2 tile_position = to_tile_position(unit_vertex, sprite.tile);
     float4 color = hsla_to_rgba(sprite.color);
 
     MonochromeSpriteVertexOutput output;
+    output.sprite_id = sprite_id;
     output.position = device_position;
     output.tile_position = tile_position;
     output.color = color;
@@ -1114,9 +1149,11 @@ MonochromeSpriteVertexOutput monochrome_sprite_vertex(uint vertex_id: SV_VertexI
 }
 
 float4 monochrome_sprite_fragment(MonochromeSpriteFragmentInput input): SV_Target {
+    MonochromeSprite sprite = mono_sprites[input.sprite_id];
+    float mask_alpha = content_mask_alpha(input.position.xy, sprite.content_mask);
     float sample = t_sprite.Sample(s_sprite, input.tile_position).r;
     float alpha_corrected = apply_contrast_and_gamma_correction(sample, input.color.rgb, grayscale_enhanced_contrast, gamma_ratios);
-    return float4(input.color.rgb, input.color.a * alpha_corrected);
+    return float4(input.color.rgb, input.color.a * alpha_corrected * mask_alpha);
 }
 
 /*
@@ -1131,7 +1168,7 @@ struct PolychromeSprite {
     uint grayscale;
     float opacity;
     Bounds bounds;
-    Bounds content_mask;
+    ContentMask content_mask;
     Corners corner_radii;
     AtlasTile tile;
 };
@@ -1156,7 +1193,7 @@ PolychromeSpriteVertexOutput polychrome_sprite_vertex(uint vertex_id: SV_VertexI
     PolychromeSprite sprite = poly_sprites[sprite_id];
     float4 device_position = to_device_position(unit_vertex, sprite.bounds);
     float4 clip_distance = distance_from_clip_rect(unit_vertex, sprite.bounds,
-                                                    sprite.content_mask);
+                                                    sprite.content_mask.bounds);
     float2 tile_position = to_tile_position(unit_vertex, sprite.tile);
 
     PolychromeSpriteVertexOutput output;
@@ -1169,6 +1206,7 @@ PolychromeSpriteVertexOutput polychrome_sprite_vertex(uint vertex_id: SV_VertexI
 
 float4 polychrome_sprite_fragment(PolychromeSpriteFragmentInput input): SV_Target {
     PolychromeSprite sprite = poly_sprites[input.sprite_id];
+    float mask_alpha = content_mask_alpha(input.position.xy, sprite.content_mask);
     float4 sample = t_sprite.Sample(s_sprite, input.tile_position);
     float distance = quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
 
@@ -1177,6 +1215,6 @@ float4 polychrome_sprite_fragment(PolychromeSpriteFragmentInput input): SV_Targe
         float3 grayscale = dot(color.rgb, GRAYSCALE_FACTORS);
         color = float4(grayscale, sample.a);
     }
-    color.a *= sprite.opacity * saturate(0.5 - distance);
+    color.a *= sprite.opacity * saturate(0.5 - distance) * mask_alpha;
     return color;
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -152,6 +152,9 @@ pub struct Style {
     /// How children overflowing their container should affect layout
     #[refineable]
     pub overflow: Point<Overflow>,
+    /// Edge fade distances for overflow masking.
+    #[refineable]
+    pub overflow_fade: Edges<AbsoluteLength>,
     /// How much space (in points) should be reserved for the scrollbars of `Overflow::Scroll` and `Overflow::Auto` nodes.
     pub scrollbar_width: AbsoluteLength,
     /// Whether both x and y axis should be scrollable at the same time.
@@ -551,6 +554,9 @@ impl Style {
 
     /// Get the content mask for this element style, based on the given bounds.
     /// If the element does not hide its overflow, this will return `None`.
+    ///
+    /// Note: overflow fade is axis-aligned and evaluated in window space;
+    /// it is not transform-aware.
     pub fn overflow_mask(
         &self,
         bounds: Bounds<Pixels>,
@@ -595,7 +601,39 @@ impl Style {
                     (false, false) => Bounds::from_corners(min, max),
                 };
 
-                Some(ContentMask { bounds })
+                let mut fade_out = self.overflow_fade.to_pixels(rem_size);
+                if self.overflow.x == Overflow::Visible {
+                    fade_out.left = Pixels::ZERO;
+                    fade_out.right = Pixels::ZERO;
+                }
+                if self.overflow.y == Overflow::Visible {
+                    fade_out.top = Pixels::ZERO;
+                    fade_out.bottom = Pixels::ZERO;
+                }
+
+                let max_x = bounds.size.width.max(Pixels::ZERO);
+                let max_y = bounds.size.height.max(Pixels::ZERO);
+                fade_out.top = fade_out.top.clamp(Pixels::ZERO, max_y);
+                fade_out.right = fade_out.right.clamp(Pixels::ZERO, max_x);
+                fade_out.bottom = fade_out.bottom.clamp(Pixels::ZERO, max_y);
+                fade_out.left = fade_out.left.clamp(Pixels::ZERO, max_x);
+                let normalize_pair = |start: Pixels, end: Pixels, max: Pixels| {
+                    let total = start + end;
+                    if total > max && total > Pixels::ZERO {
+                        let scale = max.0 / total.0;
+                        (start * scale, end * scale)
+                    } else {
+                        (start, end)
+                    }
+                };
+                let (left, right) = normalize_pair(fade_out.left, fade_out.right, max_x);
+                fade_out.left = left;
+                fade_out.right = right;
+                let (top, bottom) = normalize_pair(fade_out.top, fade_out.bottom, max_y);
+                fade_out.top = top;
+                fade_out.bottom = bottom;
+
+                Some(ContentMask { bounds, fade_out })
             }
         }
     }
@@ -686,12 +724,19 @@ impl Style {
                 self.border_style,
             );
 
-            window.with_content_mask(Some(ContentMask { bounds: top_bounds }), |window| {
-                window.paint_quad(quad.clone());
-            });
+            window.with_content_mask(
+                Some(ContentMask {
+                    bounds: top_bounds,
+                    ..Default::default()
+                }),
+                |window| {
+                    window.paint_quad(quad.clone());
+                },
+            );
             window.with_content_mask(
                 Some(ContentMask {
                     bounds: right_bounds,
+                    ..Default::default()
                 }),
                 |window| {
                     window.paint_quad(quad.clone());
@@ -700,6 +745,7 @@ impl Style {
             window.with_content_mask(
                 Some(ContentMask {
                     bounds: bottom_bounds,
+                    ..Default::default()
                 }),
                 |window| {
                     window.paint_quad(quad.clone());
@@ -708,6 +754,7 @@ impl Style {
             window.with_content_mask(
                 Some(ContentMask {
                     bounds: left_bounds,
+                    ..Default::default()
                 }),
                 |window| {
                     window.paint_quad(quad);
@@ -737,6 +784,7 @@ impl Default for Style {
                 x: Overflow::Visible,
                 y: Overflow::Visible,
             },
+            overflow_fade: Edges::<AbsoluteLength>::zero(),
             allow_concurrent_scroll: false,
             restrict_scroll_to_axis: false,
             scrollbar_width: AbsoluteLength::default(),

--- a/src/styled.rs
+++ b/src/styled.rs
@@ -1,6 +1,6 @@
 use crate::{
     self as gpui, AbsoluteLength, AlignContent, AlignItems, BorderStyle, CursorStyle,
-    DefiniteLength, Display, Fill, FlexDirection, FlexWrap, Font, FontFeatures, FontStyle,
+    DefiniteLength, Display, Edges, Fill, FlexDirection, FlexWrap, Font, FontFeatures, FontStyle,
     FontWeight, GridPlacement, Hsla, JustifyContent, Length, SharedString, StrikethroughStyle,
     StyleRefinement, TextAlign, TextOverflow, TextStyleRefinement, UnderlineStyle, WhiteSpace, px,
     relative, rems,
@@ -123,6 +123,39 @@ pub trait Styled: Sized {
     /// [Docs](https://tailwindcss.com/docs/text-overflow#truncate)
     fn truncate(mut self) -> Self {
         self.overflow_hidden().whitespace_nowrap().text_ellipsis()
+    }
+
+    /// Sets per-edge fade distances for the overflow mask.
+    fn overflow_fade(mut self, fade: impl Into<Edges<AbsoluteLength>>) -> Self {
+        let fade = fade.into();
+        let overflow_fade = &mut self.style().overflow_fade;
+        overflow_fade.top = Some(fade.top);
+        overflow_fade.right = Some(fade.right);
+        overflow_fade.bottom = Some(fade.bottom);
+        overflow_fade.left = Some(fade.left);
+        self
+    }
+
+    /// Sets horizontal fade distances (left and right) for the overflow mask.
+    fn overflow_fade_x(mut self, fade: impl Into<AbsoluteLength>) -> Self {
+        let fade = fade.into();
+        let overflow_fade = &mut self.style().overflow_fade;
+        overflow_fade.top = Some(px(0.).into());
+        overflow_fade.right = Some(fade);
+        overflow_fade.bottom = Some(px(0.).into());
+        overflow_fade.left = Some(fade);
+        self
+    }
+
+    /// Sets vertical fade distances (top and bottom) for the overflow mask.
+    fn overflow_fade_y(mut self, fade: impl Into<AbsoluteLength>) -> Self {
+        let fade = fade.into();
+        let overflow_fade = &mut self.style().overflow_fade;
+        overflow_fade.top = Some(fade);
+        overflow_fade.right = Some(px(0.).into());
+        overflow_fade.bottom = Some(fade);
+        overflow_fade.left = Some(px(0.).into());
+        self
     }
 
     /// Sets number of lines to show before truncating the text.

--- a/src/window.rs
+++ b/src/window.rs
@@ -1333,11 +1333,15 @@ pub(crate) struct DispatchEventResult {
 /// Indicates which region of the window is visible. Content falling outside of this mask will not be
 /// rendered. Currently, only rectangular content masks are supported, but we give the mask its own type
 /// to leave room to support more complex shapes in the future.
+///
+/// `fade_out` is evaluated in window space against these axis-aligned bounds and is not transform-aware.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[repr(C)]
 pub struct ContentMask<P: Clone + Debug + Default + PartialEq> {
     /// The bounds
     pub bounds: Bounds<P>,
+    /// Edge fade distances. `0` means no fade for that edge.
+    pub fade_out: Edges<P>,
 }
 
 impl ContentMask<Pixels> {
@@ -1345,13 +1349,193 @@ impl ContentMask<Pixels> {
     pub fn scale(&self, factor: f32) -> ContentMask<ScaledPixels> {
         ContentMask {
             bounds: self.bounds.scale(factor),
+            fade_out: self.fade_out.scale(factor),
         }
     }
 
     /// Intersect the content mask with the given content mask.
     pub fn intersect(&self, other: &Self) -> Self {
         let bounds = self.bounds.intersect(&other.bounds);
-        ContentMask { bounds }
+
+        let left = if self.bounds.left() > other.bounds.left() {
+            self.fade_out.left
+        } else if other.bounds.left() > self.bounds.left() {
+            other.fade_out.left
+        } else {
+            self.fade_out.left.max(other.fade_out.left)
+        };
+
+        let top = if self.bounds.top() > other.bounds.top() {
+            self.fade_out.top
+        } else if other.bounds.top() > self.bounds.top() {
+            other.fade_out.top
+        } else {
+            self.fade_out.top.max(other.fade_out.top)
+        };
+
+        let right = if self.bounds.right() < other.bounds.right() {
+            self.fade_out.right
+        } else if other.bounds.right() < self.bounds.right() {
+            other.fade_out.right
+        } else {
+            self.fade_out.right.max(other.fade_out.right)
+        };
+
+        let bottom = if self.bounds.bottom() < other.bounds.bottom() {
+            self.fade_out.bottom
+        } else if other.bounds.bottom() < self.bounds.bottom() {
+            other.fade_out.bottom
+        } else {
+            self.fade_out.bottom.max(other.fade_out.bottom)
+        };
+
+        let max_x = bounds.size.width.max(Pixels::ZERO);
+        let max_y = bounds.size.height.max(Pixels::ZERO);
+        let mut top = top.clamp(Pixels::ZERO, max_y);
+        let mut right = right.clamp(Pixels::ZERO, max_x);
+        let mut bottom = bottom.clamp(Pixels::ZERO, max_y);
+        let mut left = left.clamp(Pixels::ZERO, max_x);
+        let normalize_pair = |start: Pixels, end: Pixels, max: Pixels| {
+            let total = start + end;
+            if total > max && total > Pixels::ZERO {
+                let scale = max.0 / total.0;
+                (start * scale, end * scale)
+            } else {
+                (start, end)
+            }
+        };
+        (left, right) = normalize_pair(left, right, max_x);
+        (top, bottom) = normalize_pair(top, bottom, max_y);
+        let fade_out = Edges {
+            top,
+            right,
+            bottom,
+            left,
+        };
+        ContentMask { bounds, fade_out }
+    }
+}
+
+#[cfg(test)]
+mod content_mask_tests {
+    use super::*;
+
+    fn mask(
+        origin_x: f32,
+        origin_y: f32,
+        width: f32,
+        height: f32,
+        fade_out: Edges<Pixels>,
+    ) -> ContentMask<Pixels> {
+        ContentMask {
+            bounds: Bounds {
+                origin: point(px(origin_x), px(origin_y)),
+                size: size(px(width), px(height)),
+            },
+            fade_out,
+        }
+    }
+
+    #[test]
+    fn intersect_drops_fade_when_that_edge_is_not_part_of_resulting_bounds() {
+        let outer = mask(
+            0.,
+            0.,
+            100.,
+            100.,
+            Edges {
+                top: px(0.),
+                right: px(0.),
+                bottom: px(0.),
+                left: px(20.),
+            },
+        );
+        let inner = mask(
+            30.,
+            0.,
+            40.,
+            100.,
+            Edges {
+                top: px(0.),
+                right: px(0.),
+                bottom: px(0.),
+                left: px(0.),
+            },
+        );
+
+        let combined = outer.intersect(&inner);
+        assert_eq!(combined.bounds.left(), px(30.));
+        assert_eq!(combined.fade_out.left, px(0.));
+    }
+
+    #[test]
+    fn intersect_keeps_fade_from_mask_that_defines_resulting_edge() {
+        let parent = mask(
+            0.,
+            0.,
+            200.,
+            100.,
+            Edges {
+                top: px(0.),
+                right: px(0.),
+                bottom: px(0.),
+                left: px(16.),
+            },
+        );
+        let child = mask(
+            0.,
+            0.,
+            120.,
+            100.,
+            Edges {
+                top: px(0.),
+                right: px(0.),
+                bottom: px(0.),
+                left: px(8.),
+            },
+        );
+
+        let combined = parent.intersect(&child);
+        assert_eq!(combined.bounds.left(), px(0.));
+        assert_eq!(combined.fade_out.left, px(16.));
+    }
+
+    #[test]
+    fn intersect_clamps_fade_to_resulting_bounds() {
+        let a = mask(
+            0.,
+            0.,
+            40.,
+            40.,
+            Edges {
+                top: px(200.),
+                right: px(200.),
+                bottom: px(200.),
+                left: px(200.),
+            },
+        );
+        let b = mask(
+            10.,
+            10.,
+            5.,
+            5.,
+            Edges {
+                top: px(200.),
+                right: px(200.),
+                bottom: px(200.),
+                left: px(200.),
+            },
+        );
+
+        let combined = a.intersect(&b);
+        assert_eq!(combined.bounds.size.width, px(5.));
+        assert_eq!(combined.bounds.size.height, px(5.));
+        assert_eq!(combined.fade_out.left + combined.fade_out.right, px(5.));
+        assert_eq!(combined.fade_out.top + combined.fade_out.bottom, px(5.));
+        assert_eq!(combined.fade_out.left, px(2.5));
+        assert_eq!(combined.fade_out.right, px(2.5));
+        assert_eq!(combined.fade_out.top, px(2.5));
+        assert_eq!(combined.fade_out.bottom, px(2.5));
     }
 }
 
@@ -2652,6 +2836,7 @@ impl Window {
                     origin: Point::default(),
                     size: self.viewport_size,
                 },
+                fade_out: Edges::default(),
             })
     }
 


### PR DESCRIPTION
## Summary

This update introduces per-edge overflow fade support for content masks via the `ContentMask.fade_out` method.  It also adds style APIs for controlling fade: `overflow_fade(...)`, `overflow_fade_x(...)`, and `overflow_fade_y(...)`.  These fade masks are propagated through list/uniform list rendering and all GPU backends (Blade, Metal, DirectX).  For quick visual verification, an example is provided in `examples/learn/overflow_fade.rs`.

## Context

This feature draws inspiration from the CSS `mask-image` fade-out pattern: https://pqina.nl/blog/fade-out-overflow-using-css-mask-image/

## Overflow Fade API

### Methods

```rust
fn overflow_fade(self, fade: impl Into<Edges<AbsoluteLength>>) -> Self
fn overflow_fade_x(self, fade: impl Into<AbsoluteLength>) -> Self
fn overflow_fade_y(self, fade: impl Into<AbsoluteLength>) -> Self
```

### Usage

Here's how to use the overflow fade API:

```rust
use gpui::{div, px, Edges, prelude::*};

// Vertical scroll with top/bottom fade
div()
    .overflow_y_scroll()
    .overflow_fade_y(px(16.));

// Horizontal scroll with left/right fade
div()
    .overflow_x_scroll()
    .overflow_fade_x(px(24.));

// Per-edge fade control
div()
    .overflow_y_scroll()
    .overflow_fade(Edges {
        top: px(8.).into(),
        right: px(0.).into(),
        bottom: px(20.).into(),
        left: px(0.).into(),
    });

// Bottom-only fade
div()
    .overflow_y_scroll()
    .overflow_fade(Edges {
        top: px(0.).into(),
        right: px(0.).into(),
        bottom: px(20.).into(),
        left: px(0.).into(),
    });
```

`overflow_fade_x(...)` and `overflow_fade_y(...)` are shorthand for left and right fades respectively, with the top and bottom set to 0.

## Demo

### macOS

https://github.com/user-attachments/assets/ff04999f-c52f-484e-bf8f-849f2b6d9248

### Windows

⌛

### Linux

⌛

## Notes

- Fades are axis-aligned and evaluated in window space.
- This is intended for overflow clipping and fading and is not transform-aware.
- Overflow fade uses CSS-style alpha mask composition.  Opposing edge fades are applied independently and then combined.  This means if fade regions overlap, like large left-right or top-bottom values, the centre may also dim.