### PR TITLE
Fix: gpui_web; update application lifecycle management for web platform

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -203,6 +203,12 @@ impl Application {
             let cx = &mut *this.borrow_mut();
             on_finish_launching(cx);
         }));
+
+        // Native platform run loops block until shutdown, keeping `self` alive for the
+        // application's lifetime. The web platform schedules startup and returns
+        // immediately, so retain the application until the browser tears down the page.
+        #[cfg(target_family = "wasm")]
+        std::mem::forget(self);
     }
 
     /// Register a handler to be invoked when the platform instructs the application

--- a/crates/gpui_web/examples/hello_web/Trunk.toml
+++ b/crates/gpui_web/examples/hello_web/Trunk.toml
@@ -1,0 +1,13 @@
+[build]
+locked = true
+no_sri = true
+
+[serve]
+addresses = ["127.0.0.1"]
+port = 8080
+open = true
+no_spa = true
+
+# Headers required for WebGPU / SharedArrayBuffer support. Disable caching so
+# browser reloads cannot retain references to removed hashed build artifacts.
+headers = { "Cache-Control" = "no-store", "Cross-Origin-Embedder-Policy" = "require-corp", "Cross-Origin-Opener-Policy" = "same-origin" }

--- a/crates/gpui_web/examples/hello_web/trunk.toml
+++ b/crates/gpui_web/examples/hello_web/trunk.toml
@@ -1,7 +1,0 @@
-[serve]
-addresses = ["127.0.0.1"]
-port = 8080
-open = true
-
-# Headers required for WebGPU / SharedArrayBuffer support.
-headers = { "Cross-Origin-Embedder-Policy" = "require-corp", "Cross-Origin-Opener-Policy" = "same-origin" }


### PR DESCRIPTION

<img width="1535" height="896" alt="image" src="https://github.com/user-attachments/assets/668470b1-a6fc-4e61-a855-7105c59f2e41" />


- web example fix
- trunk looks for Trunk.toml now instead of trunk.toml so renaming it