### PR TITLE
replace custom Rgba & Hsla implementations with palette crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ar_archive_writer"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +794,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
@@ -2449,6 +2464,7 @@ dependencies = [
  "objc",
  "objc2 0.6.4",
  "objc2-metal 0.3.2",
+ "palette",
  "parking",
  "parking_lot",
  "pathfinder_geometry",
@@ -2519,6 +2535,7 @@ version = "0.1.0"
 dependencies = [
  "gpui",
  "gpui_platform",
+ "palette",
  "smallvec",
  "unicode-segmentation",
 ]
@@ -2611,6 +2628,7 @@ dependencies = [
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
  "objc2-user-notifications",
+ "palette",
  "parking_lot",
  "pathfinder_geometry",
  "raw-window-handle",
@@ -4360,6 +4378,37 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "palette"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
+dependencies = [
+ "approx",
+ "palette_derive",
+ "palette_math",
+ "phf",
+ "serde",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
 
 [[package]]
 name = "parking"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ image = "0.25.1"
 inventory = "0.3.19"
 itertools = "0.14.0"
 log = { version = "0.4.16", features = ["kv_unstable_serde", "serde"] }
+palette = { version = "0.7.6", features = ["serializing"] }
 parking_lot = "0.12.1"
 postage = { version = "0.5", features = ["futures-traits"] }
 proptest = { version = "1.10", features = ["attr-macro"] }

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -63,6 +63,7 @@ log.workspace = true
 num_cpus = "1.13"
 parking = "2.0.0"
 parking_lot.workspace = true
+palette.workspace = true
 postage.workspace = true
 proptest = { workspace = true, optional = true }
 chrono.workspace = true

--- a/crates/gpui/examples/bench/pattern.rs
+++ b/crates/gpui/examples/bench/pattern.rs
@@ -2,6 +2,7 @@ use gpui::{
     App, AppContext, Bounds, Context, Window, WindowBounds, WindowOptions, div, linear_color_stop,
     linear_gradient, pattern_slash, prelude::*, px, rgb, size,
 };
+use palette::WithAlpha;
 
 struct PatternExample;
 
@@ -52,7 +53,7 @@ impl Render for PatternExample {
                     .flex_col()
                     .border_1()
                     .border_color(gpui::blue())
-                    .bg(gpui::green().opacity(0.16))
+                    .bg(gpui::green().with_alpha(0.16))
                     .child("Elements the same height should align")
                     .child(div().w(px(256.0)).h(px(56.0)).bg(pattern_slash(
                         gpui::red(),

--- a/crates/gpui/examples/learn/animation.rs
+++ b/crates/gpui/examples/learn/animation.rs
@@ -15,10 +15,11 @@ use std::time::Duration;
 use anyhow::Result;
 use gpui::colors::Colors;
 use gpui::{
-    Animation, AnimationExt as _, App, AssetSource, Bounds, Context, Hsla, SharedString,
+    Animation, AnimationExt as _, App, AssetSource, Bounds, ColorExt, Context, Hsla, SharedString,
     Transformation, Window, WindowBounds, WindowOptions, bounce, div, ease_in_out, linear,
     percentage, prelude::*, px, rgb, size as gpui_size, svg,
 };
+use palette::IntoColor;
 
 struct Assets {}
 
@@ -241,7 +242,7 @@ fn combined_example(colors: &Colors) -> impl IntoElement {
 }
 
 fn section(colors: &Colors, title: &'static str, content: impl IntoElement) -> impl IntoElement {
-    let surface: Hsla = colors.container.into();
+    let surface: Hsla = colors.container.into_color();
 
     div()
         .flex()

--- a/crates/gpui/examples/learn/custom_drawing.rs
+++ b/crates/gpui/examples/learn/custom_drawing.rs
@@ -9,10 +9,11 @@
 
 use gpui::colors::Colors;
 use gpui::{
-    App, Bounds, Context, Hsla, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Path,
-    PathBuilder, Pixels, Point, Render, Rgba, Window, WindowBounds, WindowOptions, canvas, div,
-    fill, point, prelude::*, px, rgb, size,
+    App, Bounds, ColorExt, Context, Hsla, MouseButton, MouseDownEvent, MouseMoveEvent,
+    MouseUpEvent, Path, PathBuilder, Pixels, Point, Render, Rgba, Window, WindowBounds,
+    WindowOptions, canvas, div, fill, point, prelude::*, px, rgb, size,
 };
+use palette::IntoColor;
 
 #[path = "../shared/prelude.rs"]
 mod example_prelude;
@@ -430,7 +431,7 @@ fn section(
     content: impl IntoElement,
     height: Pixels,
 ) -> impl IntoElement {
-    let surface: Hsla = colors.container.into();
+    let surface: Hsla = colors.container.into_color();
 
     div()
         .flex()

--- a/crates/gpui/examples/learn/haptic_feedback.rs
+++ b/crates/gpui/examples/learn/haptic_feedback.rs
@@ -14,11 +14,12 @@ mod example_prelude;
 
 use example_prelude::init_example;
 use gpui::{
-    App, Bounds, Context, DragMoveEvent, FontWeight, HapticFeedbackStyle, Hsla, InteractiveElement,
-    IntoElement, MouseButton, MouseDownEvent, ParentElement, Pixels, Render,
+    App, Bounds, ColorExt, Context, DragMoveEvent, FontWeight, HapticFeedbackStyle, Hsla,
+    InteractiveElement, IntoElement, MouseButton, MouseDownEvent, ParentElement, Pixels, Render,
     StatefulInteractiveElement, Styled, Window, WindowBounds, WindowOptions, colors::Colors, div,
     prelude::*, px, relative, rgb, size,
 };
+use palette::IntoColor;
 
 const SLIDER_MIN: f32 = 0.0;
 const SLIDER_MAX: f32 = 100.0;
@@ -56,11 +57,12 @@ impl HapticFeedbackExample {
         id: &'static str,
         label: &'static str,
         style: HapticFeedbackStyle,
-        color: Hsla,
+        color: impl IntoColor<Hsla>,
         colors: &Colors,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let _ = cx;
+        let color = color.into_color();
 
         div()
             .id(id)
@@ -80,7 +82,7 @@ impl HapticFeedbackExample {
                 div()
                     .text_base()
                     .font_weight(FontWeight::MEDIUM)
-                    .text_color(Hsla::from(colors.selected_text))
+                    .text_color(colors.selected_text)
                     .child(label),
             )
             .on_hover(move |hovered, _, cx| {
@@ -131,7 +133,7 @@ impl Render for HapticFeedbackExample {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let colors = Colors::for_appearance(window);
         let slider_percentage = Self::value_to_percentage(self.slider_value);
-        let slider_color = Hsla::from(rgb(0x3b82f6));
+        let slider_color = rgb(0x3b82f6);
 
         div()
             .flex()
@@ -167,10 +169,11 @@ impl Render for HapticFeedbackExample {
                     .py_2()
                     .rounded_md()
                     .bg(if self.supported {
-                        Hsla::from(rgb(0x22c55e)).opacity(0.1)
+                        rgb(0x22c55e)
                     } else {
-                        Hsla::from(rgb(0xf59e0b)).opacity(0.1)
-                    })
+                        rgb(0xf59e0b)
+                    }
+                    .opacity(0.1))
                     .child({
                         let dot = if self.supported {
                             rgb(0x22c55e)
@@ -205,7 +208,7 @@ impl Render for HapticFeedbackExample {
                         "btn-generic",
                         "Generic",
                         HapticFeedbackStyle::Generic,
-                        Hsla::from(rgb(0x3b82f6)),
+                        rgb(0x3b82f6),
                         &colors,
                         cx,
                     ))
@@ -213,7 +216,7 @@ impl Render for HapticFeedbackExample {
                         "btn-alignment",
                         "Alignment",
                         HapticFeedbackStyle::Alignment,
-                        Hsla::from(rgb(0x10b981)),
+                        rgb(0x10b981),
                         &colors,
                         cx,
                     ))
@@ -221,7 +224,7 @@ impl Render for HapticFeedbackExample {
                         "btn-levelchange",
                         "LevelChange",
                         HapticFeedbackStyle::LevelChange,
-                        Hsla::from(rgb(0x8b5cf6)),
+                        rgb(0x8b5cf6),
                         &colors,
                         cx,
                     )),
@@ -278,7 +281,7 @@ impl Render for HapticFeedbackExample {
                                     .w_full()
                                     .h_1p5()
                                     .rounded_full()
-                                    .bg(Hsla::from(colors.text).opacity(0.12))
+                                    .bg(colors.text.opacity(0.12))
                                     .flex()
                                     .items_center()
                                     .justify_between()

--- a/crates/gpui/examples/learn/interactive_elements.rs
+++ b/crates/gpui/examples/learn/interactive_elements.rs
@@ -13,9 +13,11 @@ mod example_prelude;
 use example_prelude::init_example;
 use gpui::colors::Colors;
 use gpui::{
-    App, Bounds, ClickEvent, Context, Entity, Half, Hsla, IntoElement, MouseButton, MouseMoveEvent,
-    Pixels, Point, Render, Window, WindowBounds, WindowOptions, div, prelude::*, px, rgb, size,
+    App, Bounds, ClickEvent, ColorExt, Context, Entity, Half, Hsla, IntoElement, MouseButton,
+    MouseMoveEvent, Pixels, Point, Render, Window, WindowBounds, WindowOptions, div, prelude::*,
+    px, rgb, size,
 };
+use palette::IntoColor;
 
 // ============================================================================
 // Click Events Demo
@@ -423,7 +425,7 @@ impl Render for DragDropDemo {
                     .flex()
                     .gap_2()
                     .children(item_colors.into_iter().enumerate().map(|(index, color)| {
-                        let drag_data = DragData::new(index, color.into());
+                        let drag_data = DragData::new(index, color.into_color());
 
                         div()
                             .id(("drag-item", index))
@@ -436,7 +438,7 @@ impl Render for DragDropDemo {
                             .text_xs()
                             .cursor_grab()
                             .hover(move |style| {
-                                let c: Hsla = color.into();
+                                let c: Hsla = color.into_color();
                                 style.bg(c.opacity(0.1))
                             })
                             .child(format!("Item {}", index + 1))
@@ -457,7 +459,7 @@ impl Render for DragDropDemo {
                     .border_color(
                         self.dropped_item
                             .map(|d| d.color)
-                            .unwrap_or_else(|| colors.border.into()),
+                            .unwrap_or_else(|| colors.border.into_color()),
                     )
                     .when_some(self.dropped_item, |el, data| el.bg(data.color.opacity(0.2)))
                     .flex()

--- a/crates/gpui/examples/learn/layout.rs
+++ b/crates/gpui/examples/learn/layout.rs
@@ -12,9 +12,10 @@ mod example_prelude;
 use example_prelude::init_example;
 use gpui::colors::Colors;
 use gpui::{
-    Bounds, Context, Div, Hsla, Render, Rgba, Window, WindowBounds, WindowOptions, div, prelude::*,
-    px, size,
+    Bounds, ColorExt, Context, Div, Hsla, Render, Rgba, Window, WindowBounds, WindowOptions, div,
+    prelude::*, px, size,
 };
+use palette::{IntoColor, WithAlpha};
 
 // Helper: Colored block for visualization
 
@@ -25,7 +26,7 @@ fn block(label: &'static str, color: Hsla, text_color: Rgba) -> Div {
         .justify_center()
         .bg(color)
         .border_1()
-        .border_color(gpui::white().opacity(0.3))
+        .border_color(gpui::white().with_alpha(0.3))
         .rounded_md()
         .text_xs()
         .text_color(text_color)
@@ -363,7 +364,7 @@ fn stack_pattern(colors: &Colors) -> impl IntoElement {
                         .top_2()
                         .left_2()
                         .size_10()
-                        .bg(gpui::red().opacity(0.7))
+                        .bg(gpui::red().with_alpha(0.7))
                         .rounded_md(),
                 )
                 .child(
@@ -372,7 +373,7 @@ fn stack_pattern(colors: &Colors) -> impl IntoElement {
                         .top_4()
                         .left_4()
                         .size_10()
-                        .bg(gpui::green().opacity(0.7))
+                        .bg(gpui::green().with_alpha(0.7))
                         .rounded_md(),
                 )
                 .child(
@@ -381,7 +382,7 @@ fn stack_pattern(colors: &Colors) -> impl IntoElement {
                         .top_6()
                         .left_6()
                         .size_10()
-                        .bg(gpui::blue().opacity(0.7))
+                        .bg(gpui::blue().with_alpha(0.7))
                         .rounded_md(),
                 ),
         )
@@ -464,7 +465,7 @@ impl Render for LayoutExample {
 }
 
 fn section(colors: &Colors, title: &'static str, content: impl IntoElement) -> impl IntoElement {
-    let surface: Hsla = colors.container.into();
+    let surface: Hsla = colors.container.into_color();
 
     div()
         .flex()

--- a/crates/gpui/examples/learn/styling.rs
+++ b/crates/gpui/examples/learn/styling.rs
@@ -8,9 +8,10 @@
 
 use gpui::colors::Colors;
 use gpui::{
-    App, Bounds, Context, FocusHandle, Hsla, KeyBinding, Menu, MenuItem, Render, Rgba, Window,
-    WindowBounds, WindowOptions, actions, div, prelude::*, px, rgb, size,
+    App, Bounds, ColorExt, Context, FocusHandle, Hsla, KeyBinding, Menu, MenuItem, Render, Rgba,
+    Window, WindowBounds, WindowOptions, actions, div, prelude::*, px, rgb, size,
 };
+use palette::{IntoColor, WithAlpha};
 
 actions!(styling_example, [Quit, Tab, TabPrev]);
 
@@ -147,7 +148,7 @@ fn list_item(
                 .text_color(text_muted)
         })
         .when(!is_disabled && is_selected, move |el| {
-            let accent_bg: Hsla = accent.into();
+            let accent_bg: Hsla = accent.into_color();
             el.bg(accent_bg.opacity(0.2))
                 .border_color(accent)
                 .text_color(text)
@@ -438,8 +439,8 @@ impl Render for StylingExample {
 }
 
 fn section(colors: &Colors, title: &'static str, content: impl IntoElement) -> impl IntoElement {
-    let surface: Hsla = colors.container.into();
-    let border: Hsla = colors.border.into();
+    let surface: Hsla = colors.container.into_color();
+    let border: Hsla = colors.border.into_color();
 
     div()
         .flex()
@@ -474,7 +475,7 @@ fn color_swatch(colors: &Colors, name: &'static str, color: Rgba) -> impl IntoEl
                 .rounded_md()
                 .bg(color)
                 .border_1()
-                .border_color(gpui::white().opacity(0.2)),
+                .border_color(gpui::white().with_alpha(0.2)),
         )
         .child(div().text_xs().text_color(text_muted).child(name))
 }

--- a/crates/gpui/examples/learn/text.rs
+++ b/crates/gpui/examples/learn/text.rs
@@ -14,9 +14,10 @@ mod example_prelude;
 
 use example_prelude::init_example;
 use gpui::{
-    App, Bounds, Context, FontStyle, FontWeight, Hsla, Render, StyledText, TextOverflow, Window,
-    WindowBounds, WindowOptions, colors::Colors, div, prelude::*, px, relative, rgb, size,
+    App, Bounds, ColorExt, Context, FontStyle, FontWeight, Hsla, Render, StyledText, TextOverflow,
+    Window, WindowBounds, WindowOptions, colors::Colors, div, prelude::*, px, relative, rgb, size,
 };
+use palette::IntoColor;
 
 // Text Styling Examples
 
@@ -546,7 +547,7 @@ impl Render for TextExample {
 }
 
 fn section(colors: &Colors, title: &'static str, content: impl IntoElement) -> impl IntoElement {
-    let surface: Hsla = colors.container.into();
+    let surface: Hsla = colors.container.into_color();
 
     div()
         .flex()

--- a/crates/gpui/examples/legacy/image_loading.rs
+++ b/crates/gpui/examples/legacy/image_loading.rs
@@ -6,6 +6,7 @@ use gpui::{
     Resource, SharedString, Window, WindowBounds, WindowOptions, black, div, img, prelude::*,
     pulsating_between, px, red, size,
 };
+use palette::WithAlpha;
 
 struct Assets {}
 
@@ -77,13 +78,13 @@ impl ImageLoadingExample {
                 Animation::new(Duration::from_secs(3))
                     .repeat()
                     .with_easing(pulsating_between(0.04, 0.24)),
-                move |this, delta| this.bg(black().opacity(delta)),
+                move |this, delta| this.bg(black().with_alpha(delta)),
             ),
         )
     }
 
     fn fallback_element() -> impl IntoElement {
-        let fallback_color: Hsla = black().opacity(0.5);
+        let fallback_color: Hsla = black().with_alpha(0.5);
 
         div().size_full().flex_none().p_0p5().child(
             div()

--- a/crates/gpui/examples/legacy/scrollable.rs
+++ b/crates/gpui/examples/legacy/scrollable.rs
@@ -1,4 +1,5 @@
 use gpui::{App, Bounds, Context, Window, WindowBounds, WindowOptions, div, prelude::*, px, size};
+use palette::WithAlpha;
 
 struct Scrollable {}
 
@@ -16,7 +17,7 @@ impl Render for Scrollable {
                     .h(px(5000.))
                     .border_1()
                     .border_color(gpui::blue())
-                    .bg(gpui::blue().opacity(0.05))
+                    .bg(gpui::blue().with_alpha(0.05))
                     .p_4()
                     .child(
                         div()
@@ -28,8 +29,8 @@ impl Render for Scrollable {
                                 div()
                                     .w(px(2000.))
                                     .h(px(150.))
-                                    .bg(gpui::green().opacity(0.1))
-                                    .hover(|this| this.bg(gpui::green().opacity(0.2)))
+                                    .bg(gpui::green().with_alpha(0.1))
+                                    .hover(|this| this.bg(gpui::green().with_alpha(0.2)))
                                     .border_1()
                                     .border_color(gpui::green())
                                     .p_4()

--- a/crates/gpui/examples/legacy/tab_stop.rs
+++ b/crates/gpui/examples/legacy/tab_stop.rs
@@ -2,6 +2,7 @@ use gpui::{
     App, Bounds, Context, Div, ElementId, FocusHandle, KeyBinding, SharedString, Stateful, Window,
     WindowBounds, WindowOptions, actions, div, prelude::*, px, size,
 };
+use palette::WithAlpha;
 
 actions!(example, [Tab, TabPrev]);
 
@@ -99,7 +100,7 @@ impl Render for Example {
                             )
                             .map(|this| match item_handle.tab_stop {
                                 true => this
-                                    .hover(|this| this.bg(gpui::black().opacity(0.1)))
+                                    .hover(|this| this.bg(gpui::black().with_alpha(0.1)))
                                     .child(format!("tab_index: {}", item_handle.tab_index)),
                                 false => this.opacity(0.4).child("tab_stop: false"),
                             })

--- a/crates/gpui/examples/legacy/window_shadow.rs
+++ b/crates/gpui/examples/legacy/window_shadow.rs
@@ -108,12 +108,7 @@ impl Render for WindowShadow {
                                     gpui::BoxShadow::new(
                                         px(0.),
                                         px(0.),
-                                        Hsla {
-                                            h: 0.,
-                                            s: 0.,
-                                            l: 0.,
-                                            a: 0.4,
-                                        },
+                                        Hsla::new(0., 0., 0., 0.4),
                                     )
                                     .blur_radius(shadow_size / 2.),
                                 ])
@@ -150,12 +145,7 @@ impl Render for WindowShadow {
                                             gpui::BoxShadow::new(
                                                 px(0.),
                                                 px(0.),
-                                                Hsla {
-                                                    h: 0.,
-                                                    s: 0.,
-                                                    l: 0.,
-                                                    a: 1.0,
-                                                },
+                                                Hsla::new(0., 0., 0., 1.),
                                             )
                                             .blur_radius(px(20.0)),
                                         ])

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -1,25 +1,24 @@
-use anyhow::{Context as _, bail};
+use palette::{IntoColor, OklabHue, Oklcha, RgbHue};
 use schemars::{JsonSchema, json_schema};
-use serde::{
-    Deserialize, Deserializer, Serialize, Serializer,
-    de::{self, Visitor},
-};
-use std::borrow::Cow;
-use std::{
-    fmt::{self, Display, Formatter},
-    hash::{Hash, Hasher},
-};
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display, Formatter};
+
+// Re-exported for api maintenance
+pub use palette::{Hsla, rgb::Rgba};
 
 /// Convert an RGB hex color code number to a color type
 pub fn rgb(hex: u32) -> Rgba {
     let [_, r, g, b] = hex.to_be_bytes().map(|b| (b as f32) / 255.0);
-    Rgba { r, g, b, a: 1.0 }
+    Rgba {
+        color: palette::rgb::Rgb::new(r, g, b),
+        alpha: 1.0,
+    }
 }
 
 /// Convert an RGBA hex color code number to [`Rgba`]
 pub fn rgba(hex: u32) -> Rgba {
     let [r, g, b, a] = hex.to_be_bytes().map(|b| (b as f32) / 255.0);
-    Rgba { r, g, b, a }
+    Rgba::new(r, g, b, a)
 }
 
 /// Swap from RGBA with premultiplied alpha to BGRA
@@ -33,710 +32,198 @@ pub fn swap_rgba_pa_to_bgra(color: &mut [u8]) {
     }
 }
 
-/// An RGBA color
-#[derive(PartialEq, Clone, Copy, Default)]
-#[repr(C)]
-pub struct Rgba {
-    /// The red component of the color, in the range 0.0 to 1.0
-    pub r: f32,
-    /// The green component of the color, in the range 0.0 to 1.0
-    pub g: f32,
-    /// The blue component of the color, in the range 0.0 to 1.0
-    pub b: f32,
-    /// The alpha component of the color, in the range 0.0 to 1.0
-    pub a: f32,
-}
-
-impl fmt::Debug for Rgba {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "rgba({:#010x})", u32::from(*self))
-    }
-}
-
-impl Rgba {
-    /// Create a new [`Rgba`] color by blending this and another color together
-    pub fn blend(&self, other: Rgba) -> Self {
-        if other.a >= 1.0 {
-            other
-        } else if other.a <= 0.0 {
-            *self
-        } else {
-            Rgba {
-                r: (self.r * (1.0 - other.a)) + (other.r * other.a),
-                g: (self.g * (1.0 - other.a)) + (other.g * other.a),
-                b: (self.b * (1.0 - other.a)) + (other.b * other.a),
-                a: self.a,
-            }
-        }
-    }
-
-    /// Returns a new RGBA color with the same red, green and blue channels, but
-    /// with a new alpha value.
-    ///
-    /// Example:
-    /// ```
-    /// use gpui::rgba;
-    /// let color = rgba(0xFF0000FF);
-    /// let faded = color.alpha(0.25);
-    /// assert_eq!(faded.a, 0.25);
-    /// ```
-    ///
-    /// This will return a red color with 25% opacity.
-    ///
-    /// Example:
-    /// ```
-    /// use gpui::rgba;
-    /// let color = rgba(0x3399FFCC);
-    /// let transparent = color.alpha(0.0);
-    /// assert_eq!(transparent.a, 0.0);
-    /// ```
-    ///
-    /// This will return the same blue color, fully transparent.
-    pub fn alpha(&self, a: f32) -> Self {
-        Rgba {
-            r: self.r,
-            g: self.g,
-            b: self.b,
-            a: a.clamp(0., 1.),
-        }
-    }
-
-    /// Returns a new RGBA color with the same red, green, and blue channels,
-    /// but with the alpha channel multiplied by the given factor.
-    ///
-    /// Example:
-    /// ```
-    /// use gpui::rgba;
-    /// let color = rgba(0xFF0000FF); // Fully opaque red
-    /// let faded = color.opacity(0.5);
-    /// assert_eq!(faded.a, 0.5);
-    /// ```
-    ///
-    /// This will return a red color with 50% opacity.
-    ///
-    /// Example:
-    /// ```
-    /// use gpui::rgba;
-    /// let color = rgba(0x3399FFCC); // A light blue with 80% opacity
-    /// let faded = color.opacity(0.5);
-    /// assert!((faded.a - 0.4).abs() < 1e-6);
-    /// ```
-    ///
-    /// This will return the same blue color scaled down to 40% opacity.
-    pub fn opacity(&self, factor: f32) -> Self {
-        Rgba {
-            r: self.r,
-            g: self.g,
-            b: self.b,
-            a: self.a * factor.clamp(0., 1.),
-        }
-    }
-}
-
-impl From<Rgba> for u32 {
-    fn from(rgba: Rgba) -> Self {
-        let r = (rgba.r * 255.0) as u32;
-        let g = (rgba.g * 255.0) as u32;
-        let b = (rgba.b * 255.0) as u32;
-        let a = (rgba.a * 255.0) as u32;
-        (r << 24) | (g << 16) | (b << 8) | a
-    }
-}
-
-struct RgbaVisitor;
-
-impl Visitor<'_> for RgbaVisitor {
-    type Value = Rgba;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("a string in the format #rrggbb or #rrggbbaa")
-    }
-
-    fn visit_str<E: de::Error>(self, value: &str) -> Result<Rgba, E> {
-        Rgba::try_from(value).map_err(E::custom)
-    }
-}
-
-impl JsonSchema for Rgba {
-    fn schema_name() -> Cow<'static, str> {
-        "Rgba".into()
-    }
-
-    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
-        json_schema!({
-            "type": "string",
-            "pattern": "^#([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$"
-        })
-    }
-}
-
-impl<'de> Deserialize<'de> for Rgba {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        deserializer.deserialize_str(RgbaVisitor)
-    }
-}
-
-impl Serialize for Rgba {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let r = (self.r * 255.0).round() as u8;
-        let g = (self.g * 255.0).round() as u8;
-        let b = (self.b * 255.0).round() as u8;
-        let a = (self.a * 255.0).round() as u8;
-
-        let s = format!("#{r:02x}{g:02x}{b:02x}{a:02x}");
-        serializer.serialize_str(&s)
-    }
-}
-
-impl From<Hsla> for Rgba {
-    fn from(color: Hsla) -> Self {
-        let h = color.h;
-        let s = color.s;
-        let l = color.l;
-
-        let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
-        let x = c * (1.0 - ((h * 6.0) % 2.0 - 1.0).abs());
-        let m = l - c / 2.0;
-        let cm = c + m;
-        let xm = x + m;
-
-        let (r, g, b) = match (h * 6.0).floor() as i32 {
-            0 | 6 => (cm, xm, m),
-            1 => (xm, cm, m),
-            2 => (m, cm, xm),
-            3 => (m, xm, cm),
-            4 => (xm, m, cm),
-            _ => (cm, m, xm),
-        };
-
-        Rgba {
-            r: r.clamp(0., 1.),
-            g: g.clamp(0., 1.),
-            b: b.clamp(0., 1.),
-            a: color.a,
-        }
-    }
-}
-
-impl TryFrom<&'_ str> for Rgba {
-    type Error = anyhow::Error;
-
-    fn try_from(value: &'_ str) -> Result<Self, Self::Error> {
-        const RGB: usize = "rgb".len();
-        const RGBA: usize = "rgba".len();
-        const RRGGBB: usize = "rrggbb".len();
-        const RRGGBBAA: usize = "rrggbbaa".len();
-
-        const EXPECTED_FORMATS: &str = "Expected #rgb, #rgba, #rrggbb, or #rrggbbaa";
-        const INVALID_UNICODE: &str = "invalid unicode characters in color";
-
-        let Some(("", hex)) = value.trim().split_once('#') else {
-            bail!("invalid RGBA hex color: '{value}'. {EXPECTED_FORMATS}");
-        };
-
-        let (r, g, b, a) = match hex.len() {
-            RGB | RGBA => {
-                let r = u8::from_str_radix(
-                    hex.get(0..1).with_context(|| {
-                        format!("{INVALID_UNICODE}: r component of #rgb/#rgba for value: '{value}'")
-                    })?,
-                    16,
-                )?;
-                let g = u8::from_str_radix(
-                    hex.get(1..2).with_context(|| {
-                        format!("{INVALID_UNICODE}: g component of #rgb/#rgba for value: '{value}'")
-                    })?,
-                    16,
-                )?;
-                let b = u8::from_str_radix(
-                    hex.get(2..3).with_context(|| {
-                        format!("{INVALID_UNICODE}: b component of #rgb/#rgba for value: '{value}'")
-                    })?,
-                    16,
-                )?;
-                let a = if hex.len() == RGBA {
-                    u8::from_str_radix(
-                        hex.get(3..4).with_context(|| {
-                            format!("{INVALID_UNICODE}: a component of #rgba for value: '{value}'")
-                        })?,
-                        16,
-                    )?
-                } else {
-                    0xf
-                };
-
-                /// Duplicates a given hex digit.
-                /// E.g., `0xf` -> `0xff`.
-                const fn duplicate(value: u8) -> u8 {
-                    (value << 4) | value
-                }
-
-                (duplicate(r), duplicate(g), duplicate(b), duplicate(a))
-            }
-            RRGGBB | RRGGBBAA => {
-                let r = u8::from_str_radix(
-                    hex.get(0..2).with_context(|| {
-                        format!(
-                            "{}: r component of #rrggbb/#rrggbbaa for value: '{}'",
-                            INVALID_UNICODE, value
-                        )
-                    })?,
-                    16,
-                )?;
-                let g = u8::from_str_radix(
-                    hex.get(2..4).with_context(|| {
-                        format!(
-                            "{INVALID_UNICODE}: g component of #rrggbb/#rrggbbaa for value: '{value}'"
-                        )
-                    })?,
-                    16,
-                )?;
-                let b = u8::from_str_radix(
-                    hex.get(4..6).with_context(|| {
-                        format!(
-                            "{INVALID_UNICODE}: b component of #rrggbb/#rrggbbaa for value: '{value}'"
-                        )
-                    })?,
-                    16,
-                )?;
-                let a = if hex.len() == RRGGBBAA {
-                    u8::from_str_radix(
-                        hex.get(6..8).with_context(|| {
-                            format!(
-                                "{INVALID_UNICODE}: a component of #rrggbbaa for value: '{value}'"
-                            )
-                        })?,
-                        16,
-                    )?
-                } else {
-                    0xff
-                };
-                (r, g, b, a)
-            }
-            _ => bail!("invalid RGBA hex color: '{value}'. {EXPECTED_FORMATS}"),
-        };
-
-        Ok(Rgba {
-            r: r as f32 / 255.,
-            g: g as f32 / 255.,
-            b: b as f32 / 255.,
-            a: a as f32 / 255.,
-        })
-    }
-}
-
-/// An HSLA color
-#[derive(Default, Copy, Clone, Debug)]
-#[repr(C)]
-pub struct Hsla {
-    /// Hue, in a range from 0 to 1
-    pub h: f32,
-
-    /// Saturation, in a range from 0 to 1
-    pub s: f32,
-
-    /// Lightness, in a range from 0 to 1
-    pub l: f32,
-
-    /// Alpha, in a range from 0 to 1
-    pub a: f32,
-}
-
-#[cfg(feature = "proptest")]
-mod property {
-    use super::Hsla;
-    use proptest::prelude::*;
-
-    impl Hsla {
-        /// Proptest [`Strategy`] that produces opaque colors (i.e. alpha = 1).
-        ///
-        /// For truly arbitrary colors, use the [`Arbitrary`] implementation.
-        pub fn opaque_strategy() -> impl Strategy<Value = Self> {
-            (0.0f32..=1.0, 0.0f32..=1.0, 0.0f32..=1.0).prop_map(|(h, s, l)| Hsla { h, s, l, a: 1. })
-        }
-    }
-
-    impl Arbitrary for Hsla {
-        type Strategy = BoxedStrategy<Self>;
-        type Parameters = ();
-
-        fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
-            (0.0f32..=1.0, 0.0f32..=1.0, 0.0f32..=1.0, 0.0f32..=1.0)
-                .prop_map(|(h, s, l, a)| Hsla { h, s, l, a })
-                .boxed()
-        }
-    }
-}
-
-impl PartialEq for Hsla {
-    fn eq(&self, other: &Self) -> bool {
-        self.h
-            .total_cmp(&other.h)
-            .then(self.s.total_cmp(&other.s))
-            .then(self.l.total_cmp(&other.l).then(self.a.total_cmp(&other.a)))
-            .is_eq()
-    }
-}
-
-impl PartialOrd for Hsla {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for Hsla {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.h
-            .total_cmp(&other.h)
-            .then(self.s.total_cmp(&other.s))
-            .then(self.l.total_cmp(&other.l).then(self.a.total_cmp(&other.a)))
-    }
-}
-
-impl Eq for Hsla {}
-
-impl Hash for Hsla {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write_u32(u32::from_be_bytes(self.h.to_be_bytes()));
-        state.write_u32(u32::from_be_bytes(self.s.to_be_bytes()));
-        state.write_u32(u32::from_be_bytes(self.l.to_be_bytes()));
-        state.write_u32(u32::from_be_bytes(self.a.to_be_bytes()));
-    }
-}
-
-impl Display for Hsla {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "hsla({:.2}, {:.2}%, {:.2}%, {:.2})",
-            self.h * 360.,
-            self.s * 100.,
-            self.l * 100.,
-            self.a
-        )
-    }
-}
-
 /// Construct an [`Hsla`] object from plain values
 pub const fn hsla(h: f32, s: f32, l: f32, a: f32) -> Hsla {
     Hsla {
-        h: h.clamp(0., 1.),
-        s: s.clamp(0., 1.),
-        l: l.clamp(0., 1.),
-        a: a.clamp(0., 1.),
+        color: palette::Hsl::new_const(
+            RgbHue::new(h.clamp(0., 1.)),
+            s.clamp(0., 1.),
+            l.clamp(0., 1.),
+        ),
+        alpha: a.clamp(0., 1.),
     }
+}
+
+/// Constructs a ['Oklcha'](palette::Oklcha) object from plain values.
+pub fn oklcha<T>(lightness: T, chroma: T, hue: impl Into<OklabHue<T>>, alpha: T) -> Oklcha<T> {
+    Oklcha::new(lightness, chroma, hue, alpha)
 }
 
 /// Pure black in [`Hsla`]
 pub const fn black() -> Hsla {
-    Hsla {
-        h: 0.,
-        s: 0.,
-        l: 0.,
-        a: 1.,
-    }
+    Hsla::new_const(RgbHue::new(0.), 0., 0., 1.)
 }
 
 /// Transparent black in [`Hsla`]
 pub const fn transparent_black() -> Hsla {
-    Hsla {
-        h: 0.,
-        s: 0.,
-        l: 0.,
-        a: 0.,
-    }
+    Hsla::new_const(RgbHue::new(0.), 0., 0., 0.)
 }
 
 /// Transparent white in [`Hsla`]
 pub const fn transparent_white() -> Hsla {
-    Hsla {
-        h: 0.,
-        s: 0.,
-        l: 1.,
-        a: 0.,
-    }
+    Hsla::new_const(RgbHue::new(0.), 0., 1., 0.)
 }
 
-/// Opaque grey in [`Hsla`], values will be clamped to the range [0, 1]
+/// Opaque grey in [`Hsla`], values must be provided in the range [0, 1]
 pub const fn opaque_grey(lightness: f32, opacity: f32) -> Hsla {
-    Hsla {
-        h: 0.,
-        s: 0.,
-        l: lightness.clamp(0., 1.),
-        a: opacity.clamp(0., 1.),
-    }
+    Hsla::new_const(RgbHue::new(0.), 0., lightness, opacity)
 }
 
 /// Pure white in [`Hsla`]
 pub const fn white() -> Hsla {
-    Hsla {
-        h: 0.,
-        s: 0.,
-        l: 1.,
-        a: 1.,
-    }
+    Hsla::new_const(RgbHue::new(0.), 0., 1., 1.)
 }
 
 /// The color red in [`Hsla`]
 pub const fn red() -> Hsla {
-    Hsla {
-        h: 0.,
-        s: 1.,
-        l: 0.5,
-        a: 1.,
-    }
+    Hsla::new_const(RgbHue::new(0.), 1., 0.5, 1.)
 }
 
 /// The color blue in [`Hsla`]
 pub const fn blue() -> Hsla {
-    Hsla {
-        h: 0.6666666667,
-        s: 1.,
-        l: 0.5,
-        a: 1.,
-    }
+    Hsla::new_const(RgbHue::new(0.6666666667), 1., 0.5, 1.)
 }
 
 /// The color green in [`Hsla`]
 pub const fn green() -> Hsla {
-    Hsla {
-        h: 0.3333333333,
-        s: 1.,
-        l: 0.25,
-        a: 1.,
-    }
+    Hsla::new_const(RgbHue::new(0.3333333333), 1., 0.25, 1.)
 }
 
 /// The color yellow in [`Hsla`]
 pub const fn yellow() -> Hsla {
-    Hsla {
-        h: 0.1666666667,
-        s: 1.,
-        l: 0.5,
-        a: 1.,
-    }
+    Hsla::new_const(RgbHue::new(0.1666666667), 1., 0.5, 1.)
 }
 
-impl Hsla {
-    /// Converts this HSLA color to an RGBA color.
-    pub fn to_rgb(self) -> Rgba {
-        self.into()
-    }
-
-    /// The color red
-    pub const fn red() -> Self {
-        red()
-    }
-
-    /// The color green
-    pub const fn green() -> Self {
-        green()
-    }
-
-    /// The color blue
-    pub const fn blue() -> Self {
-        blue()
-    }
-
-    /// The color black
-    pub const fn black() -> Self {
-        black()
-    }
-
-    /// The color white
-    pub const fn white() -> Self {
-        white()
-    }
-
-    /// The color transparent black
-    pub const fn transparent_black() -> Self {
-        transparent_black()
-    }
-
-    /// Returns true if the HSLA color is fully transparent, false otherwise.
-    pub fn is_transparent(&self) -> bool {
-        self.a == 0.0
-    }
-
-    /// Returns true if the HSLA color is fully opaque, false otherwise.
-    pub fn is_opaque(&self) -> bool {
-        self.a == 1.0
-    }
-
-    /// Blends `other` on top of `self` based on `other`'s alpha value. The resulting color is a combination of `self`'s and `other`'s colors.
-    ///
-    /// If `other`'s alpha value is 1.0 or greater, `other` color is fully opaque, thus `other` is returned as the output color.
-    /// If `other`'s alpha value is 0.0 or less, `other` color is fully transparent, thus `self` is returned as the output color.
-    /// Else, the output color is calculated as a blend of `self` and `other` based on their weighted alpha values.
-    ///
-    /// Assumptions:
-    /// - Alpha values are contained in the range [0, 1], with 1 as fully opaque and 0 as fully transparent.
-    /// - The relative contributions of `self` and `other` is based on `self`'s alpha value (`self.a`) and `other`'s  alpha value (`other.a`), `self` contributing `self.a * (1.0 - other.a)` and `other` contributing its own alpha value.
-    /// - RGB color components are contained in the range [0, 1].
-    /// - If `self` and `other` colors are out of the valid range, the blend operation's output and behavior is undefined.
-    pub fn blend(self, other: Hsla) -> Hsla {
-        let alpha = other.a;
-
-        if alpha >= 1.0 {
-            other
-        } else if alpha <= 0.0 {
-            self
-        } else {
-            let converted_self = Rgba::from(self);
-            let converted_other = Rgba::from(other);
-            let blended_rgb = converted_self.blend(converted_other);
-            Hsla::from(blended_rgb)
+/// Generates the JsonSchema for palette::Hsla
+pub fn hsla_schemar(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    // https://github.com/Ogeon/palette/blob/9aa1ac21a7da60db398e8c044a43dbf3fdaf4855/palette/src/hsl.rs#L633-L636
+    // https://github.com/Ogeon/palette/blob/9aa1ac21a7da60db398e8c044a43dbf3fdaf4855/palette/src/alpha/alpha.rs#L1197
+    json_schema!({
+        "type": "object",
+        "properties": {
+          "hue": {
+              "type": "number",
+              "format": "float"
+          },
+          "saturation": {
+              "type": "number",
+              "format": "float"
+          },
+          "lightness": {
+              "type": "number",
+              "format": "float"
+          },
+          "alpha": {
+              "type": "number",
+              "format": "float"
+          },
         }
-    }
+    })
+}
 
-    /// Returns a new HSLA color with the same hue, and lightness, but with no saturation.
-    pub fn grayscale(&self) -> Self {
-        Hsla {
-            h: self.h,
-            s: 0.,
-            l: self.l,
-            a: self.a,
+/// Generates the JsonSchema for palette::Rgba
+pub fn rgba_schemar(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    // https://github.com/Ogeon/palette/blob/9aa1ac21a7da60db398e8c044a43dbf3fdaf4855/palette/src/rgb/rgb.rs#L1690
+    // https://github.com/Ogeon/palette/blob/9aa1ac21a7da60db398e8c044a43dbf3fdaf4855/palette/src/alpha/alpha.rs#L1197
+    json_schema!({
+        "type": "object",
+        "properties": {
+          "red": {
+              "type": "number",
+              "format": "float"
+          },
+          "green": {
+              "type": "number",
+              "format": "float"
+          },
+          "blue": {
+              "type": "number",
+              "format": "float"
+          },
+          "alpha": {
+              "type": "number",
+              "format": "float"
+          },
         }
-    }
+    })
+}
+
+/// Wrapper methods to make alpha operations more convenient
+pub trait ColorExt {
+    /// Performs a SrcAlpha x (1 - SrcAlpha) blend
+    fn blend(&self, other: &Self) -> Self
+    where
+        Self: Sized;
 
     /// Fade out the color by a given factor. This factor should be between 0.0 and 1.0.
     /// Where 0.0 will leave the color unchanged, and 1.0 will completely fade out the color.
-    pub fn fade_out(&mut self, factor: f32) {
-        self.a *= 1.0 - factor.clamp(0., 1.);
-    }
+    fn fade_out(&mut self, factor: f32);
 
-    /// Multiplies the alpha value of the color by a given factor
-    /// and returns a new HSLA color.
+    /// Multiplies the alpha value of the color by a given factor and returns a new color.
+    /// If the color was previously opaque, then this is equivalent to
+    /// [`with_alpha`](palette::WithAlpha::with_alpha).
     ///
     /// Useful for transforming colors with dynamic opacity,
     /// like a color from an external source.
     ///
     /// Example:
     /// ```
+    /// use gpui::ColorExt;
     /// let color = gpui::red();
     /// let faded_color = color.opacity(0.5);
-    /// assert_eq!(faded_color.a, 0.5);
+    /// assert_eq!(faded_color.alpha, 0.5);
     /// ```
     ///
     /// This will return a red color with half the opacity.
     ///
     /// Example:
     /// ```
-    /// use gpui::hsla;
+    /// use gpui::{hsla, ColorExt};
     /// let color = hsla(0.7, 1.0, 0.5, 0.7); // A saturated blue
     /// let faded_color = color.opacity(0.16);
-    /// assert!((faded_color.a - 0.112).abs() < 1e-6);
+    /// assert!((faded_color.alpha - 0.112).abs() < 1e-6);
     /// ```
     ///
     /// This will return a blue color with around ~10% opacity,
     /// suitable for an element's hover or selected state.
     ///
-    pub fn opacity(&self, factor: f32) -> Self {
-        Hsla {
-            h: self.h,
-            s: self.s,
-            l: self.l,
-            a: self.a * factor.clamp(0., 1.),
-        }
-    }
-
-    /// Returns a new HSLA color with the same hue, saturation,
-    /// and lightness, but with a new alpha value.
-    ///
-    /// Example:
-    /// ```
-    /// let color = gpui::red();
-    /// let red_color = color.alpha(0.25);
-    /// assert_eq!(red_color.a, 0.25);
-    /// ```
-    ///
-    /// This will return a red color with 25% opacity.
-    ///
-    /// Example:
-    /// ```
-    /// use gpui::hsla;
-    /// let color = hsla(0.7, 1.0, 0.5, 0.7); // A saturated blue
-    /// let faded_color = color.alpha(0.25);
-    /// assert_eq!(faded_color.a, 0.25);
-    /// ```
-    ///
-    /// This will return a blue color with 25% opacity.
-    pub fn alpha(&self, a: f32) -> Self {
-        Hsla {
-            h: self.h,
-            s: self.s,
-            l: self.l,
-            a: a.clamp(0., 1.),
-        }
-    }
-}
-
-impl From<Rgba> for Hsla {
-    fn from(color: Rgba) -> Self {
-        let r = color.r;
-        let g = color.g;
-        let b = color.b;
-
-        let max = r.max(g.max(b));
-        let min = r.min(g.min(b));
-        let delta = max - min;
-
-        let l = (max + min) / 2.0;
-        let s = if l == 0.0 || l == 1.0 {
-            0.0
-        } else if l < 0.5 {
-            delta / (2.0 * l)
-        } else {
-            delta / (2.0 - 2.0 * l)
-        };
-
-        let h = if delta == 0.0 {
-            0.0
-        } else if max == r {
-            ((g - b) / delta).rem_euclid(6.0) / 6.0
-        } else if max == g {
-            ((b - r) / delta + 2.0) / 6.0
-        } else {
-            ((r - g) / delta + 4.0) / 6.0
-        };
-
-        Hsla {
-            h,
-            s,
-            l,
-            a: color.a,
-        }
-    }
-}
-
-impl JsonSchema for Hsla {
-    fn schema_name() -> Cow<'static, str> {
-        Rgba::schema_name()
-    }
-
-    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
-        Rgba::json_schema(generator)
-    }
-}
-
-impl Serialize for Hsla {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    fn opacity(&self, factor: f32) -> Self
     where
-        S: Serializer,
-    {
-        Rgba::from(*self).serialize(serializer)
+        Self: Sized;
+}
+impl ColorExt for Rgba {
+    fn blend(&self, other: &Self) -> Self {
+        use palette::blend::{BlendWith, Equations, Parameter};
+        let blend_mode =
+            Equations::from_parameters(Parameter::OneMinusSourceAlpha, Parameter::SourceAlpha);
+        self.blend_with(*other, blend_mode)
+    }
+
+    fn fade_out(&mut self, factor: f32) {
+        self.alpha *= 1.0 - factor.clamp(0., 1.);
+    }
+
+    fn opacity(&self, factor: f32) -> Self {
+        let mut color = *self;
+        color.alpha *= factor.clamp(0., 1.);
+        color
     }
 }
+impl ColorExt for Hsla {
+    fn blend(&self, other: &Self) -> Self {
+        let this: Rgba = (*self).into_color();
+        let other: Rgba = (*other).into_color();
+        this.blend(&other).into_color()
+    }
 
-impl<'de> Deserialize<'de> for Hsla {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Ok(Rgba::deserialize(deserializer)?.into())
+    fn fade_out(&mut self, factor: f32) {
+        self.alpha *= 1.0 - factor.clamp(0., 1.);
+    }
+
+    fn opacity(&self, factor: f32) -> Self {
+        let mut color = *self;
+        color.alpha *= factor.clamp(0., 1.);
+        color
     }
 }
 
@@ -779,7 +266,7 @@ impl Display for ColorSpace {
 pub struct Background {
     pub(crate) tag: BackgroundTag,
     pub(crate) color_space: ColorSpace,
-    pub(crate) solid: Hsla,
+    pub(crate) solid: crate::SceneHsla,
     pub(crate) gradient_angle_or_pattern_height: f32,
     pub(crate) colors: [LinearColorStop; 2],
     /// Padding for alignment for repr(C) layout.
@@ -814,7 +301,7 @@ impl Default for Background {
     fn default() -> Self {
         Self {
             tag: BackgroundTag::Solid,
-            solid: Hsla::default(),
+            solid: Hsla::default().into(),
             color_space: ColorSpace::default(),
             gradient_angle_or_pattern_height: 0.0,
             colors: [LinearColorStop::default(), LinearColorStop::default()],
@@ -824,33 +311,33 @@ impl Default for Background {
 }
 
 /// Creates a hash pattern background
-pub fn pattern_slash(color: impl Into<Hsla>, width: f32, interval: f32) -> Background {
+pub fn pattern_slash(color: impl IntoColor<Hsla>, width: f32, interval: f32) -> Background {
     let width_scaled = (width * 255.0) as u32;
     let interval_scaled = (interval * 255.0) as u32;
     let height = ((width_scaled * 0xFFFF) + interval_scaled) as f32;
 
     Background {
         tag: BackgroundTag::PatternSlash,
-        solid: color.into(),
+        solid: color.into_color().into(),
         gradient_angle_or_pattern_height: height,
         ..Default::default()
     }
 }
 
 /// Creates a checkerboard pattern background
-pub fn checkerboard(color: impl Into<Hsla>, size: f32) -> Background {
+pub fn checkerboard(color: impl IntoColor<Hsla>, size: f32) -> Background {
     Background {
         tag: BackgroundTag::Checkerboard,
-        solid: color.into(),
+        solid: color.into_color().into(),
         gradient_angle_or_pattern_height: size,
         ..Default::default()
     }
 }
 
 /// Creates a solid background color.
-pub fn solid_background(color: impl Into<Hsla>) -> Background {
+pub fn solid_background(color: impl IntoColor<Hsla>) -> Background {
     Background {
-        solid: color.into(),
+        solid: color.into_color().into(),
         ..Default::default()
     }
 }
@@ -882,7 +369,7 @@ pub fn linear_gradient(
 #[repr(C)]
 pub struct LinearColorStop {
     /// The color of the color stop.
-    pub color: Hsla,
+    pub color: crate::SceneHsla,
     /// The percentage of the gradient, in the range 0.0 to 1.0.
     pub percentage: f32,
 }
@@ -890,9 +377,9 @@ pub struct LinearColorStop {
 /// Creates a new linear color stop.
 ///
 /// The percentage of the gradient, in the range 0.0 to 1.0.
-pub fn linear_color_stop(color: impl Into<Hsla>, percentage: f32) -> LinearColorStop {
+pub fn linear_color_stop(color: impl IntoColor<Hsla>, percentage: f32) -> LinearColorStop {
     LinearColorStop {
-        color: color.into(),
+        color: color.into_color().into(),
         percentage,
     }
 }
@@ -900,9 +387,10 @@ pub fn linear_color_stop(color: impl Into<Hsla>, percentage: f32) -> LinearColor
 impl LinearColorStop {
     /// Returns a new color stop with the same color, but with a modified alpha value.
     pub fn opacity(&self, factor: f32) -> Self {
+        let color: Hsla = self.color.into();
         Self {
             percentage: self.percentage,
-            color: self.color.opacity(factor),
+            color: color.opacity(factor).into(),
         }
     }
 }
@@ -911,7 +399,7 @@ impl Background {
     /// Returns the solid color if this is a solid background, None otherwise.
     pub fn as_solid(&self) -> Option<Hsla> {
         if self.tag == BackgroundTag::Solid {
-            Some(self.solid)
+            Some(self.solid.into())
         } else {
             None
         }
@@ -928,7 +416,8 @@ impl Background {
     /// Returns a new background color with the same hue, saturation, and lightness, but with a modified alpha value.
     pub fn opacity(&self, factor: f32) -> Self {
         let mut background = *self;
-        background.solid = background.solid.opacity(factor);
+        let solid: Hsla = background.solid.into();
+        background.solid = solid.opacity(factor).into();
         background.colors = [
             self.colors[0].opacity(factor),
             self.colors[1].opacity(factor),
@@ -939,29 +428,19 @@ impl Background {
     /// Returns whether the background color is transparent.
     pub fn is_transparent(&self) -> bool {
         match self.tag {
-            BackgroundTag::Solid => self.solid.is_transparent(),
-            BackgroundTag::LinearGradient => self.colors.iter().all(|c| c.color.is_transparent()),
-            BackgroundTag::PatternSlash => self.solid.is_transparent(),
-            BackgroundTag::Checkerboard => self.solid.is_transparent(),
+            BackgroundTag::Solid => self.solid.a == 0.,
+            BackgroundTag::LinearGradient => self.colors.iter().all(|c| c.color.a == 0.),
+            BackgroundTag::PatternSlash => self.solid.a == 0.,
+            BackgroundTag::Checkerboard => self.solid.a == 0.,
         }
     }
 }
 
-impl From<Hsla> for Background {
-    fn from(value: Hsla) -> Self {
-        Background {
+impl<T: IntoColor<Hsla>> From<T> for Background {
+    fn from(value: T) -> Self {
+        Self {
             tag: BackgroundTag::Solid,
-            solid: value,
-            ..Default::default()
-        }
-    }
-}
-
-impl From<Rgba> for Background {
-    fn from(value: Rgba) -> Self {
-        Background {
-            tag: BackgroundTag::Solid,
-            solid: Hsla::from(value),
+            solid: value.into_color().into(),
             ..Default::default()
         }
     }
@@ -969,62 +448,18 @@ impl From<Rgba> for Background {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
-
     use super::*;
 
     #[test]
-    fn test_deserialize_three_value_hex_to_rgba() {
-        let actual: Rgba = serde_json::from_value(json!("#f09")).unwrap();
-
-        assert_eq!(actual, rgba(0xff0099ff))
-    }
-
-    #[test]
-    fn test_deserialize_four_value_hex_to_rgba() {
-        let actual: Rgba = serde_json::from_value(json!("#f09f")).unwrap();
-
-        assert_eq!(actual, rgba(0xff0099ff))
-    }
-
-    #[test]
-    fn test_deserialize_six_value_hex_to_rgba() {
-        let actual: Rgba = serde_json::from_value(json!("#ff0099")).unwrap();
-
-        assert_eq!(actual, rgba(0xff0099ff))
-    }
-
-    #[test]
-    fn test_deserialize_eight_value_hex_to_rgba() {
-        let actual: Rgba = serde_json::from_value(json!("#ff0099ff")).unwrap();
-
-        assert_eq!(actual, rgba(0xff0099ff))
-    }
-
-    #[test]
-    fn test_deserialize_eight_value_hex_with_padding_to_rgba() {
-        let actual: Rgba = serde_json::from_value(json!(" #f5f5f5ff   ")).unwrap();
-
-        assert_eq!(actual, rgba(0xf5f5f5ff))
-    }
-
-    #[test]
-    fn test_deserialize_eight_value_hex_with_mixed_case_to_rgba() {
-        let actual: Rgba = serde_json::from_value(json!("#DeAdbEeF")).unwrap();
-
-        assert_eq!(actual, rgba(0xdeadbeef))
-    }
-
-    #[test]
     fn test_background_solid() {
-        let color = Hsla::from(rgba(0xff0099ff));
+        let color: Hsla = rgba(0xff0099ff).into_color();
         let mut background = Background::from(color);
         assert_eq!(background.tag, BackgroundTag::Solid);
-        assert_eq!(background.solid, color);
+        assert_eq!(background.solid, color.into());
 
-        assert_eq!(background.opacity(0.5).solid, color.opacity(0.5));
+        assert_eq!(background.opacity(0.5).solid, color.opacity(0.5).into());
         assert!(!background.is_transparent());
-        background.solid = hsla(0.0, 0.0, 0.0, 0.0);
+        background.solid = hsla(0.0, 0.0, 0.0, 0.0).into();
         assert!(background.is_transparent());
     }
 
@@ -1045,26 +480,18 @@ mod tests {
 
     #[test]
     fn test_rgba_alpha() {
-        let color = Rgba {
-            r: 0.2,
-            g: 0.6,
-            b: 1.0,
-            a: 0.8,
-        };
-
-        assert_eq!(color.alpha(0.25).a, 0.25);
-        assert_eq!(color.alpha(1.5).a, 1.0);
+        use palette::WithAlpha;
+        let color = Rgba::<palette::Srgb>::new(0.2, 0.6, 1.0, 0.8);
+        assert_eq!(color.with_alpha(0.25).alpha, 0.25);
+        // NOTE: diverging from upstream, where Rgba::alpha clamps. palette does not clamp alpha
+        assert_eq!(color.with_alpha(1.5).alpha, 1.5);
     }
 
     #[test]
     fn test_rgba_opacity() {
-        let color = Rgba {
-            r: 0.2,
-            g: 0.6,
-            b: 1.0,
-            a: 0.8,
-        };
-        assert!((color.opacity(0.5).a - 0.4).abs() < 1e-6);
-        assert_eq!(color.opacity(2.0).a, 0.8);
+        use super::ColorExt;
+        let color = Rgba::new(0.2, 0.6, 1.0, 0.8);
+        assert!((color.opacity(0.5).alpha - 0.4).abs() < 1e-6);
+        assert_eq!(color.opacity(2.0).alpha, 0.8);
     }
 }

--- a/crates/gpui/src/colors.rs
+++ b/crates/gpui/src/colors.rs
@@ -1,4 +1,5 @@
-use crate::{App, Global, Rgba, Window, WindowAppearance, rgb};
+use crate::{App, Global, Window, WindowAppearance, rgb};
+use palette::rgb::Rgba;
 use std::ops::Deref;
 use std::sync::Arc;
 

--- a/crates/gpui/src/lerp.rs
+++ b/crates/gpui/src/lerp.rs
@@ -1,13 +1,12 @@
 //! Lerp trait defines behaviour for interpolating between two values of the same type.
-
+use crate::{
+    Bounds, Corners, DevicePixels, Edges, Percentage, Pixels, Point, Radians, Rems, Size,
+    colors::Colors,
+};
+use palette::rgb::Rgba;
 use std::{
     fmt::Debug,
     ops::{Add, Mul, Sub},
-};
-
-use crate::{
-    Bounds, Corners, DevicePixels, Edges, Percentage, Pixels, Point, Radians, Rems, Rgba, Size,
-    colors::Colors,
 };
 
 /// A trait for types that can be linearly interpolated.
@@ -88,9 +87,19 @@ struct_lerps!(
     Edges<T> { top, right, bottom, left },
     Corners<T> { top_left, top_right, bottom_right, bottom_left },
     Bounds<T> { origin, size },
-    Rgba { r, g, b, a },
+    Rgba { color, alpha },
     Colors { text, selected_text, background, disabled, selected, border, separator, container }
 );
+
+impl Lerp for palette::rgb::Rgb {
+    fn lerp(&self, to: &Self, delta: f32) -> Self {
+        Self::new(
+            self.red.lerp(&to.red, delta),
+            self.green.lerp(&to.green, delta),
+            self.blue.lerp(&to.blue, delta),
+        )
+    }
+}
 
 macro_rules! tuple_struct_lerps {
     ( $( $ty:ident ( $n:ty ) ),+ ) => {
@@ -288,46 +297,26 @@ mod tests {
 
     #[test]
     fn test_rgba_lerp() {
-        let start = Rgba {
-            r: 0.0,
-            g: 0.0,
-            b: 0.0,
-            a: 1.0,
-        };
-        let end = Rgba {
-            r: 1.0,
-            g: 1.0,
-            b: 1.0,
-            a: 1.0,
-        };
+        let start = Rgba::new(0., 0., 0., 1.);
+        let end = Rgba::new(1., 1., 1., 1.);
 
         let mid = start.lerp(&end, 0.5);
-        assert_eq!(mid.r, 0.5);
-        assert_eq!(mid.g, 0.5);
-        assert_eq!(mid.b, 0.5);
-        assert_eq!(mid.a, 1.0);
+        assert_eq!(mid.red, 0.5);
+        assert_eq!(mid.green, 0.5);
+        assert_eq!(mid.blue, 0.5);
+        assert_eq!(mid.alpha, 1.0);
     }
 
     #[test]
     fn test_rgba_lerp_with_alpha() {
-        let start = Rgba {
-            r: 1.0,
-            g: 0.0,
-            b: 0.0,
-            a: 0.0,
-        };
-        let end = Rgba {
-            r: 0.0,
-            g: 0.0,
-            b: 1.0,
-            a: 1.0,
-        };
+        let start = Rgba::new(1., 0., 0., 0.);
+        let end = Rgba::new(0., 0., 1., 1.);
 
         let mid = start.lerp(&end, 0.5);
-        assert_eq!(mid.r, 0.5);
-        assert_eq!(mid.g, 0.0);
-        assert_eq!(mid.b, 0.5);
-        assert_eq!(mid.a, 0.5);
+        assert_eq!(mid.red, 0.5);
+        assert_eq!(mid.green, 0.0);
+        assert_eq!(mid.blue, 0.5);
+        assert_eq!(mid.alpha, 0.5);
     }
 
     #[test]

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -37,7 +37,7 @@ pub(crate) type PlatformScreenCaptureFrame = core_video::image_buffer::CVImageBu
 use crate::{
     Action, AnyWindowHandle, App, AsyncWindowContext, BackgroundExecutor, Bounds,
     DEFAULT_WINDOW_SIZE, DevicePixels, DispatchEventResult, Edges, ExternalDragPayload, Font,
-    FontId, FontMetrics, FontRun, ForegroundExecutor, GlyphId, GpuSpecs, Hsla, ImageSource, Keymap,
+    FontId, FontMetrics, FontRun, ForegroundExecutor, GlyphId, GpuSpecs, ImageSource, Keymap,
     LineLayout, Pixels, PlatformGestures, PlatformInput, Point, Priority, RenderGlyphParams,
     RenderImage, RenderImageParams, RenderSvgParams, Scene, ShapedGlyph, ShapedRun, SharedString,
     Size, SvgRenderer, SystemWindowTab, Task, Window, WindowControlArea, hash, point, px, size,
@@ -1131,7 +1131,7 @@ pub trait PlatformTextSystem: Send + Sync {
     fn recommended_rendering_mode(&self, _font_id: FontId, _font_size: Pixels)
     -> TextRenderingMode;
     /// Returns the dilation level to use for a glyph painted in the given color.
-    fn glyph_dilation_for_color(&self, _color: Hsla) -> u8 {
+    fn glyph_dilation_for_color(&self, _color: palette::Hsla) -> u8 {
         0
     }
 }

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -5,8 +5,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AtlasTextureId, AtlasTile, Background, Bounds, ContentMask, Corners, Edges, Hsla, Pixels,
-    Point, Radians, ScaledFilter, ScaledPixels, Size, bounds_tree::BoundsTree, point,
+    AtlasTextureId, AtlasTile, Background, Bounds, ContentMask, Corners, Edges, Pixels, Point,
+    Radians, ScaledFilter, ScaledPixels, Size, bounds_tree::BoundsTree, point,
 };
 use smallvec::SmallVec;
 use std::{
@@ -248,6 +248,35 @@ impl Scene {
             backdrop_filters_iter: self.backdrop_filters.iter().peekable(),
             filter_boundaries_start: 0,
             filter_boundaries_iter: self.filter_boundaries.iter().peekable(),
+        }
+    }
+}
+
+/// Internal representation of [`palette::Hsla`] which is layout sensitive, as its provided to the renderer.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[repr(C)]
+pub struct SceneHsla {
+    /// Hue, in a range from 0 to 1
+    pub(crate) h: f32,
+    /// Saturation, in a range from 0 to 1
+    pub(crate) s: f32,
+    /// Lightness, in a range from 0 to 1
+    pub(crate) l: f32,
+    /// Alpha, in a range from 0 to 1
+    pub(crate) a: f32,
+}
+impl Into<palette::Hsla> for SceneHsla {
+    fn into(self) -> palette::Hsla {
+        palette::Hsla::new(self.h * 360.0, self.s, self.l, self.a)
+    }
+}
+impl From<palette::Hsla> for SceneHsla {
+    fn from(hsla: palette::Hsla) -> Self {
+        Self {
+            h: hsla.hue.into_positive_degrees() / 360.0,
+            s: hsla.saturation,
+            l: hsla.lightness,
+            a: hsla.alpha,
         }
     }
 }
@@ -661,7 +690,7 @@ pub struct Quad {
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
     pub background: Background,
-    pub border_color: Hsla,
+    pub border_color: SceneHsla,
     pub corner_radii: Corners<ScaledPixels>,
     pub border_widths: Edges<ScaledPixels>,
 }
@@ -680,7 +709,7 @@ pub struct Underline {
     pub pad: u32, // align to 8 bytes
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
-    pub color: Hsla,
+    pub color: SceneHsla,
     pub thickness: ScaledPixels,
     pub wavy: PaddedBool32,
 }
@@ -700,7 +729,7 @@ pub struct Shadow {
     pub bounds: Bounds<ScaledPixels>,
     pub corner_radii: Corners<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
-    pub color: Hsla,
+    pub color: SceneHsla,
     pub element_bounds: Bounds<ScaledPixels>,
     pub element_corner_radii: Corners<ScaledPixels>,
     /// 0 = drop shadow (rendered outside the element), 1 = inset shadow (rendered inside).
@@ -889,7 +918,7 @@ pub struct MonochromeSprite {
     pub pad: u32,
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
-    pub color: Hsla,
+    pub color: SceneHsla,
     pub tile: AtlasTile,
     pub transformation: TransformationMatrix,
 }
@@ -908,7 +937,7 @@ pub struct SubpixelSprite {
     pub pad: u32, // align to 8 bytes
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
-    pub color: Hsla,
+    pub color: SceneHsla,
     pub tile: AtlasTile,
     pub transformation: TransformationMatrix,
 }

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -1,20 +1,16 @@
-use std::{
-    hash::{Hash, Hasher},
-    iter, mem,
-    ops::Range,
-};
-
 use crate::{
-    AbsoluteLength, App, Background, BackgroundTag, BorderStyle, Bounds, ContentMask, Corners,
-    CornersRefinement, CursorStyle, DefiniteLength, DevicePixels, Edges, EdgesRefinement, Font,
-    FontFallbacks, FontFeatures, FontStyle, FontWeight, GridLocation, Hsla, Length, Pixels, Point,
-    PointRefinement, Rgba, ScaledPixels, SharedString, Size, SizeRefinement, Styled, TextRun,
-    Window, black, phi, point, px, quad, rems, size,
+    AbsoluteLength, App, Background, BackgroundTag, BorderStyle, Bounds, ColorExt, ContentMask,
+    Corners, CornersRefinement, CursorStyle, DefiniteLength, DevicePixels, Edges, EdgesRefinement,
+    Font, FontFallbacks, FontFeatures, FontStyle, FontWeight, GridLocation, Length, Pixels, Point,
+    PointRefinement, ScaledPixels, SharedString, Size, SizeRefinement, Styled, TextRun, Window,
+    black, phi, point, px, quad, rems, size,
 };
 use collections::HashSet;
+use palette::{Hsla, IntoColor, rgb::Rgba};
 use refineable::Refineable;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::{iter, mem, ops::Range};
 
 /// Use this struct for interfacing with the 'debug_below' styling from your own elements.
 /// If a parent element has this style set on it, then this struct will be set as a global in
@@ -176,7 +172,7 @@ pub struct GridTemplate {
 
 /// The CSS styling that can be applied to an element via the `Styled` trait
 #[derive(Clone, Refineable, Debug)]
-#[refineable(Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[refineable(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Style {
     /// What layout strategy should be used?
     pub display: Display,
@@ -351,7 +347,7 @@ pub enum Visibility {
 }
 
 /// The possible values of the box-shadow property
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BoxShadow {
     /// What color should the shadow have?
     pub color: Hsla,
@@ -511,7 +507,7 @@ pub enum TextTransform {
 
 /// The properties that can be used to style text in GPUI
 #[derive(Refineable, Clone, Debug, PartialEq)]
-#[refineable(Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[refineable(Debug, PartialEq, Serialize, Deserialize)]
 pub struct TextStyle {
     /// The color of the text
     pub color: Hsla,
@@ -604,7 +600,7 @@ impl TextStyle {
         }
 
         if let Some(color) = style.color {
-            self.color = self.color.blend(color);
+            self.color = self.color.blend(&color);
         }
 
         if let Some(factor) = style.fade_out {
@@ -693,22 +689,6 @@ pub struct HighlightStyle {
     pub fade_out: Option<f32>,
 }
 
-impl Eq for HighlightStyle {}
-
-impl Hash for HighlightStyle {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.color.hash(state);
-        self.font_weight.hash(state);
-        self.font_style.hash(state);
-        self.background_color.hash(state);
-        self.underline.hash(state);
-        self.strikethrough.hash(state);
-        state.write_u32(u32::from_be_bytes(
-            self.fade_out.map(|f| f.to_be_bytes()).unwrap_or_default(),
-        ));
-    }
-}
-
 impl Style {
     /// Returns true if the style is visible and the background is opaque.
     pub fn has_opaque_background(&self) -> bool {
@@ -742,10 +722,7 @@ impl Style {
                 let mut min = bounds.origin;
                 let mut max = bounds.bottom_right();
 
-                if self
-                    .border_color
-                    .is_some_and(|color| !color.is_transparent())
-                {
+                if self.border_color.is_some_and(|color| color.alpha > 0.) {
                     min.x += self.border_widths.left.to_pixels(rem_size);
                     max.x -= self.border_widths.right.to_pixels(rem_size);
                     min.y += self.border_widths.top.to_pixels(rem_size);
@@ -819,17 +796,17 @@ impl Style {
                     Some(color) => match color.tag {
                         BackgroundTag::Solid
                         | BackgroundTag::PatternSlash
-                        | BackgroundTag::Checkerboard => color.solid,
+                        | BackgroundTag::Checkerboard => color.solid.into(),
 
                         BackgroundTag::LinearGradient => color
                             .colors
                             .first()
-                            .map(|stop| stop.color)
+                            .map(|stop| stop.color.into())
                             .unwrap_or_default(),
                     },
                     None => Hsla::default(),
                 };
-                border_color.a = 0.;
+                border_color.alpha = 0.;
                 window.paint_quad(quad(
                     bounds,
                     corner_radii,
@@ -847,7 +824,7 @@ impl Style {
             if self.is_border_visible() {
                 let border_widths = self.border_widths.to_pixels(rem_size);
                 let mut background = self.border_color.unwrap_or_default();
-                background.a = 0.;
+                background.alpha = 0.;
                 window.paint_quad(quad(
                     bounds,
                     corner_radii,
@@ -874,8 +851,7 @@ impl Style {
     }
 
     fn is_border_visible(&self) -> bool {
-        self.border_color
-            .is_some_and(|color| !color.is_transparent())
+        self.border_color.is_some_and(|color| color.alpha > 0.)
             && self.border_widths.any(|length| !length.is_zero())
     }
 }
@@ -936,9 +912,7 @@ impl Default for Style {
 }
 
 /// The properties that can be applied to an underline.
-#[derive(
-    Refineable, Copy, Clone, Default, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
-)]
+#[derive(Refineable, Copy, Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UnderlineStyle {
     /// The thickness of the underline.
     pub thickness: Pixels,
@@ -951,9 +925,7 @@ pub struct UnderlineStyle {
 }
 
 /// The properties that can be applied to a strikethrough.
-#[derive(
-    Refineable, Copy, Clone, Default, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
-)]
+#[derive(Refineable, Copy, Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StrikethroughStyle {
     /// The thickness of the strikethrough.
     pub thickness: Pixels,
@@ -986,21 +958,9 @@ impl Default for Fill {
     }
 }
 
-impl From<Hsla> for Fill {
-    fn from(color: Hsla) -> Self {
+impl<T: Into<Background>> From<T> for Fill {
+    fn from(color: T) -> Self {
         Self::Color(color.into())
-    }
-}
-
-impl From<Rgba> for Fill {
-    fn from(color: Rgba) -> Self {
-        Self::Color(color.into())
-    }
-}
-
-impl From<Background> for Fill {
-    fn from(background: Background) -> Self {
-        Self::Color(background)
     }
 }
 
@@ -1041,7 +1001,7 @@ impl HighlightStyle {
                 .color
                 .map(|other_color| {
                     if let Some(color) = self.color {
-                        color.blend(other_color)
+                        color.blend(&other_color)
                     } else {
                         other_color
                     }
@@ -1094,7 +1054,7 @@ impl From<FontStyle> for HighlightStyle {
 impl From<Rgba> for HighlightStyle {
     fn from(color: Rgba) -> Self {
         Self {
-            color: Some(color.into()),
+            color: Some(color.into_color()),
             ..Default::default()
         }
     }
@@ -1445,6 +1405,7 @@ impl From<Position> for taffy::style::Position {
 #[cfg(test)]
 mod tests {
     use crate::{blue, green, px, red, yellow};
+    use palette::WithAlpha;
 
     use super::*;
 
@@ -1492,7 +1453,7 @@ mod tests {
         let mut style_c = expected_style;
 
         let style_d = HighlightStyle {
-            color: Some(blue().alpha(0.7)),
+            color: Some(blue().with_alpha(0.7)),
             strikethrough: Some(StrikethroughStyle {
                 thickness: px(4.),
                 color: Some(crate::red()),
@@ -1509,7 +1470,7 @@ mod tests {
         };
 
         let expected_style = HighlightStyle {
-            color: Some(red().blend(blue().alpha(0.7))),
+            color: Some(red().blend(&blue().with_alpha(0.7))),
             strikethrough: Some(StrikethroughStyle {
                 thickness: px(4.),
                 color: Some(red()),
@@ -1535,6 +1496,7 @@ mod tests {
 
     #[test]
     fn test_combine_highlights() {
+        let nearly_blue = Hsla::new_const(palette::RgbHue::new(0.6666684), 1., 0.5, 1.);
         assert_eq!(
             combine_highlights(
                 [
@@ -1560,14 +1522,14 @@ mod tests {
                 (
                     1..2,
                     HighlightStyle {
-                        color: Some(blue()),
+                        color: Some(nearly_blue),
                         ..Default::default()
                     }
                 ),
                 (
                     2..3,
                     HighlightStyle {
-                        color: Some(blue()),
+                        color: Some(nearly_blue),
                         font_style: Some(FontStyle::Italic),
                         ..Default::default()
                     }

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -1,8 +1,8 @@
 use crate::{
     self as gpui, AbsoluteLength, AlignContent, AlignItems, AlignSelf, BorderStyle, CursorStyle,
     DefiniteLength, Display, Fill, Filter, FlexDirection, FlexWrap, Font, FontFeatures, FontStyle,
-    FontWeight, GridPlacement, GridTemplate, GridTemplateMinSize, Hsla, JustifyContent, Length,
-    Pixels, SharedString, StrikethroughStyle, StyleRefinement, TextAlign, TextOverflow,
+    FontWeight, GridPlacement, GridTemplate, GridTemplateMinSize, JustifyContent, Length, Pixels,
+    SharedString, StrikethroughStyle, StyleRefinement, TextAlign, TextOverflow,
     TextStyleRefinement, TextTransform, UnderlineStyle, WhiteSpace, px, relative, rems,
 };
 pub use gpui_macros::{
@@ -10,6 +10,7 @@ pub use gpui_macros::{
     overflow_style_methods, padding_style_methods, position_style_methods,
     visibility_style_methods,
 };
+use palette::{Hsla, IntoColor};
 const ELLIPSIS: SharedString = SharedString::new_static("…");
 
 /// A trait for elements that can be styled.
@@ -570,8 +571,8 @@ pub trait Styled: Sized {
     /// Sets the text color of this element.
     ///
     /// This value cascades to its child elements.
-    fn text_color(mut self, color: impl Into<Hsla>) -> Self {
-        self.text_style().color = Some(color.into());
+    fn text_color(mut self, color: impl IntoColor<Hsla>) -> Self {
+        self.text_style().color = Some(color.into_color());
         self
     }
 
@@ -586,8 +587,8 @@ pub trait Styled: Sized {
     /// Sets the background color of this element.
     ///
     /// This value cascades to its child elements.
-    fn text_bg(mut self, bg: impl Into<Hsla>) -> Self {
-        self.text_style().background_color = Some(bg.into());
+    fn text_bg(mut self, bg: impl IntoColor<Hsla>) -> Self {
+        self.text_style().background_color = Some(bg.into_color());
         self
     }
 
@@ -693,10 +694,10 @@ pub trait Styled: Sized {
     }
 
     /// Sets the color for the underline on this element
-    fn text_decoration_color(mut self, color: impl Into<Hsla>) -> Self {
+    fn text_decoration_color(mut self, color: impl IntoColor<Hsla>) -> Self {
         let style = self.text_style();
         let underline = style.underline.get_or_insert_with(Default::default);
-        underline.color = Some(color.into());
+        underline.color = Some(color.into_color());
         self
     }
 

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -1,3 +1,26 @@
+use crate::{
+    Bounds, DevicePixels, Pixels, PlatformTextSystem, Point, Result, SharedString, Size,
+    StrikethroughStyle, TextRenderingMode, UnderlineStyle, px,
+};
+use anyhow::{Context as _, anyhow};
+use collections::FxHashMap;
+use core::fmt;
+use derive_more::{Add, Deref, FromStr, Sub};
+use itertools::Itertools;
+use palette::Hsla;
+use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use smallvec::{SmallVec, smallvec};
+use std::{
+    borrow::Cow,
+    cmp,
+    fmt::{Debug, Display, Formatter},
+    hash::{Hash, Hasher},
+    ops::{Deref, DerefMut, Range},
+    sync::Arc,
+};
+
 mod font_fallbacks;
 mod font_features;
 mod line;
@@ -9,28 +32,6 @@ pub use font_features::*;
 pub use line::*;
 pub use line_layout::*;
 pub use line_wrapper::*;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
-use crate::{
-    Bounds, DevicePixels, Hsla, Pixels, PlatformTextSystem, Point, Result, SharedString, Size,
-    StrikethroughStyle, TextRenderingMode, UnderlineStyle, px,
-};
-use anyhow::{Context as _, anyhow};
-use collections::FxHashMap;
-use core::fmt;
-use derive_more::{Add, Deref, FromStr, Sub};
-use itertools::Itertools;
-use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
-use smallvec::{SmallVec, smallvec};
-use std::{
-    borrow::Cow,
-    cmp,
-    fmt::{Debug, Display, Formatter},
-    hash::{Hash, Hasher},
-    ops::{Deref, DerefMut, Range},
-    sync::Arc,
-};
 
 /// An opaque identifier for a specific font.
 #[derive(Hash, PartialEq, Eq, Clone, Copy, Debug)]
@@ -1015,7 +1016,7 @@ impl Display for FontStyle {
 }
 
 /// A styled run of text, for use in [`crate::TextLayout`].
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct TextRun {
     /// A number of utf8 bytes
     pub len: usize,

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -1,9 +1,10 @@
 use crate::{
-    App, Bounds, DevicePixels, Half, Hsla, LineLayout, Pixels, Point, RenderGlyphParams, Result,
+    App, Bounds, DevicePixels, Half, LineLayout, Pixels, Point, RenderGlyphParams, Result,
     ShapedGlyph, ShapedRun, SharedString, StrikethroughStyle, TextAlign, UnderlineStyle, Window,
     WrapBoundary, WrappedLineLayout, black, fill, point, px, size,
 };
 use derive_more::{Deref, DerefMut};
+use palette::Hsla;
 use smallvec::SmallVec;
 use std::sync::Arc;
 
@@ -941,24 +942,9 @@ mod tests {
     fn test_split_at_decorations() {
         // Three decoration runs: red [0..2), green [2..5), blue [5..6).
         // Split at byte 3 — red goes entirely left, green straddles, blue goes entirely right.
-        let red = Hsla {
-            h: 0.0,
-            s: 1.0,
-            l: 0.5,
-            a: 1.0,
-        };
-        let green = Hsla {
-            h: 0.3,
-            s: 1.0,
-            l: 0.5,
-            a: 1.0,
-        };
-        let blue = Hsla {
-            h: 0.6,
-            s: 1.0,
-            l: 0.5,
-            a: 1.0,
-        };
+        let red = Hsla::new(0., 1., 0.5, 1.);
+        let green = Hsla::new(0.3, 1., 0.5, 1.);
+        let blue = Hsla::new(0.6, 1., 0.5, 1.);
 
         let line = make_shaped_line(
             "abcdef",

--- a/crates/gpui/src/transition.rs
+++ b/crates/gpui/src/transition.rs
@@ -298,7 +298,8 @@ mod tests {
     use crate::AppContext;
 
     use super::*;
-    use gpui::{Point, Rgba, TestAppContext, px};
+    use gpui::{Point, TestAppContext, px};
+    use palette::rgb::Rgba;
 
     /// Helper to create a Transition directly without using window hooks.
     /// This bypasses the render-phase restriction of use_transition/use_keyed_transition.
@@ -465,18 +466,13 @@ mod tests {
     #[gpui::test]
     fn test_transition_with_rgba(cx: &mut TestAppContext) {
         cx.update(|cx| {
-            let initial = Rgba {
-                r: 1.0,
-                g: 0.0,
-                b: 0.0,
-                a: 1.0,
-            };
+            let initial = Rgba::new(1., 0., 0., 1.);
             let transition = create_transition(cx, Duration::from_millis(300), initial);
 
             let goal = transition.read_goal(cx);
-            assert_eq!(goal.r, 1.0);
-            assert_eq!(goal.g, 0.0);
-            assert_eq!(goal.b, 0.0);
+            assert_eq!(goal.red, 1.0);
+            assert_eq!(goal.green, 0.0);
+            assert_eq!(goal.blue, 0.0);
         });
     }
 
@@ -712,18 +708,13 @@ mod tests {
 
     #[test]
     fn test_state_with_rgba() {
-        let initial = Rgba {
-            r: 1.0,
-            g: 0.5,
-            b: 0.0,
-            a: 1.0,
-        };
+        let initial = Rgba::new(1., 0.5, 0., 1.);
         let state = TransitionState::new(initial);
 
-        assert_eq!(state.initial_goal.r, 1.0);
-        assert_eq!(state.initial_goal.g, 0.5);
-        assert_eq!(state.initial_goal.b, 0.0);
-        assert_eq!(state.initial_goal.a, 1.0);
+        assert_eq!(state.initial_goal.red, 1.0);
+        assert_eq!(state.initial_goal.green, 0.5);
+        assert_eq!(state.initial_goal.blue, 0.0);
+        assert_eq!(state.initial_goal.alpha, 1.0);
     }
 
     #[test]

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3,18 +3,18 @@ use crate::Inspector;
 use crate::{
     Action, AnyDrag, AnyElement, AnyImageCache, AnyTooltip, AnyView, App, AppContext, Arena, Asset,
     AsyncWindowContext, AtlasTile, AvailableSpace, BackdropFilter, Background, BorderStyle, Bounds,
-    BoxShadow, Capslock, Context, Corners, CursorHideMode, CursorStyle, Decorations, DevicePixels,
-    DispatchActionListener, DispatchNodeId, DispatchTree, DisplayId, Edges, Effect, Entity,
-    EntityId, EventEmitter, FileDropEvent, Filter, FilterBoundary, FontId, Global, GlobalElementId,
-    GlyphId, GpuSpecs, Hsla, InputHandler, IsZero, KeyBinding, KeyContext, KeyDownEvent, KeyEvent,
-    Keystroke, KeystrokeEvent, LayoutId, Lerp, LineLayoutIndex, Modifiers, ModifiersChangedEvent,
-    MonochromeSprite, MouseButton, MouseEvent, MouseMoveEvent, MouseUpEvent, Path, Pixels,
-    PlatformAtlas, PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point,
-    PolychromeSprite, Priority, PromptButton, PromptLevel, Quad, Render, RenderGlyphParams,
-    RenderImage, RenderImageParams, RenderSvgParams, Replay, ResizeEdge, SMOOTH_SVG_SCALE_FACTOR,
-    SUBPIXEL_VARIANTS_X, SUBPIXEL_VARIANTS_Y, ScaledFilter, ScaledPixels, Scene, Shadow,
-    SharedString, Size, StrikethroughStyle, Style, SubpixelSprite, SubscriberSet, Subscription,
-    SystemWindowTab, SystemWindowTabController, TabStopMap, TaffyLayoutEngine, Task,
+    BoxShadow, Capslock, ColorExt, Context, Corners, CursorHideMode, CursorStyle, Decorations,
+    DevicePixels, DispatchActionListener, DispatchNodeId, DispatchTree, DisplayId, Edges, Effect,
+    Entity, EntityId, EventEmitter, FileDropEvent, Filter, FilterBoundary, FontId, Global,
+    GlobalElementId, GlyphId, GpuSpecs, InputHandler, IsZero, KeyBinding, KeyContext, KeyDownEvent,
+    KeyEvent, Keystroke, KeystrokeEvent, LayoutId, Lerp, LineLayoutIndex, Modifiers,
+    ModifiersChangedEvent, MonochromeSprite, MouseButton, MouseEvent, MouseMoveEvent, MouseUpEvent,
+    Path, Pixels, PlatformAtlas, PlatformDisplay, PlatformInput, PlatformInputHandler,
+    PlatformWindow, Point, PolychromeSprite, Priority, PromptButton, PromptLevel, Quad, Render,
+    RenderGlyphParams, RenderImage, RenderImageParams, RenderSvgParams, Replay, ResizeEdge,
+    SMOOTH_SVG_SCALE_FACTOR, SUBPIXEL_VARIANTS_X, SUBPIXEL_VARIANTS_Y, ScaledFilter, ScaledPixels,
+    Scene, Shadow, SharedString, Size, StrikethroughStyle, Style, SubpixelSprite, SubscriberSet,
+    Subscription, SystemWindowTab, SystemWindowTabController, TabStopMap, TaffyLayoutEngine, Task,
     TextRenderingMode, TextStyle, TextStyleRefinement, ThermalState, TransformationMatrix,
     Transition, TransitionState, Underline, UnderlineStyle, WindowAppearance,
     WindowBackgroundAppearance, WindowBounds, WindowControls, WindowDecorations, WindowOptions,
@@ -34,6 +34,7 @@ use gpui_util::{ResultExt, measure};
 use hdrhistogram::Histogram;
 use itertools::FoldWhile::{Continue, Done};
 use itertools::Itertools;
+use palette::{Hsla, IntoColor};
 use parking_lot::RwLock;
 use raw_window_handle::{HandleError, HasDisplayHandle, HasWindowHandle};
 use refineable::Refineable;
@@ -3942,7 +3943,7 @@ impl Window {
                 bounds: self.cover_bounds(shadow_bounds),
                 content_mask,
                 corner_radii: corner_radii.scale(scale_factor),
-                color: shadow.color.opacity(opacity),
+                color: shadow.color.opacity(opacity).into(),
                 element_bounds,
                 element_corner_radii,
                 inset: 0,
@@ -3987,7 +3988,7 @@ impl Window {
                 bounds: self.cover_bounds(hole),
                 content_mask,
                 corner_radii: hole_corner_radii.scale(scale_factor),
-                color: shadow.color.opacity(opacity),
+                color: shadow.color.opacity(opacity).into(),
                 element_bounds,
                 element_corner_radii,
                 inset: 1,
@@ -4108,7 +4109,7 @@ impl Window {
             bounds: snapped_bounds,
             content_mask: self.snapped_content_mask(),
             background: quad.background.opacity(opacity),
-            border_color: quad.border_color.opacity(opacity),
+            border_color: quad.border_color.opacity(opacity).into(),
             corner_radii: quad.corner_radii.scale(self.scale_factor()),
             border_widths: snapped_border_widths,
             border_style: quad.border_style,
@@ -4230,7 +4231,11 @@ impl Window {
             pad: 0,
             bounds,
             content_mask: self.snapped_content_mask(),
-            color: style.color.unwrap_or_default().opacity(element_opacity),
+            color: style
+                .color
+                .unwrap_or_default()
+                .opacity(element_opacity)
+                .into(),
             thickness,
             wavy: style.wavy.into(),
         });
@@ -4261,7 +4266,7 @@ impl Window {
             bounds,
             content_mask: self.snapped_content_mask(),
             thickness: self.snap_stroke(style.thickness),
-            color: style.color.unwrap_or_default().opacity(opacity),
+            color: style.color.unwrap_or_default().opacity(opacity).into(),
             wavy: false.into(),
         });
     }
@@ -4333,7 +4338,7 @@ impl Window {
                     pad: 0,
                     bounds,
                     content_mask,
-                    color: color.opacity(element_opacity),
+                    color: color.opacity(element_opacity).into(),
                     tile,
                     transformation: TransformationMatrix::unit(),
                 });
@@ -4343,7 +4348,7 @@ impl Window {
                     pad: 0,
                     bounds,
                     content_mask,
-                    color: color.opacity(element_opacity),
+                    color: color.opacity(element_opacity).into(),
                     tile,
                     transformation: TransformationMatrix::unit(),
                 });
@@ -4490,7 +4495,7 @@ impl Window {
             pad: 0,
             bounds: final_bounds,
             content_mask,
-            color: color.opacity(element_opacity),
+            color: color.opacity(element_opacity).into(),
             tile,
             transformation,
         });
@@ -6856,9 +6861,9 @@ impl PaintQuad {
     }
 
     /// Sets the border color of the quad.
-    pub fn border_color(self, border_color: impl Into<Hsla>) -> Self {
+    pub fn border_color(self, border_color: impl IntoColor<Hsla>) -> Self {
         PaintQuad {
-            border_color: border_color.into(),
+            border_color: border_color.into_color(),
             ..self
         }
     }
@@ -6878,7 +6883,7 @@ pub fn quad(
     corner_radii: impl Into<Corners<Pixels>>,
     background: impl Into<Background>,
     border_widths: impl Into<Edges<Pixels>>,
-    border_color: impl Into<Hsla>,
+    border_color: impl IntoColor<Hsla>,
     border_style: BorderStyle,
 ) -> PaintQuad {
     PaintQuad {
@@ -6886,7 +6891,7 @@ pub fn quad(
         corner_radii: corner_radii.into(),
         background: background.into(),
         border_widths: border_widths.into(),
-        border_color: border_color.into(),
+        border_color: border_color.into_color(),
         border_style,
     }
 }
@@ -6906,7 +6911,7 @@ pub fn fill(bounds: impl Into<Bounds<Pixels>>, background: impl Into<Background>
 /// Creates a rectangle outline with the given bounds, border color, and a 1px border width
 pub fn outline(
     bounds: impl Into<Bounds<Pixels>>,
-    border_color: impl Into<Hsla>,
+    border_color: impl IntoColor<Hsla>,
     border_style: BorderStyle,
 ) -> PaintQuad {
     PaintQuad {
@@ -6914,7 +6919,7 @@ pub fn outline(
         corner_radii: (0.).into(),
         background: transparent_black().into(),
         border_widths: (1.).into(),
-        border_color: border_color.into(),
+        border_color: border_color.into_color(),
         border_style,
     }
 }

--- a/crates/gpui_elements/Cargo.toml
+++ b/crates/gpui_elements/Cargo.toml
@@ -14,6 +14,7 @@ ignored = ["gpui"]
 [dependencies]
 gpui.workspace = true
 unicode-segmentation.workspace = true
+palette.workspace = true
 smallvec.workspace = true
 
 [dev-dependencies]

--- a/crates/gpui_elements/examples/editable_text.rs
+++ b/crates/gpui_elements/examples/editable_text.rs
@@ -1,5 +1,5 @@
 use gpui::{
-    App, Bounds, Context, Hsla, Window, WindowBounds, WindowOptions, div, prelude::*, px, rgb, size,
+    App, Bounds, Context, Window, WindowBounds, WindowOptions, div, prelude::*, px, rgb, size,
 };
 use gpui_elements::editable_text::{
     actions::{DEFAULT_INPUT_CONTEXT, default_bindings},
@@ -24,7 +24,7 @@ impl Render for Example {
                     .placeholder("some placeholder text")
                     .border_1()
                     .rounded_lg()
-                    .border_color(Hsla::white()) // has a border
+                    .border_color(gpui::white()) // has a border
                     .p_2() // padding between the text and border
                     .min_w_10()
                     .max_w_128()
@@ -37,7 +37,7 @@ impl Render for Example {
                     .placeholder("empty text")
                     .border_1()
                     .rounded_lg()
-                    .border_color(Hsla::white()) // has a border
+                    .border_color(gpui::white()) // has a border
                     .p_2() // padding between the text and border
                     .w_full()
                     .min_h_24()

--- a/crates/gpui_elements/src/editable_text.rs
+++ b/crates/gpui_elements/src/editable_text.rs
@@ -44,7 +44,7 @@
 //! use gpui_elements::editable_text::text_input;
 //! text_input("my_input")
 //!     .placeholder("empty text")
-//!     .border_1().rounded_lg().border_color(Hsla::white()) // has a border
+//!     .border_1().rounded_lg().border_color(gpui::white()) // has a border
 //!     .p_2() // padding between the text and border
 //!     .min_w_10().max_w_128()
 //!     .min_h_auto()
@@ -60,7 +60,7 @@
 //! use gpui_elements::editable_text::text_area;
 //! text_area("message")
 //!     .placeholder("empty text")
-//!     .border_1().rounded_lg().border_color(Hsla::white()) // has a border
+//!     .border_1().rounded_lg().border_color(gpui::white()) // has a border
 //!     .p_2() // padding between the text and border
 //!     .min_w_10().max_w_128()
 //!     .min_h_24().max_h_128()

--- a/crates/gpui_elements/src/editable_text/element.rs
+++ b/crates/gpui_elements/src/editable_text/element.rs
@@ -82,29 +82,15 @@ struct EditableTextColors {
 }
 impl Default for EditableTextColors {
     fn default() -> Self {
-        const WHITE_50PC: Hsla = Hsla {
-            h: 0.0,
-            s: 0.0,
-            l: 1.0,
-            a: 0.5,
-        };
-        const WHITE_70PC: Hsla = Hsla {
-            h: 0.0,
-            s: 0.0,
-            l: 1.0,
-            a: 0.7,
-        };
+        use palette::RgbHue;
+        const WHITE_50PC: Hsla = Hsla::new_const(RgbHue::new(0.), 0., 1., 0.5);
+        const WHITE_70PC: Hsla = Hsla::new_const(RgbHue::new(0.), 0., 1., 0.7);
         // approx rgb(38 79 120) or oklch(41.9% 0.0829 250.4)
-        const LIGHT_NAVY_BLUE_50PC: Hsla = Hsla {
-            h: 0.583,
-            s: 0.519,
-            l: 0.31,
-            a: 0.5,
-        };
+        const LIGHT_NAVY_BLUE_50PC: Hsla = Hsla::new_const(RgbHue::new(0.583), 0.519, 0.31, 0.5);
         Self {
             placeholder: WHITE_50PC,
             selection: LIGHT_NAVY_BLUE_50PC,
-            caret: Hsla::white(),
+            caret: gpui::white(),
             ime_underline: WHITE_70PC,
         }
     }

--- a/crates/gpui_macos/Cargo.toml
+++ b/crates/gpui_macos/Cargo.toml
@@ -55,6 +55,7 @@ objc2.workspace = true
 objc2-app-kit.workspace = true
 objc2-foundation.workspace = true
 objc2-user-notifications.workspace = true
+palette.workspace = true
 parking_lot.workspace = true
 pathfinder_geometry.workspace = true
 raw-window-handle.workspace = true

--- a/crates/gpui_macos/build.rs
+++ b/crates/gpui_macos/build.rs
@@ -41,7 +41,7 @@ mod macos_build {
             "Size".into(),
             "Pixels".into(),
             "PointF".into(),
-            "Hsla".into(),
+            "SceneHsla".into(),
             "ContentMask".into(),
             "Uniforms".into(),
             "AtlasTile".into(),
@@ -65,6 +65,10 @@ mod macos_build {
         ]);
         config.no_includes = true;
         config.enumeration.prefix_with_name = true;
+        config
+            .export
+            .rename
+            .insert("SceneHsla".into(), "Hsla".into());
 
         let mut builder = cbindgen::Builder::new();
 

--- a/crates/gpui_macos/src/text_system.rs
+++ b/crates/gpui_macos/src/text_system.rs
@@ -222,8 +222,9 @@ impl PlatformTextSystem for MacTextSystem {
         if !font_smoothing_allowed_by_user() {
             return 0;
         }
-        let rgba: Rgba = color.into();
-        let luminance = 0.2126 * rgba.r + 0.7152 * rgba.g + 0.0722 * rgba.b;
+        use palette::IntoColor;
+        let rgba: Rgba = color.into_color();
+        let luminance = 0.2126 * rgba.red + 0.7152 * rgba.green + 0.0722 * rgba.blue;
         let level = ((4.0 * luminance) + 0.5).floor() as i32;
         level.clamp(0, 4) as u8
     }

--- a/crates/gpui_macros/src/styles.rs
+++ b/crates/gpui_macros/src/styles.rs
@@ -368,10 +368,10 @@ pub fn border_style_methods(input: TokenStream) -> TokenStream {
         /// Sets the border color of the element.
         #visibility fn border_color<C>(mut self, border_color: C) -> Self
         where
-            C: Into<gpui::Hsla>,
+            C: palette::IntoColor<palette::Hsla>,
             Self: Sized,
         {
-            self.style().border_color = Some(border_color.into());
+            self.style().border_color = Some(border_color.into_color());
             self
         }
 

--- a/crates/gpui_windows/src/direct_write.rs
+++ b/crates/gpui_windows/src/direct_write.rs
@@ -976,12 +976,7 @@ impl DirectWriteState {
 
                     let run_color = {
                         let run_color = color_run.Base.runColor;
-                        Rgba {
-                            r: run_color.r,
-                            g: run_color.g,
-                            b: run_color.b,
-                            a: run_color.a,
-                        }
+                        Rgba::new(run_color.r, run_color.g, run_color.b, run_color.a)
                     };
                     let bounds = bounds(point(color_bounds.left, color_bounds.top), color_size);
                     glyph_layers.push(GlyphLayerTexture::new(


### PR DESCRIPTION
Replacing native Hsla & Rgba implementation with [`palette`](https://docs.rs/palette/latest/palette/) crate (per discord discussions). No LLM usage.