### PR TITLE
Made default fallback prompt renderer occlude mouse events

### DIFF
--- a/crates/gpui/src/window/prompts.rs
+++ b/crates/gpui/src/window/prompts.rs
@@ -147,6 +147,7 @@ impl Render for FallbackPromptRenderer {
             }));
 
         div()
+            .occlude()
             .size_full()
             .child(
                 div()


### PR DESCRIPTION
Very small change. The default fallback prompt renderer (used when there's no platform specific prompt dialog available, so the default one on Linux), doesn't occlude mouse events, so you can click through the greyed out background of the prompt dialog.

So just add an `.occlude` :)

You can test this easily with the `legacy/window` example