### PR TITLE
add App::emit such that events can be emitted without acquiring a Context

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -961,6 +961,24 @@ impl App {
         self.pending_updates -= 1;
     }
 
+    /// Emit an event of the specified type, which can be handled by other entities that have subscribed via `subscribe` methods on their respective contexts.
+    /// A globally-callable equivalent to `Context::emit` without requiring an entity update.
+    pub fn emit<EntityType, EventType>(&mut self, entity: &Entity<EntityType>, event: EventType)
+    where
+        EntityType: EventEmitter<EventType>,
+        EventType: 'static,
+    {
+        let event = self
+            .event_arena
+            .alloc(|| event)
+            .map(|it| it as &mut dyn Any);
+        self.pending_effects.push_back(Effect::Emit {
+            emitter: entity.entity_id(),
+            event_type: TypeId::of::<EventType>(),
+            event,
+        });
+    }
+
     /// Arrange a callback to be invoked when the given entity calls `notify` on its respective context.
     pub fn observe<W>(
         &mut self,

--- a/crates/gpui/src/app/context.rs
+++ b/crates/gpui/src/app/context.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AnyView, AnyWindowHandle, AppContext, AsyncApp, DispatchPhase, Effect, EntityId, EventEmitter,
+    AnyView, AnyWindowHandle, AppContext, AsyncApp, DispatchPhase, EntityId, EventEmitter,
     FocusHandle, FocusOutEvent, Focusable, Global, KeystrokeObserver, Priority, Reservation,
     SubscriberSet, Subscription, Task, WeakEntity, WeakFocusHandle, Window, WindowHandle,
 };
@@ -767,15 +767,7 @@ impl<T> Context<'_, T> {
         T: EventEmitter<Evt>,
         Evt: 'static,
     {
-        let event = self
-            .event_arena
-            .alloc(|| event)
-            .map(|it| it as &mut dyn Any);
-        self.app.pending_effects.push_back(Effect::Emit {
-            emitter: self.entity_state.entity_id,
-            event_type: TypeId::of::<Evt>(),
-            event,
-        });
+        self.app.emit(&self.entity(), event);
     }
 }
 


### PR DESCRIPTION
I would like to be able to send events on an entity channel without needing to actually update the entity. Otherwise I'd either have to open the entity for edit/update w/o reason for actually making a change, or utilize a messaging channel (e.g. async_channel) - which i have done but it seems redundant given that entities which are Emitters are themselves messaging channels.

Example use-cases:
https://codeberg.org/temportalflux/jjui/src/commit/026ab8a1dc8c4493305eef6722403ed8168b89c7/crates/app/src/app.rs#L156
https://codeberg.org/temportalflux/jjui/src/commit/026ab8a1dc8c4493305eef6722403ed8168b89c7/crates/app/src/view/repository_view.rs#L53
https://codeberg.org/temportalflux/jjui/src/commit/026ab8a1dc8c4493305eef6722403ed8168b89c7/crates/app/src/view/repository_view.rs#L67