### PR TITLE
Fix compilation on Linux - add & to .field

### DIFF
--- a/crates/gpui/src/elements/surface.rs
+++ b/crates/gpui/src/elements/surface.rs
@@ -47,7 +47,7 @@ impl std::fmt::Debug for SurfaceSource {
             #[cfg(any(target_os = "linux", target_os = "freebsd"))]
             SurfaceSource::Texture { size, .. } => f
                 .debug_struct("Texture")
-                .field("size", size)
+                .field("size", &size)
                 .finish_non_exhaustive(),
         }
     }


### PR DESCRIPTION
```
error[E0308]: mismatched types
   --> crates/gpui/src/elements/surface.rs:50:32
    |
 50 |                 .field("size", size)
    |                  -----         ^^^^ expected `&dyn Debug`, found `Size<DevicePixels>`
    |                  |
    |                  arguments to this method are incorrect
    |
    = note: expected reference `&dyn std::fmt::Debug`
                  found struct `geometry::Size<geometry::DevicePixels>`
note: method defined here
   --> /home/sam-hollis/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/fmt/builders.rs:132:12
    |
132 |     pub fn field(&mut self, name: &str, value: &dyn fmt::Debug) -> &mut Self {
    |            ^^^^^
help: consider borrowing here
    |
 50 |                 .field("size", &size)
    |                                +
```

Fixes this compilation failure