### PR TITLE
Wayland input_region and exclusive_zone + WGPU panic fix

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -704,6 +704,7 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn start_window_move(&self) {}
     fn start_window_resize(&self, _edge: ResizeEdge) {}
     fn set_input_region(&self, _rects: &[Bounds<Pixels>]) {}
+    fn set_exclusive_zone(&self, _zone: Pixels) {}
     fn window_decorations(&self) -> Decorations {
         Decorations::Server
     }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -703,6 +703,7 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn show_window_menu(&self, _position: Point<Pixels>) {}
     fn start_window_move(&self) {}
     fn start_window_resize(&self, _edge: ResizeEdge) {}
+    fn set_input_region(&self, _rects: &[Bounds<Pixels>]) {}
     fn window_decorations(&self) -> Decorations {
         Decorations::Server
     }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1945,6 +1945,14 @@ impl Window {
         self.platform_window.request_decorations(decorations);
     }
 
+    /// Set the window's input region to the union of `rects`. Pointer events
+    /// outside the region pass through to whatever is below the window.
+    /// An empty slice resets the input region, so the window will receive all
+    /// pointer events again. (wayland only)
+    pub fn set_input_region(&self, rects: &[Bounds<Pixels>]) {
+        self.platform_window.set_input_region(rects);
+    }
+
     /// Start a window resize operation (Wayland)
     pub fn start_window_resize(&self, edge: ResizeEdge) {
         self.platform_window.start_window_resize(edge);

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1953,6 +1953,13 @@ impl Window {
         self.platform_window.set_input_region(rects);
     }
 
+    /// Controls how a surface interacts with surrounding screen space.
+    /// Positive values reserve space, 0 avoids reserved space, and -1 ignores
+    /// reserved space and may extend underneath other surfaces. (wayland only)
+    pub fn set_exclusive_zone(&self, zone: Pixels) {
+        self.platform_window.set_exclusive_zone(zone);
+    }
+
     /// Start a window resize operation (Wayland)
     pub fn start_window_resize(&self, edge: ResizeEdge) {
         self.platform_window.start_window_resize(edge);

--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -1488,14 +1488,17 @@ impl PlatformWindow for WaylandWindow {
                 .globals
                 .compositor
                 .create_region(&state.globals.qh, ());
-            for rect in rects {
-                region.add(
-                    f32::from(rect.origin.x) as i32,
-                    f32::from(rect.origin.y) as i32,
-                    f32::from(rect.size.width) as i32,
-                    f32::from(rect.size.height) as i32,
-                );
-            }
+            rects
+                .iter()
+                .map(|rect| rect.map(|pixels| f32::from(pixels) as i32))
+                .for_each(|rect| {
+                    region.add(
+                        rect.origin.x,
+                        rect.origin.y,
+                        rect.size.width,
+                        rect.size.height,
+                    )
+                });
             state.surface.set_input_region(Some(&region));
             region.destroy();
         }

--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -286,6 +286,14 @@ impl WaylandSurfaceState {
         }
     }
 
+    fn set_exclusive_zone(&self, zone: i32) {
+        if let WaylandSurfaceState::LayerShell(WaylandLayerSurfaceState { layer_surface, .. }) =
+            self
+        {
+            layer_surface.set_exclusive_zone(zone);
+        }
+    }
+
     fn destroy(&mut self) {
         match self {
             WaylandSurfaceState::Xdg(WaylandXdgSurfaceState {
@@ -1491,6 +1499,14 @@ impl PlatformWindow for WaylandWindow {
             state.surface.set_input_region(Some(&region));
             region.destroy();
         }
+        state.surface.commit();
+    }
+
+    fn set_exclusive_zone(&self, zone: Pixels) {
+        let state = self.borrow();
+        state
+            .surface_state
+            .set_exclusive_zone(f32::from(zone) as i32);
         state.surface.commit();
     }
 

--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -1471,6 +1471,29 @@ impl PlatformWindow for WaylandWindow {
         }
     }
 
+    fn set_input_region(&self, rects: &[Bounds<Pixels>]) {
+        let state = self.borrow();
+        if rects.is_empty() {
+            state.surface.set_input_region(None);
+        } else {
+            let region = state
+                .globals
+                .compositor
+                .create_region(&state.globals.qh, ());
+            for rect in rects {
+                region.add(
+                    f32::from(rect.origin.x) as i32,
+                    f32::from(rect.origin.y) as i32,
+                    f32::from(rect.size.width) as i32,
+                    f32::from(rect.size.height) as i32,
+                );
+            }
+            state.surface.set_input_region(Some(&region));
+            region.destroy();
+        }
+        state.surface.commit();
+    }
+
     fn window_decorations(&self) -> Decorations {
         let state = self.borrow();
         match state.decorations {

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -1189,7 +1189,9 @@ impl WgpuRenderer {
             self.surface_config.height = clamped_height.max(1);
             let surface_config = self.surface_config.clone();
 
-            let resources = self.resources_mut();
+            let Some(resources) = self.resources.as_mut() else {
+                return;
+            };
 
             // Wait for any in-flight GPU work to complete before destroying textures
             if let Err(e) = resources.device.poll(wgpu::PollType::Wait {

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -1189,6 +1189,7 @@ impl WgpuRenderer {
             self.surface_config.height = clamped_height.max(1);
             let surface_config = self.surface_config.clone();
 
+            // GPU resources may not exist yet, skip rather than panicking
             let Some(resources) = self.resources.as_mut() else {
                 return;
             };


### PR DESCRIPTION
This PR adds the option to update the input_region of wayland surfaces, and the exclusive_zone for layer shell surfaces. I also added a small fix in the WGPU renderer to prevent a possible panic.

### input_region

Clicks in green area can pass through the window, clicks in red area do not:

<img width="1057" height="395" alt="image" src="https://github.com/user-attachments/assets/85a89f5d-3791-40d2-af12-d650a87d0aed" />

### exclusive_zone

Allowing to update the exclusive zone makes it so applications don't have to create a new layer if they require less or more space. I need this for one of my apps :)

### WGPU panic fix

I didn't want to make a separate PR, so I'm throwing this in here: I ran into an issue where quickly creating and deleting windows would sometimes (often in debug) cause a panic which was caused because WGPU resources were not available yet, which previously caused a panic. I think this is hard to reproduce in a `--release` build because the resources are available faster there. This is probably easier to reproduce on a slower computer or with a debug build.