### PR TITLE
add a generic typed ParentElement

### DIFF
--- a/crates/gpui/src/element.rs
+++ b/crates/gpui/src/element.rs
@@ -183,6 +183,33 @@ pub trait RenderOnce: 'static {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement;
 }
 
+/// A variation on [`ParentElement`] which only supports children of a particular type.
+pub trait ParentElementTyped {
+    /// The specific item type that this element accepts (could simply implement IntoElement or be an element itself).
+    type Child;
+
+    /// Extend this element's children with the given child elements.
+    fn extend(&mut self, elements: impl IntoIterator<Item = Self::Child>);
+
+    /// Add a single child element to this element.
+    fn child(mut self, child: Self::Child) -> Self
+    where
+        Self: Sized,
+    {
+        self.extend(std::iter::once(child));
+        self
+    }
+
+    /// Add multiple child elements to this element.
+    fn children(mut self, children: impl IntoIterator<Item = Self::Child>) -> Self
+    where
+        Self: Sized,
+    {
+        self.extend(children);
+        self
+    }
+}
+
 /// This is a helper trait to provide a uniform interface for constructing elements that
 /// can accept any number of any kind of child elements
 pub trait ParentElement {


### PR DESCRIPTION
Optional API/trait which permits users to create a parent element with constraints on what children are allowed. No LLM usage.

My particular use-case - a parent element that only accepts resizeable panels of contents (https://codeberg.org/temportalflux/jjui/src/commit/30959d2c4ba8ee1b09d6af4ab2436ac094d5a48d/crates/app/src/elements/resize_group.rs#L59-L65)