### PR TITLE
gpui: add flex_grow_1, flex_shrink_1 and container_query

### DIFF
--- a/crates/gpui/src/elements/container_query.rs
+++ b/crates/gpui/src/elements/container_query.rs
@@ -1,0 +1,126 @@
+//! A container query element, in the spirit of CSS container queries.
+//! The element's own size is determined solely by its style and the space
+//! offered by its parent.
+
+use refineable::Refineable as _;
+
+use crate::{
+    AnyElement, App, AvailableSpace, Bounds, Element, ElementId, GlobalElementId,
+    InspectorElementId, IntoElement, LayoutId, Pixels, Size, Style, StyleRefinement, Styled,
+    Window, relative,
+};
+
+/// Construct a container query element with the given render callback.
+/// The callback receives the size the element was assigned during layout and
+/// returns the contents to display within it.
+///
+/// By default the element fills its parent (equivalent to `.size_full()`);
+/// use the [`Styled`] methods to size it differently. Because the contents
+/// don't exist until after layout, they cannot influence the element's size.
+///
+/// # Example
+///
+/// ```
+/// # use gpui::{container_query, div, px, IntoElement, ParentElement};
+/// container_query(|size, _window, _cx| {
+///     if size.width < px(240.) {
+///         div().child("Narrow layout")
+///     } else {
+///         div().child("Wide layout")
+///     }
+/// });
+/// ```
+pub fn container_query<E>(
+    render: impl 'static + FnOnce(Size<Pixels>, &mut Window, &mut App) -> E,
+) -> ContainerQuery
+where
+    E: IntoElement,
+{
+    let mut base_style = StyleRefinement::default();
+    base_style.size.width = Some(relative(1.).into());
+    base_style.size.height = Some(relative(1.).into());
+
+    ContainerQuery {
+        render: Some(Box::new(|size, window, cx| {
+            render(size, window, cx).into_any_element()
+        })),
+        style: base_style,
+    }
+}
+
+/// A container query element, created with [`container_query`].
+pub struct ContainerQuery {
+    render: Option<Box<dyn FnOnce(Size<Pixels>, &mut Window, &mut App) -> AnyElement>>,
+    style: StyleRefinement,
+}
+
+impl Element for ContainerQuery {
+    type RequestLayoutState = ();
+    type PrepaintState = Option<AnyElement>;
+
+    fn id(&self) -> Option<ElementId> {
+        None
+    }
+
+    fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        let mut style = Style::default();
+        style.refine(&self.style);
+        let layout_id = window.request_layout(style, [], cx);
+        (layout_id, ())
+    }
+
+    fn prepaint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Option<AnyElement> {
+        let render = self.render.take()?;
+        let mut child = render(bounds.size, window, cx);
+        child.layout_as_root(bounds.size.map(AvailableSpace::Definite), window, cx);
+        child.prepaint_at(bounds.origin, window, cx);
+        Some(child)
+    }
+
+    fn paint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        prepaint: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        if let Some(child) = prepaint {
+            child.paint(window, cx);
+        }
+    }
+}
+
+impl IntoElement for ContainerQuery {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Styled for ContainerQuery {
+    fn style(&mut self) -> &mut StyleRefinement {
+        &mut self.style
+    }
+}

--- a/crates/gpui/src/elements/mod.rs
+++ b/crates/gpui/src/elements/mod.rs
@@ -1,6 +1,7 @@
 mod anchored;
 mod animation;
 mod canvas;
+mod container_query;
 mod deferred;
 mod div;
 mod image_cache;
@@ -14,6 +15,7 @@ mod uniform_list;
 pub use anchored::*;
 pub use animation::*;
 pub use canvas::*;
+pub use container_query::*;
 pub use deferred::*;
 pub use div::*;
 pub use image_cache::*;

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -271,6 +271,16 @@ pub trait Styled: Sized {
         self
     }
 
+    /// Enables flex item growth (flex-grow: 1).
+    /// [Docs](https://tailwindcss.com/docs/flex-grow#grow-1)
+    ///
+    /// Equivalent to [`Styled::flex_grow`]; provided so component libraries
+    /// written against the Tailwind-style `_1` suffix compile unchanged.
+    fn flex_grow_1(mut self) -> Self {
+        self.style().flex_grow = Some(1.);
+        self
+    }
+
     /// Sets the element to allow a flex item to shrink if needed.
     /// [Docs](https://tailwindcss.com/docs/flex-shrink)
     fn flex_shrink(mut self) -> Self {
@@ -282,6 +292,16 @@ pub trait Styled: Sized {
     /// [Docs](https://tailwindcss.com/docs/flex-shrink#dont-shrink)
     fn flex_shrink_0(mut self) -> Self {
         self.style().flex_shrink = Some(0.);
+        self
+    }
+
+    /// Enables flex item shrinking (flex-shrink: 1).
+    /// [Docs](https://tailwindcss.com/docs/flex-shrink#shrink-1)
+    ///
+    /// Equivalent to [`Styled::flex_shrink`]; provided so component libraries
+    /// written against the Tailwind-style `_1` suffix compile unchanged.
+    fn flex_shrink_1(mut self) -> Self {
+        self.style().flex_shrink = Some(1.);
         self
     }
 


### PR DESCRIPTION
## Why

Component libraries written against upstream GPUI don't compile here without
these three. `gpui-component` is the concrete case: it uses
`flex_grow_1`/`flex_shrink_1` from June 2026 onward and `container_query` from
July, so anyone using both crates is pinned to a narrow window of
`gpui-component` revisions.

## What

All three are **purely additive** — no existing signature changes.

- **`flex_grow_1` / `flex_shrink_1`** are equivalent to this crate's existing
  no-argument `flex_grow` / `flex_shrink`. Upstream arrived at the same names by
  a different route: it changed `flex_grow`/`flex_shrink` to take an `f32` and
  added the `_1` variants alongside. Adopting that signature change would break
  every current caller here, so this PR adds only the names and leaves the
  existing methods alone.
- **`container_query`** is ported unmodified from upstream. Every type it needs
  (`InspectorElementId`, `GlobalElementId`, `AvailableSpace`, `StyleRefinement`,
  `LayoutId`, `ElementId`) already exists here, and `refineable` is already a
  dependency.

## Verified against a real consumer

Not tested in isolation. With these three additions, `gpui-component` compiles
against this crate with **zero library-side errors** up to revision `aa085920d`
(2026-06-15) — where previously it failed at 2026-06-03 on the missing
`flex_grow_1`.

`cargo check -p gpui` is clean.

## Where parity stops, and why I left it there

From `5589b892` (2026-06-15) `gpui-component` calls `.flex_grow(width)` with an
argument. Supporting that requires the breaking change to `flex_grow`/
`flex_shrink` described above — Rust has no way to add a parameter compatibly.

That's a decision about this crate's public API and its existing users, not
something a drive-by contribution should force, so it's deliberately out of
scope here. Happy to send it as a follow-up if you want the full upstream
signature, or to leave the API as it is — this PR is useful either way.
