### PR TITLE
Add cross-platform renderer-backed window capture

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["gui"]
 
 [features]
 default = ["font-kit", "wayland", "x11", "windows-manifest"]
+renderer-capture = []
 test-support = [
     "leak-detection",
     "collections/test-support",

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -508,6 +508,10 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn on_close(&self, callback: Box<dyn FnOnce()>);
     fn on_appearance_changed(&self, callback: Box<dyn FnMut()>);
     fn draw(&self, scene: &Scene);
+    #[cfg(feature = "renderer-capture")]
+    fn render_to_image(&self, _scene: &Scene) -> Result<image::RgbaImage> {
+        anyhow::bail!("renderer capture is not implemented for this platform")
+    }
     fn completed_frame(&self) {}
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas>;
 

--- a/src/platform/blade/blade_renderer.rs
+++ b/src/platform/blade/blade_renderer.rs
@@ -352,7 +352,7 @@ impl BladeRenderer {
     ) -> anyhow::Result<Self> {
         let surface_config = gpu::SurfaceConfig {
             size: config.size,
-            usage: gpu::TextureUsage::TARGET,
+            usage: gpu::TextureUsage::TARGET | gpu::TextureUsage::COPY,
             display_sync: gpu::DisplaySync::Recent,
             color_space: gpu::ColorSpace::Srgb,
             allow_exclusive_full_screen: false,
@@ -642,6 +642,18 @@ impl BladeRenderer {
     }
 
     pub fn draw(&mut self, scene: &Scene) {
+        if let Err(error) = self.render(scene, false) {
+            log::error!("failed to render GPUI scene: {error:#}");
+        }
+    }
+
+    #[cfg(feature = "renderer-capture")]
+    pub fn render_to_image(&mut self, scene: &Scene) -> anyhow::Result<image::RgbaImage> {
+        self.render(scene, true)?
+            .ok_or_else(|| anyhow::anyhow!("renderer capture did not produce an image"))
+    }
+
+    fn render(&mut self, scene: &Scene, capture: bool) -> anyhow::Result<Option<image::RgbaImage>> {
         self.command_encoder.start();
         self.atlas.before_frame(&mut self.command_encoder);
 
@@ -907,15 +919,74 @@ impl BladeRenderer {
         }
         drop(pass);
 
-        self.command_encoder.present(frame);
+        let readback = if capture {
+            let format = self.surface.info().format;
+            match format {
+                gpu::TextureFormat::Rgba8Unorm
+                | gpu::TextureFormat::Rgba8UnormSrgb
+                | gpu::TextureFormat::Bgra8Unorm
+                | gpu::TextureFormat::Bgra8UnormSrgb => {}
+                _ => anyhow::bail!("unsupported Blade capture texture format: {format:?}"),
+            }
+
+            let size = self.surface_config.size;
+            if size.width == 0 || size.height == 0 {
+                anyhow::bail!("cannot capture a zero-sized GPUI window");
+            }
+            let bytes_per_row = size.width * 4;
+            let buffer = self.gpu.create_buffer(gpu::BufferDesc {
+                name: "GPUI renderer capture readback",
+                size: u64::from(bytes_per_row) * u64::from(size.height),
+                memory: gpu::Memory::Shared,
+            });
+            {
+                let mut transfer = self.command_encoder.transfer("GPUI renderer capture");
+                transfer.copy_texture_to_buffer(
+                    frame.texture().into(),
+                    buffer.into(),
+                    bytes_per_row,
+                    size,
+                );
+            }
+            Some((buffer, format, bytes_per_row))
+        } else {
+            self.command_encoder.present(frame);
+            None
+        };
+
         let sync_point = self.gpu.submit(&mut self.command_encoder);
 
         profiling::scope!("finish");
         self.instance_belt.flush(&sync_point);
         self.atlas.after_frame(&sync_point);
 
-        self.wait_for_gpu();
-        self.last_sync_point = Some(sync_point);
+        if let Some((buffer, format, bytes_per_row)) = readback {
+            while !self.gpu.wait_for(&sync_point, MAX_FRAME_TIME_MS) {}
+            self.gpu.sync_buffer(buffer);
+
+            let size = self.surface_config.size;
+            let byte_len = bytes_per_row as usize * size.height as usize;
+            let mut pixels =
+                unsafe { std::slice::from_raw_parts(buffer.data(), byte_len) }.to_vec();
+            self.gpu.destroy_buffer(buffer);
+
+            if matches!(
+                format,
+                gpu::TextureFormat::Bgra8Unorm | gpu::TextureFormat::Bgra8UnormSrgb
+            ) {
+                for pixel in pixels.chunks_exact_mut(4) {
+                    pixel.swap(0, 2);
+                }
+            }
+
+            image::RgbaImage::from_raw(size.width, size.height, pixels)
+                .map(Some)
+                .ok_or_else(|| anyhow::anyhow!("failed to construct captured GPUI image"))
+        } else {
+            self.wait_for_gpu();
+            self.last_sync_point = Some(sync_point);
+            Ok(None)
+        }
     }
 }
 

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -1216,6 +1216,12 @@ impl PlatformWindow for WaylandWindow {
         state.renderer.draw(scene);
     }
 
+    #[cfg(feature = "renderer-capture")]
+    fn render_to_image(&self, scene: &Scene) -> anyhow::Result<image::RgbaImage> {
+        let mut state = self.borrow_mut();
+        state.renderer.render_to_image(scene)
+    }
+
     fn completed_frame(&self) {
         let state = self.borrow();
         state.surface.commit();

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -1475,6 +1475,12 @@ impl PlatformWindow for X11Window {
         inner.renderer.draw(scene);
     }
 
+    #[cfg(feature = "renderer-capture")]
+    fn render_to_image(&self, scene: &Scene) -> anyhow::Result<image::RgbaImage> {
+        let mut inner = self.0.state.borrow_mut();
+        inner.renderer.render_to_image(scene)
+    }
+
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {
         let inner = self.0.state.borrow();
         inner.renderer.sprite_atlas().clone()

--- a/src/platform/mac/metal_renderer.rs
+++ b/src/platform/mac/metal_renderer.rs
@@ -380,8 +380,12 @@ impl MetalRenderer {
         loop {
             let mut instance_buffer = self.instance_buffer_pool.lock().acquire(&self.device);
 
-            let command_buffer =
-                self.draw_primitives(scene, &mut instance_buffer, drawable, viewport_size);
+            let command_buffer = self.draw_primitives(
+                scene,
+                &mut instance_buffer,
+                drawable.texture(),
+                viewport_size,
+            );
 
             match command_buffer {
                 Ok(command_buffer) => {
@@ -426,11 +430,92 @@ impl MetalRenderer {
         }
     }
 
+    /// Re-renders a GPUI scene into an offscreen Metal texture and reads it as RGBA pixels.
+    #[cfg(feature = "renderer-capture")]
+    pub fn render_to_image(&mut self, scene: &Scene) -> Result<image::RgbaImage> {
+        let drawable_size = self.layer.drawable_size();
+        let viewport_size: Size<DevicePixels> = size(
+            (drawable_size.width.ceil() as i32).into(),
+            (drawable_size.height.ceil() as i32).into(),
+        );
+        if viewport_size.width.0 <= 0 || viewport_size.height.0 <= 0 {
+            anyhow::bail!("cannot capture a zero-sized GPUI window");
+        }
+
+        self.update_path_intermediate_textures(viewport_size);
+
+        let descriptor = metal::TextureDescriptor::new();
+        descriptor.set_width(viewport_size.width.0 as u64);
+        descriptor.set_height(viewport_size.height.0 as u64);
+        descriptor.set_pixel_format(MTLPixelFormat::BGRA8Unorm);
+        descriptor.set_usage(metal::MTLTextureUsage::RenderTarget);
+        descriptor.set_storage_mode(metal::MTLStorageMode::Managed);
+        let target_texture = self.device.new_texture(&descriptor);
+
+        loop {
+            let mut instance_buffer = self.instance_buffer_pool.lock().acquire(&self.device);
+            match self.draw_primitives(scene, &mut instance_buffer, &target_texture, viewport_size)
+            {
+                Ok(command_buffer) => {
+                    let instance_buffer_pool = self.instance_buffer_pool.clone();
+                    let instance_buffer = Cell::new(Some(instance_buffer));
+                    let block = ConcreteBlock::new(move |_| {
+                        if let Some(instance_buffer) = instance_buffer.take() {
+                            instance_buffer_pool.lock().release(instance_buffer);
+                        }
+                    })
+                    .copy();
+                    command_buffer.add_completed_handler(&block);
+
+                    if !self.device.has_unified_memory() {
+                        let blit = command_buffer.new_blit_command_encoder();
+                        blit.synchronize_resource(&target_texture);
+                        blit.end_encoding();
+                    }
+                    command_buffer.commit();
+                    command_buffer.wait_until_completed();
+
+                    let width = viewport_size.width.0 as u32;
+                    let height = viewport_size.height.0 as u32;
+                    let bytes_per_row = width as usize * 4;
+                    let mut pixels = vec![0; height as usize * bytes_per_row];
+                    target_texture.get_bytes(
+                        pixels.as_mut_ptr().cast(),
+                        bytes_per_row as u64,
+                        metal::MTLRegion {
+                            origin: metal::MTLOrigin { x: 0, y: 0, z: 0 },
+                            size: metal::MTLSize {
+                                width: width as u64,
+                                height: height as u64,
+                                depth: 1,
+                            },
+                        },
+                        0,
+                    );
+
+                    for pixel in pixels.chunks_exact_mut(4) {
+                        pixel.swap(0, 2);
+                    }
+                    return image::RgbaImage::from_raw(width, height, pixels)
+                        .ok_or_else(|| anyhow::anyhow!("failed to construct captured GPUI image"));
+                }
+                Err(error) => {
+                    let mut pool = self.instance_buffer_pool.lock();
+                    if pool.buffer_size >= 256 * 1024 * 1024 {
+                        return Err(error);
+                    }
+                    let next_size = pool.buffer_size * 2;
+                    pool.reset(next_size);
+                }
+            }
+        }
+    }
+
     fn draw_primitives(
         &mut self,
         scene: &Scene,
         instance_buffer: &mut InstanceBuffer,
-        drawable: &metal::MetalDrawableRef,
+        target_texture: &metal::TextureRef,
         viewport_size: Size<DevicePixels>,
     ) -> Result<metal::CommandBuffer> {
         let command_queue = self.command_queue.clone();
@@ -440,7 +525,7 @@ impl MetalRenderer {
 
         let mut command_encoder = new_command_encoder(
             command_buffer,
-            drawable,
+            target_texture,
             viewport_size,
             |color_attachment| {
                 color_attachment.set_load_action(metal::MTLLoadAction::Clear);
@@ -477,7 +562,7 @@ impl MetalRenderer {
 
                     command_encoder = new_command_encoder(
                         command_buffer,
-                        drawable,
+                        target_texture,
                         viewport_size,
                         |color_attachment| {
                             color_attachment.set_load_action(metal::MTLLoadAction::Load);
@@ -1168,7 +1253,7 @@ impl MetalRenderer {
 
 fn new_command_encoder<'a>(
     command_buffer: &'a metal::CommandBufferRef,
-    drawable: &'a metal::MetalDrawableRef,
+    target_texture: &'a metal::TextureRef,
     viewport_size: Size<DevicePixels>,
     configure_color_attachment: impl Fn(&RenderPassColorAttachmentDescriptorRef),
 ) -> &'a metal::RenderCommandEncoderRef {
@@ -1177,7 +1262,7 @@ fn new_command_encoder<'a>(
         .color_attachments()
         .object_at(0)
         .unwrap();
-    color_attachment.set_texture(Some(drawable.texture()));
+    color_attachment.set_texture(Some(target_texture));
     color_attachment.set_store_action(metal::MTLStoreAction::Store);
     configure_color_attachment(color_attachment);
 

--- a/src/platform/mac/window.rs
+++ b/src/platform/mac/window.rs
@@ -1474,6 +1474,12 @@ impl PlatformWindow for MacWindow {
         this.renderer.draw(scene);
     }
 
+    #[cfg(feature = "renderer-capture")]
+    fn render_to_image(&self, scene: &crate::Scene) -> anyhow::Result<image::RgbaImage> {
+        let mut this = self.0.lock();
+        this.renderer.render_to_image(scene)
+    }
+
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {
         self.0.lock().renderer.sprite_atlas().clone()
     }

--- a/src/platform/windows/directx_renderer.rs
+++ b/src/platform/windows/directx_renderer.rs
@@ -305,6 +305,11 @@ impl DirectXRenderer {
             // and so likely do not have the textures anymore that are required for drawing
             return Ok(());
         }
+        self.draw_scene(scene)?;
+        self.present()
+    }
+
+    fn draw_scene(&mut self, scene: &Scene) -> Result<()> {
         self.pre_draw()?;
         for batch in scene.batches() {
             match batch {
@@ -337,7 +342,80 @@ impl DirectXRenderer {
                 scene.surfaces.len(),
             ))?;
         }
-        self.present()
+        Ok(())
+    }
+
+    #[cfg(feature = "renderer-capture")]
+    pub(crate) fn render_to_image(&mut self, scene: &Scene) -> Result<image::RgbaImage> {
+        if self.skip_draws {
+            anyhow::bail!("cannot capture while the Direct3D renderer is recovering");
+        }
+        if self.width == 0 || self.height == 0 {
+            anyhow::bail!("cannot capture a zero-sized GPUI window");
+        }
+
+        self.draw_scene(scene)?;
+
+        let devices = self.devices.as_ref().context("devices missing")?;
+        let resources = self.resources.as_ref().context("resources missing")?;
+        let source = resources
+            .render_target
+            .as_ref()
+            .context("render target missing")?;
+
+        let mut staging = None;
+        let descriptor = D3D11_TEXTURE2D_DESC {
+            Width: self.width,
+            Height: self.height,
+            MipLevels: 1,
+            ArraySize: 1,
+            Format: RENDER_TARGET_FORMAT,
+            SampleDesc: DXGI_SAMPLE_DESC {
+                Count: 1,
+                Quality: 0,
+            },
+            Usage: D3D11_USAGE_STAGING,
+            BindFlags: 0,
+            CPUAccessFlags: D3D11_CPU_ACCESS_READ.0 as u32,
+            MiscFlags: 0,
+        };
+        unsafe {
+            devices
+                .device
+                .CreateTexture2D(&descriptor, None, Some(&mut staging))?;
+        }
+        let staging = staging.context("failed to create Direct3D capture staging texture")?;
+        unsafe {
+            devices.device_context.CopyResource(&staging, source);
+        }
+
+        let mut mapped = D3D11_MAPPED_SUBRESOURCE::default();
+        unsafe {
+            devices
+                .device_context
+                .Map(&staging, 0, D3D11_MAP_READ, 0, Some(&mut mapped))?;
+        }
+
+        let bytes_per_row = self.width as usize * 4;
+        let mut pixels = vec![0; bytes_per_row * self.height as usize];
+        for row in 0..self.height as usize {
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    (mapped.pData as *const u8).add(mapped.RowPitch as usize * row),
+                    pixels.as_mut_ptr().add(bytes_per_row * row),
+                    bytes_per_row,
+                );
+            }
+        }
+        unsafe {
+            devices.device_context.Unmap(&staging, 0);
+        }
+
+        for pixel in pixels.chunks_exact_mut(4) {
+            pixel.swap(0, 2);
+        }
+        image::RgbaImage::from_raw(self.width, self.height, pixels)
+            .ok_or_else(|| anyhow::anyhow!("failed to construct captured GPUI image"))
     }
 
     pub(crate) fn resize(&mut self, new_size: Size<DevicePixels>) -> Result<()> {

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -884,6 +884,11 @@ impl PlatformWindow for WindowsWindow {
         self.state.renderer.borrow_mut().draw(scene).log_err();
     }
 
+    #[cfg(feature = "renderer-capture")]
+    fn render_to_image(&self, scene: &Scene) -> anyhow::Result<image::RgbaImage> {
+        self.state.renderer.borrow_mut().render_to_image(scene)
+    }
+
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {
         self.state.renderer.borrow().sprite_atlas()
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -1764,6 +1764,16 @@ impl Window {
         self.platform_window.bounds()
     }
 
+    /// Renders the current GPUI scene to an offscreen target and returns its RGBA pixels.
+    ///
+    /// Unlike a compositor screenshot, this captures only content rendered by GPUI and does not
+    /// require the window to be visible or grant operating-system screen-recording permission.
+    #[cfg(feature = "renderer-capture")]
+    pub fn render_to_image(&self) -> anyhow::Result<image::RgbaImage> {
+        self.platform_window
+            .render_to_image(&self.rendered_frame.scene)
+    }
+
     /// Set the content size of the window.
     pub fn resize(&mut self, size: Size<Pixels>) {
         self.platform_window.resize(size);


### PR DESCRIPTION
## Summary

- add an opt-in `renderer-capture` feature to the published gpui-ce 0.3.3 line
- expose `Window::render_to_image` through `PlatformWindow`
- capture directly from every active native renderer:
  - macOS: render the current `Scene` into an offscreen managed Metal texture and synchronize discrete-GPU resources before readback
  - Linux X11/Wayland: copy the Blade surface texture into shared GPU/CPU memory and normalize RGBA/BGRA formats
  - Windows: copy the Direct3D 11 render target into a CPU-readable staging texture while respecting mapped row pitch

## Motivation

UI automation and visual regression tooling need application pixels without invoking the operating-system compositor or requiring Screen Recording permission. The current `main` branch has a related test-support capture API; this change makes the capability available as a narrow opt-in feature on the 0.3.3 `publish` branch.

All implementations re-render the current GPUI `Scene` through the existing backend and return an `image::RgbaImage`. The feature is disabled by default.

## Validation

- formatting: all changed Rust files pass `rustfmt --edition 2024 --check`
- macOS Metal: `cargo check --lib --features renderer-capture`
- macOS Blade: `cargo check --lib --no-default-features --features font-kit,macos-blade,renderer-capture`
- Linux X11 + Wayland: native Debian build with upstream CI system packages, `cargo check --lib --features renderer-capture`
- Windows Direct3D: `cargo check --lib --target x86_64-pc-windows-gnu --no-default-features --features renderer-capture`
- live macOS integration in ZenIDE Commander, including overlay capture at 2400x1602 RGBA