### PR TITLE
Added filtering options for WGPU Surface element

### DIFF
--- a/crates/gpui/src/elements/surface.rs
+++ b/crates/gpui/src/elements/surface.rs
@@ -1,6 +1,6 @@
 use crate::{
     App, Bounds, Element, ElementId, GlobalElementId, InspectorElementId, IntoElement, LayoutId,
-    ObjectFit, Pixels, Style, StyleRefinement, Styled, Window,
+    ObjectFit, Pixels, SamplerType, Style, StyleRefinement, Styled, Window,
 };
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use crate::{DevicePixels, Size};
@@ -65,6 +65,7 @@ pub struct Surface {
     source: SurfaceSource,
     object_fit: ObjectFit,
     style: StyleRefinement,
+    sampler_type: Option<SamplerType>,
 }
 
 /// Create a new surface element.
@@ -73,6 +74,7 @@ pub fn surface(source: impl Into<SurfaceSource>) -> Surface {
         source: source.into(),
         object_fit: ObjectFit::Contain,
         style: Default::default(),
+        sampler_type: None,
     }
 }
 
@@ -80,6 +82,11 @@ impl Surface {
     /// Set the object fit for the image.
     pub fn object_fit(mut self, object_fit: ObjectFit) -> Self {
         self.object_fit = object_fit;
+        self
+    }
+
+    pub fn sampler_type(mut self, sampler_type: SamplerType) -> Self {
+        self.sampler_type = Some(sampler_type);
         self
     }
 }
@@ -144,7 +151,7 @@ impl Element for Surface {
                 ref size,
             } => {
                 let new_bounds = self.object_fit.get_bounds(_bounds, *size);
-                _window.paint_surface(new_bounds, Arc::clone(texture), *size);
+                _window.paint_surface(new_bounds, Arc::clone(texture), *size, self.sampler_type);
             }
         }
     }

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -968,6 +968,14 @@ impl From<PolychromeSprite> for Primitive {
     }
 }
 
+#[repr(u32)]
+#[derive(Clone, Copy, Default, Debug)]
+pub enum SamplerType {
+    #[default]
+    Linear = 0,
+    Nearest = 1,
+}
+
 #[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct PaintSurface {
@@ -980,6 +988,8 @@ pub struct PaintSurface {
     pub texture: std::sync::Arc<dyn std::any::Any + Send + Sync>,
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     pub texture_size: Size<crate::DevicePixels>,
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    pub sampler_type: SamplerType,
 }
 
 impl From<PaintSurface> for Primitive {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1,5 +1,7 @@
 #[cfg(any(feature = "inspector", debug_assertions))]
 use crate::Inspector;
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
+use crate::SamplerType;
 use crate::{
     Action, AnyDrag, AnyElement, AnyImageCache, AnyTooltip, AnyView, App, AppContext, Arena, Asset,
     AsyncWindowContext, AtlasTile, AvailableSpace, BackdropFilter, Background, BorderStyle, Bounds,
@@ -4637,6 +4639,7 @@ impl Window {
         bounds: Bounds<Pixels>,
         texture: std::sync::Arc<dyn std::any::Any + Send + Sync>,
         texture_size: Size<DevicePixels>,
+        sampler_type: Option<SamplerType>,
     ) {
         use crate::PaintSurface;
 
@@ -4651,6 +4654,7 @@ impl Window {
             content_mask,
             texture,
             texture_size,
+            sampler_type: sampler_type.unwrap_or_default(),
         });
     }
 

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -167,6 +167,10 @@ struct TransformationMatrix {
     translation: vec2<f32>,
 }
 
+alias SamplerType = u32;
+const LINEAR_SAMPLER = 0;
+const NEAREST_SAMPLER = 1;
+
 fn to_device_position_impl(position: vec2<f32>) -> vec4<f32> {
     let device_position = position / globals.viewport_size * vec2<f32>(2.0, -2.0) + vec2<f32>(-1.0, 1.0);
     return vec4<f32>(device_position, 0.0, 1.0);
@@ -1317,11 +1321,14 @@ fn fs_poly_sprite(input: PolySpriteVarying) -> @location(0) vec4<f32> {
 struct SurfaceParams {
     bounds: Bounds,
     content_mask: Bounds,
+    sampler_type: SamplerType,
 }
 
 @group(1) @binding(0) var<uniform> surface_locals: SurfaceParams;
 @group(1) @binding(1) var t_surface: texture_2d<f32>;
-@group(1) @binding(2) var s_surface: sampler;
+@group(1) @binding(2) var s_surface_linear: sampler;
+@group(1) @binding(3) var s_surface_nearest: sampler;
+
 
 struct SurfaceVarying {
     @builtin(position) position: vec4<f32>,
@@ -1346,7 +1353,13 @@ fn fs_surface(input: SurfaceVarying) -> @location(0) vec4<f32> {
         return vec4<f32>(0.0);
     }
 
-    return textureSampleLevel(t_surface, s_surface, input.texture_position, 0.0);
+    if (surface_locals.sampler_type == LINEAR_SAMPLER) {
+        return textureSampleLevel(t_surface, s_surface_linear, input.texture_position, 0.0);
+    }
+    else {
+        return textureSampleLevel(t_surface, s_surface_nearest, input.texture_position, 0.0);
+    }
+
 }
 
 // --- blur --- //

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -752,6 +752,12 @@ impl WgpuRenderer {
                     ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                     count: None,
                 },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 3,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
             ],
         });
 

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -731,9 +731,9 @@ impl WgpuRenderer {
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: false,
-                        min_binding_size: dbg!(NonZeroU64::new(
+                        min_binding_size: NonZeroU64::new(
                             std::mem::size_of::<SurfaceParams>() as u64
-                        )),
+                        ),
                     },
                     count: None,
                 },

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -55,6 +55,7 @@ impl From<Bounds<ScaledPixels>> for PodBounds {
 struct SurfaceParams {
     bounds: PodBounds,
     content_mask: PodBounds,
+    sampler_type: u32,
 }
 
 /// Uniform passed to the blur pipelines. The same struct drives the downsample, separable
@@ -166,7 +167,8 @@ struct WgpuResources {
     pipelines: WgpuPipelines,
     bind_group_layouts: WgpuBindGroupLayouts,
     atlas_sampler: wgpu::Sampler,
-    surface_sampler: wgpu::Sampler,
+    surface_sampler_linear: wgpu::Sampler,
+    surface_sampler_nearest: wgpu::Sampler,
     #[allow(dead_code)]
     surface_uniform_buffer: wgpu::Buffer,
     /// One reused uniform buffer holding [`BlurParams`] for every blur pass in a frame, each at a
@@ -478,10 +480,17 @@ impl WgpuRenderer {
             ..Default::default()
         });
 
-        let surface_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            label: Some("surface_sampler"),
+        let surface_sampler_linear = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("surface_sampler_linear"),
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
+
+        let surface_sampler_nearest = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("surface_sampler_nearest"),
+            mag_filter: wgpu::FilterMode::Nearest,
+            min_filter: wgpu::FilterMode::Nearest,
             ..Default::default()
         });
 
@@ -587,7 +596,8 @@ impl WgpuRenderer {
             pipelines,
             bind_group_layouts,
             atlas_sampler,
-            surface_sampler,
+            surface_sampler_linear,
+            surface_sampler_nearest,
             surface_uniform_buffer,
             blur_params_buffer,
             globals_buffer,
@@ -1865,6 +1875,7 @@ impl WgpuRenderer {
             let params = SurfaceParams {
                 bounds: surface.bounds.into(),
                 content_mask: surface.content_mask.bounds.into(),
+                sampler_type: surface.sampler_type as u32,
             };
 
             resources.queue.write_buffer(
@@ -1889,7 +1900,15 @@ impl WgpuRenderer {
                         },
                         wgpu::BindGroupEntry {
                             binding: 2,
-                            resource: wgpu::BindingResource::Sampler(&resources.surface_sampler),
+                            resource: wgpu::BindingResource::Sampler(
+                                &resources.surface_sampler_linear,
+                            ),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 3,
+                            resource: wgpu::BindingResource::Sampler(
+                                &resources.surface_sampler_nearest,
+                            ),
                         },
                     ],
                 });
@@ -1945,7 +1964,7 @@ impl WgpuRenderer {
                     },
                     wgpu::BindGroupEntry {
                         binding: 2,
-                        resource: wgpu::BindingResource::Sampler(&resources.surface_sampler),
+                        resource: wgpu::BindingResource::Sampler(&resources.surface_sampler_linear),
                     },
                 ],
             })

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -56,6 +56,7 @@ struct SurfaceParams {
     bounds: PodBounds,
     content_mask: PodBounds,
     sampler_type: u32,
+    pad: u32,
 }
 
 /// Uniform passed to the blur pipelines. The same struct drives the downsample, separable
@@ -730,9 +731,9 @@ impl WgpuRenderer {
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: false,
-                        min_binding_size: NonZeroU64::new(
+                        min_binding_size: dbg!(NonZeroU64::new(
                             std::mem::size_of::<SurfaceParams>() as u64
-                        ),
+                        )),
                     },
                     count: None,
                 },
@@ -1882,6 +1883,7 @@ impl WgpuRenderer {
                 bounds: surface.bounds.into(),
                 content_mask: surface.content_mask.bounds.into(),
                 sampler_type: surface.sampler_type as u32,
+                pad: 0,
             };
 
             resources.queue.write_buffer(


### PR DESCRIPTION
This adds filtering options for the Surface element so you can switch between nearest-neighbor and linear filtering.

To be honest, this was really quick and dirty so there's probably a nicer way to actually implement this, and it should probably also be done for images and whatnot, but I personally only needed it for Surface in my project so that's all I've done at the moment