### PR TITLE
editable_text: remove caret scroll debug output

### DIFF
--- a/crates/gpui_elements/src/editable_text/state.rs
+++ b/crates/gpui_elements/src/editable_text/state.rs
@@ -428,7 +428,6 @@ impl EditableTextState {
         if let Cow::Owned(mut offset) = scroll_offset {
             offset.x = offset.x.clamp(Pixels::ZERO, content_size.width);
             offset.y = offset.y.clamp(Pixels::ZERO, content_size.height);
-            println!("shift to {offset:?}");
             self.layout_data.next_scroll_offset = Some(offset);
         }
     }


### PR DESCRIPTION
## Summary

Remove a leftover debug `println!` from
`EditableTextState::scroll_to_caret()`.

It wrote the adjusted scroll offset to stdout, adding noise to application logs
without serving a functional purpose. Caret scrolling behavior is unchanged.

## Validation

- `just fmt-check`
- `just check`
- Editable-text tests — 99 passed

## AI disclosure

AI assistance was used for repository analysis and environment setup. I noticed
this one-line issue while using GPUI in my own application. I reviewed the final
diff and validation results and take responsibility for the change.
