### PR TITLE
Enable surfaces on Windows when using the wgpu renderer

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -18,6 +18,9 @@ workspace = true
 
 [features]
 default = ["font-kit", "wayland", "x11", "windows-manifest"]
+# Enables `SurfaceSource::Texture` + `gpu_context()` on Windows. Turned on by
+# `gpui_windows/wgpu`, which is what actually puts the wgpu renderer there.
+wgpu-surfaces = []
 test-support = [
   "leak-detection",
   "collections/test-support",

--- a/crates/gpui/src/elements/surface.rs
+++ b/crates/gpui/src/elements/surface.rs
@@ -2,12 +2,20 @@ use crate::{
     App, Bounds, Element, ElementId, GlobalElementId, InspectorElementId, IntoElement, LayoutId,
     ObjectFit, Pixels, Style, StyleRefinement, Styled, Window,
 };
-#[cfg(any(target_os = "linux", target_os = "freebsd"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    all(target_os = "windows", feature = "wgpu-surfaces")
+))]
 use crate::{DevicePixels, Size};
 #[cfg(target_os = "macos")]
 use core_video::pixel_buffer::CVPixelBuffer;
 use refineable::Refineable;
-#[cfg(any(target_os = "linux", target_os = "freebsd"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    all(target_os = "windows", feature = "wgpu-surfaces")
+))]
 use std::sync::Arc;
 
 /// A source of a surface's content.
@@ -16,7 +24,11 @@ pub enum SurfaceSource {
     #[cfg(target_os = "macos")]
     Surface(CVPixelBuffer),
     /// A GPU texture handle (type-erased to avoid depending on wgpu)
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        all(target_os = "windows", feature = "wgpu-surfaces")
+    ))]
     Texture {
         /// The GPU texture, type-erased (expected to be `Arc<wgpu::Texture>`)
         texture: Arc<dyn std::any::Any + Send + Sync>,
@@ -30,7 +42,11 @@ impl Clone for SurfaceSource {
         match *self {
             #[cfg(target_os = "macos")]
             SurfaceSource::Surface(ref buf) => SurfaceSource::Surface(buf.clone()),
-            #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "freebsd",
+                all(target_os = "windows", feature = "wgpu-surfaces")
+            ))]
             SurfaceSource::Texture { ref texture, size } => SurfaceSource::Texture {
                 texture: Arc::clone(texture),
                 size,
@@ -44,7 +60,11 @@ impl std::fmt::Debug for SurfaceSource {
         match *self {
             #[cfg(target_os = "macos")]
             SurfaceSource::Surface(ref buf) => _f.debug_tuple("Surface").field(buf).finish(),
-            #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "freebsd",
+                all(target_os = "windows", feature = "wgpu-surfaces")
+            ))]
             SurfaceSource::Texture { size, .. } => _f
                 .debug_struct("Texture")
                 .field("size", &size)
@@ -138,7 +158,11 @@ impl Element for Surface {
                 // TODO: Add support for corner_radii
                 _window.paint_surface(new_bounds, surface.clone());
             }
-            #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "freebsd",
+                all(target_os = "windows", feature = "wgpu-surfaces")
+            ))]
             SurfaceSource::Texture {
                 ref texture,
                 ref size,

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -960,7 +960,11 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
 
     /// Returns the GPU context for this window's renderer.
     /// The returned `Box` contains `(Arc<wgpu::Device>, Arc<wgpu::Queue>)`.
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        all(target_os = "windows", feature = "wgpu-surfaces")
+    ))]
     fn gpu_context(&self) -> Option<Box<dyn std::any::Any>> {
         None
     }
@@ -971,7 +975,11 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     /// captured the device from `gpu_context` should stop submitting while
     /// this is `Some(true)` and re-acquire the device once it reads
     /// `Some(false)` again.
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        all(target_os = "windows", feature = "wgpu-surfaces")
+    ))]
     fn gpu_device_lost(&self) -> Option<bool> {
         None
     }

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -976,9 +976,17 @@ pub struct PaintSurface {
     pub content_mask: ContentMask<ScaledPixels>,
     #[cfg(target_os = "macos")]
     pub image_buffer: core_video::pixel_buffer::CVPixelBuffer,
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        all(target_os = "windows", feature = "wgpu-surfaces")
+    ))]
     pub texture: std::sync::Arc<dyn std::any::Any + Send + Sync>,
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        all(target_os = "windows", feature = "wgpu-surfaces")
+    ))]
     pub texture_size: Size<crate::DevicePixels>,
 }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4631,7 +4631,11 @@ impl Window {
     /// Paint a surface into the scene for the next frame at the current z-index.
     ///
     /// This method should only be called as part of the paint phase of element drawing.
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        all(target_os = "windows", feature = "wgpu-surfaces")
+    ))]
     pub fn paint_surface(
         &mut self,
         bounds: Bounds<Pixels>,
@@ -6045,7 +6049,11 @@ impl Window {
 
     /// Returns the GPU context (device + queue) if available.
     /// The returned `Box` contains `(Arc<wgpu::Device>, Arc<wgpu::Queue>)`.
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        all(target_os = "windows", feature = "wgpu-surfaces")
+    ))]
     pub fn gpu_context(&self) -> Option<Box<dyn std::any::Any>> {
         self.platform_window.gpu_context()
     }
@@ -6055,7 +6063,11 @@ impl Window {
     /// cannot know. Embedders that captured the device from
     /// [`Self::gpu_context`] should stop submitting while this is
     /// `Some(true)` and re-acquire the device once it reads `Some(false)`.
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        all(target_os = "windows", feature = "wgpu-surfaces")
+    ))]
     pub fn gpu_device_lost(&self) -> Option<bool> {
         self.platform_window.gpu_device_lost()
     }

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -1852,7 +1852,7 @@ impl WgpuRenderer {
         )
     }
 
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "windows"))]
     fn draw_surfaces(&self, surfaces: &[PaintSurface], pass: &mut wgpu::RenderPass<'_>) -> bool {
         let resources = self.resources();
         for surface in surfaces {
@@ -1902,7 +1902,7 @@ impl WgpuRenderer {
         true
     }
 
-    #[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
+    #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "windows")))]
     fn draw_surfaces(&self, _surfaces: &[PaintSurface], _pass: &mut wgpu::RenderPass<'_>) -> bool {
         true
     }

--- a/crates/gpui_windows/Cargo.toml
+++ b/crates/gpui_windows/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/gpui_windows.rs"
 default = ["gpui/default"]
 test-support = ["gpui/test-support"]
 screen-capture = ["gpui/screen-capture", "scap"]
-wgpu = ["dep:gpui_wgpu"]
+wgpu = ["dep:gpui_wgpu", "gpui/wgpu-surfaces"]
 
 [dependencies]
 gpui.workspace = true

--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -1091,6 +1091,19 @@ impl PlatformWindow for WindowsWindow {
             .set(Some(callback));
     }
 
+    #[cfg(feature = "wgpu")]
+    fn gpu_context(&self) -> Option<Box<dyn std::any::Any>> {
+        let (device, queue) = self.state.renderer.borrow().gpu_context();
+        Some(Box::new((device, queue)))
+    }
+
+    #[cfg(feature = "wgpu")]
+    fn gpu_device_lost(&self) -> Option<bool> {
+        // Only loads an atomic flag - safe even mid-recovery, when
+        // gpu_context would panic on the torn-down resources.
+        Some(self.state.renderer.borrow().device_lost())
+    }
+
     fn draw(&self, scene: &Scene) {
         #[cfg(not(feature = "wgpu"))]
         {


### PR DESCRIPTION
Surfaces work on Linux but not on Windows, even though both run the same wgpu renderer and the same surface code.

The API (`SurfaceSource::Texture`, `Window::paint_surface`, `gpu_context()`) is gated on operating system rather than on which renderer is active, so it compiles out on Windows regardless. Windows has been able to run the wgpu renderer since #90, via the `wgpu` feature on `gpui_windows`.

I changed the gate to follow the active renderer instead of the operating system, via a `gpui/wgpu-surfaces` feature that `gpui_windows/wgpu` enables.

I tested on Windows 11, RTX 4090:
- default build compiles, API correctly absent
- `--features wgpu` compiles, API present
- a wgpu app I wrote draws 16.2M triangles into a texture from `gpu_context()` and composites correctly through `surface()`. I verified by reading the pixels back rather than trusting timings.