### PR TITLE
fix: borrow size in SurfaceSource Debug impl

### DIFF
--- a/crates/gpui/src/elements/surface.rs
+++ b/crates/gpui/src/elements/surface.rs
@@ -47,7 +47,7 @@ impl std::fmt::Debug for SurfaceSource {
             #[cfg(any(target_os = "linux", target_os = "freebsd"))]
             SurfaceSource::Texture { size, .. } => f
                 .debug_struct("Texture")
-                .field("size", size)
+                .field("size", &size)
                 .finish_non_exhaustive(),
         }
     }


### PR DESCRIPTION
# fix: borrow size in SurfaceSource Debug impl

Fix a type mismatch in the manual `Debug` implementation for `SurfaceSource` on Linux/FreeBSD.

`DebugStruct::field` expects `&dyn Debug`, but `size` was passed by value. Add `&` to borrow it.

This fixes a compile error introduced in #39.

