### PR TITLE
Update windows dependency to 0.62.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.35.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53cf47daed85312e763fbf85ceca136e0d7abc68e0a7e12abe11f48172bc3b10"
+checksum = "f950720ce064757a1b629caad3a408e8d2c63bb01f29b8a3ff8daa331053ffeb"
 dependencies = [
  "accesskit",
  "hashbrown 0.16.1",
@@ -80,12 +80,12 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.32.1"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff7009f1a532e917d66970a1e80c965140c6cfbbabbdde3d64e5431e6c78e21"
+checksum = "36e93ac7bf50b964f1cbb75f741629a4e950571baa1ef1274457ab5a80d9bcc2"
 dependencies = [
  "accesskit",
- "accesskit_consumer 0.35.0",
+ "accesskit_consumer 0.37.0",
  "hashbrown 0.16.1",
  "static_assertions",
  "windows 0.62.2",
@@ -2497,7 +2497,7 @@ dependencies = [
  "waker-fn",
  "wasm-bindgen",
  "web-time",
- "windows 0.61.3",
+ "windows 0.62.2",
  "zed-font-kit",
  "zed-scap",
 ]
@@ -2812,9 +2812,9 @@ dependencies = [
  "raw-window-handle",
  "smallvec",
  "uuid",
- "windows 0.61.3",
- "windows-core 0.61.2",
- "windows-numerics 0.2.0",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "windows-numerics 0.3.1",
  "windows-registry",
  "zed-scap",
 ]
@@ -2858,7 +2858,7 @@ dependencies = [
  "url",
  "walkdir",
  "which",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -7264,13 +7264,13 @@ dependencies = [
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ readme = "README.md"
 accesskit = { version = "0.24.0", features = ["enumn"] }
 accesskit_macos = "0.26.0"
 accesskit_unix = "0.22.0"
-accesskit_windows = "0.32.1"
+accesskit_windows = "0.33.1"
 anyhow = "1.0.86"
 async-task = "4.7"
 backtrace = "0.3"
@@ -176,7 +176,7 @@ objc2-app-kit = { version = "0.3", default-features = false, features = [
   "NSWindow",
 ] }
 semver = { version = "1.0", features = ["serde"] }
-windows-core = "0.61"
+windows-core = "0.62.2"
 tokio = { version = "1" }
 gpui_util = { path = "crates/gpui_ce_util", version = "0.2.2", package = "gpui_ce_util" }
 
@@ -194,7 +194,7 @@ gpui_shared_string = { path = "./crates/gpui_shared_string/", version = "0.1.0" 
 gpui_tokio = { path = "./crates/gpui_tokio/", version = "0.1.0" }
 
 [workspace.dependencies.windows]
-version = "0.61"
+version = "0.62.2"
 features = [
   "Foundation_Numerics",
   "Globalization_DateTimeFormatting",

--- a/crates/gpui_windows/Cargo.toml
+++ b/crates/gpui_windows/Cargo.toml
@@ -40,12 +40,12 @@ smallvec.workspace = true
 uuid.workspace = true
 windows.workspace = true
 windows-core.workspace = true
-windows-numerics = "0.2"
-windows-registry = "0.5"
+windows-numerics = "0.3.1"
+windows-registry = "0.6.1"
 
 [target.'cfg(target_os = "windows")'.dependencies.scap]
 workspace = true
 optional = true
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
-windows-registry = "0.5"
+windows-registry = "0.6.1"


### PR DESCRIPTION
Unlocks the ability to access MoveWindow for https://github.com/gpui-ce/gpui-ce/issues/95