### PR TITLE
fix gpui_window Window::zoom not restoring the window when already maximized

### DIFF
--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -860,14 +860,23 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn zoom(&self) {
-        unsafe {
-            if IsWindowVisible(self.0.hwnd).as_bool() {
-                ShowWindowAsync(self.0.hwnd, SW_MAXIMIZE).ok().log_err();
-            } else if let Some(mut status) = self.state.initial_placement.take() {
-                status.state = WindowOpenState::Maximized;
-                self.state.initial_placement.set(Some(status));
+        let is_visible = unsafe { IsWindowVisible(self.0.hwnd).as_bool() };
+        if !is_visible {
+            if let Some(mut status) = self.state.initial_placement.take() {
+            status.state = WindowOpenState::Maximized;
+            self.state.initial_placement.set(Some(status));
             }
+            return;
         }
+
+        let window_operation = if self.is_maximized() {
+       	    SW_RESTORE
+        }
+        else
+        {
+           SW_MAXIMIZE
+        };
+       	unsafe { ShowWindowAsync(self.0.hwnd, window_operation).ok().log_err(); }
     }
 
     fn toggle_fullscreen(&self) {


### PR DESCRIPTION
fixes https://github.com/gpui-ce/gpui-ce/issues/32

did i create 32 and then immediately fix it?... maybe... did i think the fix would be easy and I would have the time to do it right away?.... not really