### PR TITLE
gpui: Add gpu_device_lost() to query device-loss state on Linux

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -723,6 +723,17 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
         None
     }
 
+    /// Whether this window's GPU device has been lost (the platform renderer
+    /// recovers it on a subsequent draw). `None` when the backend cannot
+    /// know. Safe to call mid-recovery, unlike `gpu_context`. Embedders that
+    /// captured the device from `gpu_context` should stop submitting while
+    /// this is `Some(true)` and re-acquire the device once it reads
+    /// `Some(false)` again.
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    fn gpu_device_lost(&self) -> Option<bool> {
+        None
+    }
+
     fn update_ime_position(&self, _bounds: Bounds<Pixels>);
 
     fn play_system_bell(&self) {}

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -5516,6 +5516,16 @@ impl Window {
         self.platform_window.gpu_context()
     }
 
+    /// Whether the GPU device backing this window has been lost (recovery
+    /// happens on a subsequent platform draw). `None` when the backend
+    /// cannot know. Embedders that captured the device from
+    /// [`Self::gpu_context`] should stop submitting while this is
+    /// `Some(true)` and re-acquire the device once it reads `Some(false)`.
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    pub fn gpu_device_lost(&self) -> Option<bool> {
+        self.platform_window.gpu_device_lost()
+    }
+
     /// Perform titlebar double-click action.
     /// This is macOS specific.
     pub fn titlebar_double_click(&self) {

--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -1527,6 +1527,12 @@ impl PlatformWindow for WaylandWindow {
         Some(Box::new((device, queue)))
     }
 
+    fn gpu_device_lost(&self) -> Option<bool> {
+        // Only loads an atomic flag — safe even mid-recovery, when
+        // `gpu_context` would panic on the torn-down resources.
+        Some(self.borrow().renderer.device_lost())
+    }
+
     fn play_system_bell(&self) {
         let state = self.borrow();
         let surface = if state.surface_state.toplevel().is_some() {

--- a/crates/gpui_linux/src/linux/x11/window.rs
+++ b/crates/gpui_linux/src/linux/x11/window.rs
@@ -1901,6 +1901,12 @@ impl PlatformWindow for X11Window {
         Some(Box::new((device, queue)))
     }
 
+    fn gpu_device_lost(&self) -> Option<bool> {
+        // Only loads an atomic flag — safe even mid-recovery, when
+        // `gpu_context` would panic on the torn-down resources.
+        Some(self.0.state.borrow().renderer.device_lost())
+    }
+
     fn play_system_bell(&self) {
         // Volume 0% means don't increase or decrease from system volume
         let _ = self.0.xcb.bell(0);


### PR DESCRIPTION
PlatformWindow::gpu_device_lost() (default None) exposed via Window::gpu_device_lost(), implemented for Wayland/X11 from the renderer's existing device-lost atomic. Lets embedders that captured the device from gpu_context() stop submitting while the device is lost and re-acquire it after recovery - safe to call mid-recovery, unlike gpu_context().

Rationale: lets a wgpu surface element user detect when the GPU device is lost (e.g. on suspend) and re-init once it is available again.