### PR TITLE
Scale hue to degrees before wrapping it in RgbHue

### DIFF
--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -36,7 +36,9 @@ pub fn swap_rgba_pa_to_bgra(color: &mut [u8]) {
 pub const fn hsla(h: f32, s: f32, l: f32, a: f32) -> Hsla {
     Hsla {
         color: palette::Hsl::new_const(
-            RgbHue::new(h.clamp(0., 1.)),
+            // `RgbHue` stores degrees, so the 0..1 fraction of the circle needs
+            // scaling to 0..360 before it's wrapped.
+            RgbHue::new(h.clamp(0., 1.) * 360.),
             s.clamp(0., 1.),
             l.clamp(0., 1.),
         ),
@@ -81,17 +83,17 @@ pub const fn red() -> Hsla {
 
 /// The color blue in [`Hsla`]
 pub const fn blue() -> Hsla {
-    Hsla::new_const(RgbHue::new(0.6666666667), 1., 0.5, 1.)
+    Hsla::new_const(RgbHue::new(240.), 1., 0.5, 1.)
 }
 
 /// The color green in [`Hsla`]
 pub const fn green() -> Hsla {
-    Hsla::new_const(RgbHue::new(0.3333333333), 1., 0.25, 1.)
+    Hsla::new_const(RgbHue::new(120.), 1., 0.25, 1.)
 }
 
 /// The color yellow in [`Hsla`]
 pub const fn yellow() -> Hsla {
-    Hsla::new_const(RgbHue::new(0.1666666667), 1., 0.5, 1.)
+    Hsla::new_const(RgbHue::new(60.), 1., 0.5, 1.)
 }
 
 /// Generates the JsonSchema for palette::Hsla

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -1496,7 +1496,6 @@ mod tests {
 
     #[test]
     fn test_combine_highlights() {
-        let nearly_blue = Hsla::new_const(palette::RgbHue::new(0.6666684), 1., 0.5, 1.);
         assert_eq!(
             combine_highlights(
                 [
@@ -1522,14 +1521,14 @@ mod tests {
                 (
                     1..2,
                     HighlightStyle {
-                        color: Some(nearly_blue),
+                        color: Some(blue()),
                         ..Default::default()
                     }
                 ),
                 (
                     2..3,
                     HighlightStyle {
-                        color: Some(nearly_blue),
+                        color: Some(blue()),
                         font_style: Some(FontStyle::Italic),
                         ..Default::default()
                     }

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -943,8 +943,8 @@ mod tests {
         // Three decoration runs: red [0..2), green [2..5), blue [5..6).
         // Split at byte 3 — red goes entirely left, green straddles, blue goes entirely right.
         let red = Hsla::new(0., 1., 0.5, 1.);
-        let green = Hsla::new(0.3, 1., 0.5, 1.);
-        let blue = Hsla::new(0.6, 1., 0.5, 1.);
+        let green = Hsla::new(108., 1., 0.5, 1.);
+        let blue = Hsla::new(216., 1., 0.5, 1.);
 
         let line = make_shaped_line(
             "abcdef",

--- a/crates/gpui_elements/src/editable_text/element.rs
+++ b/crates/gpui_elements/src/editable_text/element.rs
@@ -86,7 +86,7 @@ impl Default for EditableTextColors {
         const WHITE_50PC: Hsla = Hsla::new_const(RgbHue::new(0.), 0., 1., 0.5);
         const WHITE_70PC: Hsla = Hsla::new_const(RgbHue::new(0.), 0., 1., 0.7);
         // approx rgb(38 79 120) or oklch(41.9% 0.0829 250.4)
-        const LIGHT_NAVY_BLUE_50PC: Hsla = Hsla::new_const(RgbHue::new(0.583), 0.519, 0.31, 0.5);
+        const LIGHT_NAVY_BLUE_50PC: Hsla = Hsla::new_const(RgbHue::new(210.), 0.519, 0.31, 0.5);
         Self {
             placeholder: WHITE_50PC,
             selection: LIGHT_NAVY_BLUE_50PC,


### PR DESCRIPTION
`palette::RgbHue` stores degrees but `gpui::hsla()` passes the 0..1 fraction straight through it so `hsla(240./360., ..)` was stored as 0.667° not 240° and every saturated color collapsed toward red.

`rgb(0x..)` was working fine because it converts through palette's `IntoColor` and never touches `RgbHue::new` so it's correct either way.

I also updated `blue()`, `green()`, `yellow()` too, plus every other place in the codebase constructing an RgbHue from 0..1 fraction instead of degrees.

Attached before and after to make it clear what changed.

| Before | After |
|---|---|
| <img width="421" height="432" alt="before" src="https://github.com/user-attachments/assets/e9ed3739-a4a8-4514-a369-0ac32419f972" /> | <img width="421" height="434" alt="after" src="https://github.com/user-attachments/assets/53fbbf68-73fc-4ba4-9b3e-462b4b70faa5" /> |