### PR TITLE
Hard cut workspace to WGPU 30.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,13 @@ jobs:
           fi
           CHANGED_FILES="$(git diff --name-only "$COMPARE_REV" "$GITHUB_SHA")"
 
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "run_tests=true" >> "$GITHUB_OUTPUT"
+            echo "run_style=true" >> "$GITHUB_OUTPUT"
+            echo "run_docs=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           check_pattern() {
             local name="$1" pattern="$2" invert="${3:-false}"
             if [ "$invert" = "true" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ name: CI
 # TODO: Setup coverage using cargo-mutants, but only for minor/major version bumps (would probably take hours :() -- also our testing infra sucks
 
 on:
+  workflow_dispatch:
   push:
     branches: [main, 'v[0-9]+.[0-9]+.x']
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,12 @@ jobs:
       - uses: extractions/setup-just@v2
       - run: just build
       - run: just test
+      - name: Check gpui_embed
+        run: cargo check -p gpui_embed --all-targets
+      - name: Test gpui_embed
+        run: cargo test -p gpui_embed
+      - name: Check gpui_embed examples
+        run: cargo check -p gpui_embed --examples
 
   # Examples
   check-examples:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,7 +529,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -794,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
 dependencies = [
  "async-channel",
  "async-task",
@@ -817,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
  "serde_core",
@@ -860,7 +860,7 @@ checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -967,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.2"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1457,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -1570,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d83cb7e7a873830708d6b02a78cd36a592c6fa14bf267b68725103b85c0d77f"
+checksum = "914a755b7c2d4af2bdcff7ce1739e2db9a1b81a9b07123d8015786ae03c0980d"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -1752,7 +1752,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1811,9 +1811,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "embed-resource"
@@ -2045,9 +2045,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fixedbitset"
@@ -2118,9 +2118,9 @@ dependencies = [
 
 [[package]]
 name = "font-types"
-version = "0.12.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7299a780854a6d391be2ae1c8521c9368471b559dbfd6a8dbd9f407eaff100"
+checksum = "e64eb721ca85a34323425f4041adc5d82704d3782d5f8f03793bc012419dce23"
 dependencies = [
  "bytemuck",
 ]
@@ -2166,7 +2166,7 @@ checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2207,9 +2207,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2222,9 +2222,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2245,15 +2245,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2262,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -2296,32 +2296,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3122,9 +3122,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -3136,9 +3136,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -3149,9 +3149,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -3163,16 +3163,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -3183,15 +3184,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -3606,9 +3607,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "bitflags 2.13.1",
  "libc",
@@ -3624,15 +3625,15 @@ checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
 name = "link-section"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee1a0d6e252afe82e7bc2db42fba60e02ddf3b1accaf8cb21d96e34ba61f3d4"
+checksum = "39c29a617ce3df32c08497bdc1ab6e2376e0b17948ac166a2fbe5977c5954cd9"
 
 [[package]]
 name = "linktime-proc-macro"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348d0075b1fc163b26d72a7f75fc5141daf2fd1bdf128d873cbaf6785d495bdf"
+checksum = "7e57c38c1e860fd37c604281cdfb1dd2216977fd76a50f85ba2f388ef3219616"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3648,9 +3649,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "litrs"
@@ -3669,9 +3670,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 dependencies = [
  "serde_core",
  "value-bag",
@@ -4122,9 +4123,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -4625,9 +4626,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "open"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cfef937e9c486488c7e3d949ae31c0f1d06bdacd75b99c086cb35356e30408"
+checksum = "ade3be4664bc1ef537ce133015f04c176b737815c2ba9fd60edf212d6e90dd55"
 dependencies = [
  "is-wsl",
  "libc",
@@ -4651,9 +4652,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "5.3.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+checksum = "8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0"
 dependencies = [
  "num-traits",
 ]
@@ -4881,9 +4882,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plain"
@@ -4982,9 +4983,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -5014,9 +5015,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -5193,15 +5194,6 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
@@ -5232,9 +5224,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -5306,9 +5298,9 @@ checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
 name = "rangemap"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+checksum = "a611d15b50743feb4c76b7d03edcb0e64f399c26961e4efe6975bc398be6aa3d"
 
 [[package]]
 name = "rav1e"
@@ -5425,7 +5417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
 dependencies = [
  "bytemuck",
- "font-types 0.12.2",
+ "font-types 0.12.4",
  "once_cell",
 ]
 
@@ -5486,22 +5478,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5743,7 +5735,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5853,7 +5845,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5864,7 +5856,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5911,7 +5903,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6194,7 +6186,7 @@ checksum = "6feeae42a2d6b0dcb8aeb2f08d9e48cdac600239cf8a20fc59f9e252e86bdfe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6358,9 +6350,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6512,7 +6504,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6585,9 +6577,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -6920,9 +6912,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -7112,9 +7104,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
+checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -7203,7 +7195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.41.0",
+ "quick-xml",
  "quote",
 ]
 
@@ -8006,9 +7998,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "x11"
@@ -8065,13 +8057,13 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xcb"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4c580d8205abb0a5cf4eb7e927bd664e425b6c3263f9c5310583da96970cf6"
+checksum = "a6c2ad15e0e922856ee89afe862b8992334bbe7953adad56cd1199358cb30566"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.1",
  "libc",
- "quick-xml 0.30.0",
+ "quick-xml",
  "x11",
 ]
 
@@ -8196,9 +8188,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.18.0"
+version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -8255,14 +8247,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.18.0"
+version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -8289,6 +8281,15 @@ dependencies = [
  "winnow 1.0.4",
  "zbus_names",
  "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -8327,7 +8328,7 @@ dependencies = [
  "core-graphics-helmer-fork",
  "log",
  "objc",
- "rand 0.8.7",
+ "rand 0.8.8",
  "screencapturekit",
  "screencapturekit-sys",
  "sysinfo",
@@ -8421,9 +8422,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -8432,9 +8433,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -8443,13 +8444,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -8484,41 +8485,42 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.13.1"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "serde_bytes",
  "winnow 1.0.4",
+ "zcheapstr",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.13.1"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "3.5.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.119",
+ "syn 3.0.4",
  "winnow 1.0.4",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,22 @@
 version = 4
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
 name = "accesskit"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +143,7 @@ checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "const-random",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -164,6 +181,31 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android-activity"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
+dependencies = [
+ "android-properties",
+ "bitflags 2.13.1",
+ "cc",
+ "jni",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-context",
+ "ndk-sys",
+ "num_enum",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "android_system_properties"
@@ -841,6 +883,20 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.13.1",
+ "log",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "calloop"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
@@ -854,11 +910,23 @@ dependencies = [
 
 [[package]]
 name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop 0.13.0",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "calloop-wayland-source"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
 dependencies = [
- "calloop",
+ "calloop 0.14.4",
  "rustix 1.1.4",
  "wayland-backend",
  "wayland-client",
@@ -1111,6 +1179,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "command-fds"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1350,7 +1428,7 @@ dependencies = [
  "rustc-hash 2.1.3",
  "self_cell",
  "skrifa 0.40.0",
- "smol_str",
+ "smol_str 0.3.6",
  "swash",
  "sys-locale",
  "unicode-bidi",
@@ -1499,6 +1577,12 @@ dependencies = [
  "link-section",
  "linktime-proc-macro",
 ]
+
+[[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "data-url"
@@ -1694,6 +1778,12 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dpi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "dunce"
@@ -2548,6 +2638,7 @@ dependencies = [
  "gpui",
  "gpui_wgpu",
  "uuid",
+ "winit",
 ]
 
 [[package]]
@@ -2561,8 +2652,8 @@ dependencies = [
  "ashpd",
  "bitflags 2.13.1",
  "bytemuck",
- "calloop",
- "calloop-wayland-source",
+ "calloop 0.14.4",
+ "calloop-wayland-source 0.4.1",
  "filedescriptor",
  "futures",
  "gpui",
@@ -2637,7 +2728,7 @@ dependencies = [
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
- "objc2-user-notifications",
+ "objc2-user-notifications 0.3.2",
  "palette",
  "parking_lot",
  "pathfinder_geometry",
@@ -2723,7 +2814,7 @@ version = "0.1.0"
 dependencies = [
  "schemars",
  "serde",
- "smol_str",
+ "smol_str 0.3.6",
 ]
 
 [[package]]
@@ -3385,6 +3476,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.20",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3527,7 +3648,10 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
+ "bitflags 2.13.1",
  "libc",
+ "plain",
+ "redox_syscall 0.9.3",
 ]
 
 [[package]]
@@ -3838,6 +3962,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.13.1",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "raw-window-handle",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "ndk-sys"
 version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4052,6 +4197,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4125,6 +4292,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
 name = "objc2-core-data"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4161,6 +4352,18 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-contacts",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-location"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
@@ -4183,6 +4386,7 @@ checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.13.1",
  "block2 0.5.1",
+ "dispatch",
  "libc",
  "objc2 0.5.2",
 ]
@@ -4198,6 +4402,18 @@ dependencies = [
  "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -4253,6 +4469,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-core-location 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-link-presentation",
+ "objc2-quartz-core 0.2.2",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications 0.2.2",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
 name = "objc2-user-notifications"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4261,7 +4532,7 @@ dependencies = [
  "bitflags 2.13.1",
  "block2 0.6.2",
  "objc2 0.6.4",
- "objc2-core-location",
+ "objc2-core-location 0.3.2",
  "objc2-foundation 0.3.2",
 ]
 
@@ -4371,6 +4642,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "orbclient"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
+dependencies = [
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "ordered-float"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4387,6 +4668,15 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser",
 ]
 
 [[package]]
@@ -4444,7 +4734,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -4596,6 +4886,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -5143,9 +5439,27 @@ checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d678d17679829e73d371e96880897e98fee2ded7acc0a50bdf8af2affa4b2fe5"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -5470,6 +5784,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sctk-adwaita"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
+dependencies = [
+ "ab_glyph",
+ "log",
+ "memmap2",
+ "smithay-client-toolkit",
+ "tiny-skia",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5664,6 +5991,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simd_helpers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5671,6 +6008,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simplecss"
@@ -5729,6 +6072,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.13.1",
+ "calloop 0.13.0",
+ "calloop-wayland-source 0.3.0",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
 name = "smol"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5743,6 +6111,15 @@ dependencies = [
  "async-process",
  "blocking",
  "futures-lite 2.6.1",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6762,6 +7139,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.13.1",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
 name = "wayland-cursor"
 version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7339,6 +7727,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -7504,6 +7901,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winit"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
+dependencies = [
+ "ahash",
+ "android-activity",
+ "atomic-waker",
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "bytemuck",
+ "calloop 0.13.0",
+ "cfg_aliases",
+ "concurrent-queue",
+ "core-foundation 0.9.4",
+ "core-graphics 0.23.2",
+ "cursor-icon",
+ "dpi",
+ "js-sys",
+ "libc",
+ "memmap2",
+ "ndk",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit",
+ "orbclient",
+ "percent-encoding",
+ "pin-project",
+ "raw-window-handle",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.44",
+ "sctk-adwaita",
+ "smithay-client-toolkit",
+ "smol_str 0.2.2",
+ "tracing",
+ "unicode-segmentation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
+ "web-sys",
+ "web-time",
+ "windows-sys 0.52.0",
+ "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
+]
+
+[[package]]
 name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7579,6 +8028,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
 name = "x11rb"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7587,6 +8047,8 @@ dependencies = [
  "as-raw-xcb-connection",
  "gethostname",
  "libc",
+ "libloading",
+ "once_cell",
  "rustix 1.1.4",
  "x11rb-protocol",
  "xcursor",
@@ -7643,6 +8105,19 @@ dependencies = [
  "as-raw-xcb-connection",
  "libc",
  "memmap2",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkbcommon-dl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
+dependencies = [
+ "bitflags 2.13.1",
+ "dlib",
+ "log",
+ "once_cell",
  "xkeysym",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2541,6 +2541,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpui_embed"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "gpui",
+ "gpui_wgpu",
+ "uuid",
+]
+
+[[package]]
 name = "gpui_linux"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
 dependencies = [
  "bit-vec 0.9.1",
 ]
@@ -2103,12 +2103,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -2477,26 +2471,6 @@ dependencies = [
  "presser",
  "thiserror 2.0.20",
  "windows 0.62.2",
-]
-
-[[package]]
-name = "gpu-descriptor"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
-dependencies = [
- "bitflags 2.13.1",
- "gpu-descriptor-types",
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "gpu-descriptor-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
-dependencies = [
- "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3010,22 +2984,13 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -3033,6 +2998,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hdrhistogram"
@@ -3081,12 +3049,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hexf-parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hkdf"
@@ -3928,28 +3890,40 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "29.0.4"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
+checksum = "a616d2fb8c89516ac2723a581f69d6c18576046bed761bd6b305e5618e6ae130"
 dependencies = [
  "arrayvec",
- "bit-set 0.9.1",
+ "bit-set 0.10.0",
  "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown 0.16.1",
- "hexf-parse",
+ "hashbrown 0.17.1",
  "indexmap",
  "libm",
  "log",
+ "naga-types",
  "num-traits",
  "once_cell",
  "rustc-hash 1.1.0",
  "spirv",
  "thiserror 2.0.20",
  "unicode-ident",
+]
+
+[[package]]
+name = "naga-types"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590afbf58a6f4f62873cd5cff4468061844bafa1cdf399cc954537c22d768d49"
+dependencies = [
+ "hashbrown 0.17.1",
+ "indexmap",
+ "rustc-hash 1.1.0",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4339,6 +4313,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-core-image"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4405,6 +4391,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-link-presentation"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4464,6 +4461,7 @@ dependencies = [
  "bitflags 2.13.1",
  "objc2 0.6.4",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation 0.3.2",
  "objc2-metal 0.3.2",
 ]
@@ -7249,9 +7247,9 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wgpu"
-version = "29.0.4"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
+checksum = "527ccdf43dd5b2e8676eed9984ce00e2bbb0a1b85b70c1969dcb6cd2eb55ab9e"
 dependencies = [
  "arrayvec",
  "bitflags 2.13.1",
@@ -7259,7 +7257,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "js-sys",
  "log",
  "naga",
@@ -7279,21 +7277,22 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "29.0.4"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
+checksum = "14c018fce9b6270aa203c2fdd56f3cce996713534bd757e4ea58c8560b121f14"
 dependencies = [
  "arrayvec",
- "bit-set 0.9.1",
+ "bit-set 0.10.0",
  "bit-vec 0.9.1",
  "bitflags 2.13.1",
  "bytemuck",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "log",
  "naga",
+ "naga-types",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -7312,41 +7311,41 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "29.0.4"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e39e26c4c0e07589e67d18546cf79ff45383659fc72fca4dd293358a0347f3"
+checksum = "061f3d319a40d39d00b1ecc2c33b89fe21d4e6fe01859df3500a3a8ecccd6b68"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "29.0.4"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e09be551dc939498bdd5f6b2c66e55ab275dad25825267a08605a80fc9f0af"
+checksum = "d98b86cf4abf524a902dd35f18ca6a3f08fc2ae9847c8f10b48e30491b1f0b86"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "29.0.4"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e592c1bbef6ad047647ae6e666ebd8cee7a32bb4544d9700ec96cbf73230257"
+checksum = "7586165fd5f6d881cb9ce4bb71f40d6caab2c0f1837e3fc1d9788a197fb6004f"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "29.0.4"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ace1c17727311c22a46e4e3faf56ea6de81af99dcc839bdfb54857b94d448d"
+checksum = "b6b7fb58561a792bc237628ba0792e332de418fefe145f13b5ed8201e6d52f58"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set 0.9.1",
+ "bit-set 0.10.0",
  "bitflags 2.13.1",
  "block2 0.6.2",
  "bytemuck",
@@ -7355,17 +7354,18 @@ dependencies = [
  "glow",
  "glutin_wgl_sys",
  "gpu-allocator",
- "gpu-descriptor",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "js-sys",
  "khronos-egl",
  "libc",
  "libloading",
  "log",
  "naga",
+ "naga-types",
  "ndk-sys",
  "objc2 0.6.4",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation 0.3.2",
  "objc2-metal 0.3.2",
  "objc2-quartz-core 0.3.2",
@@ -7380,6 +7380,7 @@ dependencies = [
  "raw-window-metal",
  "renderdoc-sys",
  "smallvec",
+ "static_assertions",
  "thiserror 2.0.20",
  "wasm-bindgen",
  "wayland-sys",
@@ -7393,9 +7394,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.4"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95226013f547544b223281cd16a4fb549aa9dcb562adbda0faae4c73ffbbc161"
+checksum = "d2f62e73117bb7a62bfd9c5a5841438a823f6566c6442a808ee269d2d055c081"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -7403,15 +7404,17 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "29.0.4"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84bf84cd9ca8ca45e2b223a3868f1adf9bfc0c66aeac212e76ee7e40fdadf8f5"
+checksum = "99dad6f1fbdbbdb4c278a6508b059d44688f5cebddf78d005a46a31340269286"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
  "js-sys",
  "log",
+ "naga-types",
  "raw-window-handle",
+ "static_assertions",
  "web-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "./crates/gpui/",
   "./crates/gpui_web/",
   "./crates/gpui_wgpu/",
+  "./crates/gpui_embed/",
   "./crates/gpui_linux/",
   "./crates/gpui_macos/",
   "./crates/gpui_tokio/",
@@ -188,6 +189,7 @@ gpui_windows = { path = "./crates/gpui_windows/", version = "0.1.0" }
 gpui_web = { path = "./crates/gpui_web/", version = "0.1.0" }
 
 gpui_wgpu = { path = "./crates/gpui_wgpu/", version = "0.1.0" }
+gpui_embed = { path = "./crates/gpui_embed/", version = "0.1.0" }
 
 gpui_macros = { path = "./crates/gpui_macros/", version = "0.1.0" }
 gpui_shared_string = { path = "./crates/gpui_shared_string/", version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ ashpd = { version = "0.13", default-features = false, features = [
 libc = "0.2"
 smol = "2.0"
 util = { path = "crates/gpui_zed_util", version = "0.2.2", package = "gpui_zed_util" }
-wgpu = "29.0.3"
+wgpu = "=30.0.1"
 criterion = { version = "0.5", features = ["html_reports"] }
 objc2-app-kit = { version = "0.3", default-features = false, features = [
   "NSButton",

--- a/crates/gpui/src/elements/surface.rs
+++ b/crates/gpui/src/elements/surface.rs
@@ -1,6 +1,6 @@
 use crate::{
-    App, Bounds, Element, ElementId, GlobalElementId, InspectorElementId, IntoElement, LayoutId,
-    ObjectFit, Pixels, Style, StyleRefinement, Styled, Window,
+    App, Bounds, Element, ElementId, ExternalSurfaceId, GlobalElementId, InspectorElementId,
+    IntoElement, LayoutId, ObjectFit, Pixels, Style, StyleRefinement, Styled, Window,
 };
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use crate::{DevicePixels, Size};
@@ -159,6 +159,83 @@ impl IntoElement for Surface {
 }
 
 impl Styled for Surface {
+    fn style(&mut self) -> &mut StyleRefinement {
+        &mut self.style
+    }
+}
+
+/// An engine-owned texture sampled inside GPUI layout and draw order.
+pub struct ExternalSurfaceElement {
+    id: ExternalSurfaceId,
+    style: StyleRefinement,
+}
+
+/// Creates an external surface element for a host-registered texture.
+pub fn external_surface(id: ExternalSurfaceId) -> ExternalSurfaceElement {
+    ExternalSurfaceElement {
+        id,
+        style: Default::default(),
+    }
+}
+
+impl Element for ExternalSurfaceElement {
+    type RequestLayoutState = ();
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        None
+    }
+
+    fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        let mut style = Style::default();
+        style.refine(&self.style);
+        (window.request_layout(style, [], cx), ())
+    }
+
+    fn prepaint(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        _window: &mut Window,
+        _cx: &mut App,
+    ) -> Self::PrepaintState {
+    }
+
+    fn paint(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        _prepaint: &mut Self::PrepaintState,
+        window: &mut Window,
+        _cx: &mut App,
+    ) {
+        window.paint_external_surface(bounds, self.id);
+    }
+}
+
+impl IntoElement for ExternalSurfaceElement {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Styled for ExternalSurfaceElement {
     fn style(&mut self) -> &mut StyleRefinement {
         &mut self.style
     }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -925,7 +925,9 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn set_tabbing_identifier(&self, _identifier: Option<String>) {}
 
     #[cfg(target_os = "windows")]
-    fn get_raw_handle(&self) -> windows::Win32::Foundation::HWND;
+    fn get_raw_handle(&self) -> Option<windows::Win32::Foundation::HWND> {
+        None
+    }
 
     // Linux specific methods
     fn inner_window_bounds(&self) -> WindowBounds {

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -352,11 +352,6 @@ impl PlatformWindow for TestWindow {
         Some(self)
     }
 
-    #[cfg(target_os = "windows")]
-    fn get_raw_handle(&self) -> windows::Win32::Foundation::HWND {
-        unimplemented!()
-    }
-
     fn show_window_menu(&self, _position: Point<Pixels>) {
         unimplemented!()
     }

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -1110,6 +1110,13 @@ impl<T> ExternalSurfaceRegistry<T> {
         self.resources.get(&id).map(|entry| entry.generation)
     }
 
+    /// Iterates over the stable identifiers and current generations of all registered resources.
+    pub fn generations(&self) -> impl Iterator<Item = (ExternalSurfaceId, u64)> + '_ {
+        self.resources
+            .iter()
+            .map(|(&id, entry)| (id, entry.generation))
+    }
+
     /// Returns the number of registered resources.
     pub fn len(&self) -> usize {
         self.resources.len()
@@ -1508,9 +1515,11 @@ mod tests {
         let id = registry.register("first");
         assert_eq!(registry.generation(id), Some(1));
         assert_eq!(registry.get(id), Some(&"first"));
+        assert_eq!(registry.generations().collect::<Vec<_>>(), vec![(id, 1)]);
         assert!(registry.replace(id, "second"));
         assert_eq!(registry.generation(id), Some(2));
         assert_eq!(registry.get(id), Some(&"second"));
+        assert_eq!(registry.generations().collect::<Vec<_>>(), vec![(id, 2)]);
         assert_eq!(registry.replace_with_generation(id, "third"), Some(3));
         assert_eq!(registry.remove(id), Some("third"));
         assert_eq!(registry.len(), 0);

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use smallvec::SmallVec;
 use std::{
+    collections::HashMap,
     fmt::Debug,
     iter::Peekable,
     ops::{Add, Range, Sub},
@@ -51,6 +52,8 @@ pub struct Scene {
     pub subpixel_sprites: Vec<SubpixelSprite>,
     pub polychrome_sprites: Vec<PolychromeSprite>,
     pub surfaces: Vec<PaintSurface>,
+    /// Backend-neutral external textures drawn in scene order.
+    pub external_surfaces: Vec<ExternalSurface>,
     pub backdrop_filters: Vec<BackdropFilter>,
     pub filter_boundaries: Vec<FilterBoundary>,
 }
@@ -69,6 +72,7 @@ impl Scene {
         self.subpixel_sprites.clear();
         self.polychrome_sprites.clear();
         self.surfaces.clear();
+        self.external_surfaces.clear();
         self.backdrop_filters.clear();
         self.filter_boundaries.clear();
     }
@@ -167,6 +171,10 @@ impl Scene {
                 surface.order = order;
                 self.surfaces.push(surface.clone());
             }
+            Primitive::ExternalSurface(surface) => {
+                surface.order = order;
+                self.external_surfaces.push(*surface);
+            }
             Primitive::BackdropFilter(filter) => {
                 filter.order = order;
                 self.backdrop_filters.push(filter.clone());
@@ -210,6 +218,7 @@ impl Scene {
         self.polychrome_sprites
             .sort_by_key(|sprite| (sprite.order, sprite.tile.tile_id));
         self.surfaces.sort_by_key(|surface| surface.order);
+        self.external_surfaces.sort_by_key(|surface| surface.order);
         self.backdrop_filters.sort_by_key(|filter| filter.order);
         // Markers normally get distinct, monotonically-increasing orders (children overlap
         // their group bounds and so sort strictly between the start and end). The `!is_start`
@@ -244,6 +253,8 @@ impl Scene {
             polychrome_sprites_iter: self.polychrome_sprites.iter().peekable(),
             surfaces_start: 0,
             surfaces_iter: self.surfaces.iter().peekable(),
+            external_surfaces_start: 0,
+            external_surfaces_iter: self.external_surfaces.iter().peekable(),
             backdrop_filters_start: 0,
             backdrop_filters_iter: self.backdrop_filters.iter().peekable(),
             filter_boundaries_start: 0,
@@ -302,6 +313,7 @@ pub(crate) enum PrimitiveKind {
     SubpixelSprite,
     PolychromeSprite,
     Surface,
+    ExternalSurface,
     BackdropFilter,
     // Highest discriminant: at an equal order, a group-end is emitted after the group's content
     // so the renderer composites the filtered group only once every child has been drawn.
@@ -325,6 +337,7 @@ pub enum Primitive {
     SubpixelSprite(SubpixelSprite),
     PolychromeSprite(PolychromeSprite),
     Surface(PaintSurface),
+    ExternalSurface(ExternalSurface),
     BackdropFilter(BackdropFilter),
     FilterBoundary(FilterBoundary),
 }
@@ -341,6 +354,7 @@ impl Primitive {
             Primitive::SubpixelSprite(sprite) => &sprite.bounds,
             Primitive::PolychromeSprite(sprite) => &sprite.bounds,
             Primitive::Surface(surface) => &surface.bounds,
+            Primitive::ExternalSurface(surface) => &surface.bounds,
             Primitive::BackdropFilter(filter) => &filter.bounds,
             Primitive::FilterBoundary(boundary) => &boundary.bounds,
         }
@@ -356,6 +370,7 @@ impl Primitive {
             Primitive::SubpixelSprite(sprite) => &sprite.content_mask,
             Primitive::PolychromeSprite(sprite) => &sprite.content_mask,
             Primitive::Surface(surface) => &surface.content_mask,
+            Primitive::ExternalSurface(surface) => &surface.content_mask,
             Primitive::BackdropFilter(filter) => &filter.content_mask,
             Primitive::FilterBoundary(boundary) => &boundary.content_mask,
         }
@@ -386,6 +401,8 @@ struct BatchIterator<'a> {
     polychrome_sprites_iter: Peekable<slice::Iter<'a, PolychromeSprite>>,
     surfaces_start: usize,
     surfaces_iter: Peekable<slice::Iter<'a, PaintSurface>>,
+    external_surfaces_start: usize,
+    external_surfaces_iter: Peekable<slice::Iter<'a, ExternalSurface>>,
     backdrop_filters_start: usize,
     backdrop_filters_iter: Peekable<slice::Iter<'a, BackdropFilter>>,
     filter_boundaries_start: usize,
@@ -422,6 +439,10 @@ impl<'a> Iterator for BatchIterator<'a> {
             (
                 self.surfaces_iter.peek().map(|s| s.order),
                 PrimitiveKind::Surface,
+            ),
+            (
+                self.external_surfaces_iter.peek().map(|s| s.order),
+                PrimitiveKind::ExternalSurface,
             ),
             (
                 self.backdrop_filters_iter.peek().map(|f| f.order),
@@ -582,6 +603,22 @@ impl<'a> Iterator for BatchIterator<'a> {
                 self.surfaces_start = surfaces_end;
                 Some(PrimitiveBatch::Surfaces(surfaces_start..surfaces_end))
             }
+            PrimitiveKind::ExternalSurface => {
+                let external_surfaces_start = self.external_surfaces_start;
+                let mut external_surfaces_end = external_surfaces_start + 1;
+                self.external_surfaces_iter.next();
+                while self
+                    .external_surfaces_iter
+                    .next_if(|surface| (surface.order, batch_kind) < max_order_and_kind)
+                    .is_some()
+                {
+                    external_surfaces_end += 1;
+                }
+                self.external_surfaces_start = external_surfaces_end;
+                Some(PrimitiveBatch::ExternalSurfaces(
+                    external_surfaces_start..external_surfaces_end,
+                ))
+            }
             PrimitiveKind::BackdropFilter => {
                 let backdrop_filters_start = self.backdrop_filters_start;
                 let mut backdrop_filters_end = backdrop_filters_start + 1;
@@ -638,6 +675,7 @@ pub enum PrimitiveBatch {
         range: Range<usize>,
     },
     Surfaces(Range<usize>),
+    ExternalSurfaces(Range<usize>),
     BackdropFilters(Range<usize>),
     /// A single content-filter group boundary; index into [`Scene::filter_boundaries`]. Read
     /// `is_start` to tell whether this opens the group (switch render target) or closes it
@@ -675,6 +713,7 @@ impl PrimitiveBatch {
                 )
             }
             Self::Surfaces(range) => format!("surfaces ({})", range.len()),
+            Self::ExternalSurfaces(range) => format!("external surfaces ({})", range.len()),
             Self::BackdropFilters(range) => format!("backdrop filters ({})", range.len()),
             Self::FilterBoundary(ix) => format!("filter boundary ({ix})"),
         }
@@ -988,6 +1027,115 @@ impl From<PaintSurface> for Primitive {
     }
 }
 
+/// Stable identifier for a host-owned external texture.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct ExternalSurfaceId(u64);
+
+impl ExternalSurfaceId {
+    /// Creates an identifier from a host-managed numeric value.
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Returns the numeric identifier.
+    pub const fn value(self) -> u64 {
+        self.0
+    }
+}
+
+/// A registry that maps scene identifiers to backend-owned texture resources.
+#[derive(Debug)]
+pub struct ExternalSurfaceRegistry<T> {
+    next_id: u64,
+    resources: HashMap<ExternalSurfaceId, ExternalSurfaceEntry<T>>,
+}
+
+#[derive(Debug)]
+struct ExternalSurfaceEntry<T> {
+    resource: T,
+    generation: u64,
+}
+
+impl<T> Default for ExternalSurfaceRegistry<T> {
+    fn default() -> Self {
+        Self {
+            next_id: 1,
+            resources: HashMap::new(),
+        }
+    }
+}
+
+impl<T> ExternalSurfaceRegistry<T> {
+    /// Registers a resource and returns its stable scene identifier.
+    pub fn register(&mut self, resource: T) -> ExternalSurfaceId {
+        let id = ExternalSurfaceId::new(self.next_id);
+        self.next_id = self.next_id.wrapping_add(1).max(1);
+        self.resources.insert(
+            id,
+            ExternalSurfaceEntry {
+                resource,
+                generation: 1,
+            },
+        );
+        id
+    }
+
+    /// Replaces a resource under an existing identifier without changing scene layout identity.
+    /// The per-resource generation advances so a renderer can require a fresh backend view after
+    /// device recovery.
+    pub fn replace(&mut self, id: ExternalSurfaceId, resource: T) -> bool {
+        self.replace_with_generation(id, resource).is_some()
+    }
+
+    /// Replaces a resource and returns its new generation.
+    pub fn replace_with_generation(&mut self, id: ExternalSurfaceId, resource: T) -> Option<u64> {
+        let entry = self.resources.get_mut(&id)?;
+        entry.resource = resource;
+        entry.generation = entry.generation.wrapping_add(1).max(1);
+        Some(entry.generation)
+    }
+
+    /// Removes a resource from the registry.
+    pub fn remove(&mut self, id: ExternalSurfaceId) -> Option<T> {
+        self.resources.remove(&id).map(|entry| entry.resource)
+    }
+
+    /// Returns a registered resource.
+    pub fn get(&self, id: ExternalSurfaceId) -> Option<&T> {
+        self.resources.get(&id).map(|entry| &entry.resource)
+    }
+
+    /// Returns the current generation of a registered resource.
+    pub fn generation(&self, id: ExternalSurfaceId) -> Option<u64> {
+        self.resources.get(&id).map(|entry| entry.generation)
+    }
+
+    /// Returns the number of registered resources.
+    pub fn len(&self) -> usize {
+        self.resources.len()
+    }
+}
+
+/// A host-owned texture sampled at a GPUI-computed layout position.
+#[derive(Copy, Clone, Debug)]
+#[repr(C)]
+pub struct ExternalSurface {
+    /// Draw order assigned by the scene.
+    pub order: DrawOrder,
+    /// Device-scaled bounds of the external texture.
+    pub bounds: Bounds<ScaledPixels>,
+    /// Clip mask applied while sampling the texture.
+    pub content_mask: ContentMask<ScaledPixels>,
+    /// Registry identifier for the host-owned texture.
+    pub id: ExternalSurfaceId,
+}
+
+impl From<ExternalSurface> for Primitive {
+    fn from(surface: ExternalSurface) -> Self {
+        Primitive::ExternalSurface(surface)
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[expect(missing_docs)]
 pub struct PathId(pub usize);
@@ -1238,12 +1386,22 @@ mod tests {
         }
     }
 
+    fn external_surface(id: u64) -> ExternalSurface {
+        ExternalSurface {
+            order: 0,
+            bounds: full_bounds(),
+            content_mask: mask(),
+            id: ExternalSurfaceId::new(id),
+        }
+    }
+
     fn batch_kinds(scene: &mut Scene) -> Vec<&'static str> {
         scene.finish();
         scene
             .batches()
             .map(|batch| match batch {
                 PrimitiveBatch::Quads(_) => "quad",
+                PrimitiveBatch::ExternalSurfaces(_) => "external",
                 PrimitiveBatch::BackdropFilters(_) => "backdrop",
                 PrimitiveBatch::FilterBoundary(ix) => {
                     if scene.filter_boundaries[ix].is_start {
@@ -1322,5 +1480,39 @@ mod tests {
         scene.insert_primitive(quad());
 
         assert_eq!(batch_kinds(&mut scene), vec!["quad", "backdrop", "quad"]);
+    }
+
+    #[test]
+    fn external_surfaces_preserve_scene_order() {
+        let mut scene = Scene::default();
+        scene.insert_primitive(quad());
+        scene.insert_primitive(external_surface(7));
+        scene.insert_primitive(quad());
+
+        assert_eq!(batch_kinds(&mut scene), vec!["quad", "external", "quad"]);
+        assert_eq!(scene.external_surfaces[0].id, ExternalSurfaceId::new(7));
+    }
+
+    #[test]
+    fn external_surfaces_replay_and_registry_lifecycle() {
+        let mut scene = Scene::default();
+        scene.insert_primitive(external_surface(11));
+
+        let mut replay = Scene::default();
+        replay.replay(0..scene.len(), &scene);
+        replay.finish();
+        assert_eq!(replay.external_surfaces.len(), 1);
+        assert_eq!(replay.external_surfaces[0].id, ExternalSurfaceId::new(11));
+
+        let mut registry = ExternalSurfaceRegistry::default();
+        let id = registry.register("first");
+        assert_eq!(registry.generation(id), Some(1));
+        assert_eq!(registry.get(id), Some(&"first"));
+        assert!(registry.replace(id, "second"));
+        assert_eq!(registry.generation(id), Some(2));
+        assert_eq!(registry.get(id), Some(&"second"));
+        assert_eq!(registry.replace_with_generation(id, "third"), Some(3));
+        assert_eq!(registry.remove(id), Some("third"));
+        assert_eq!(registry.len(), 0);
     }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1119,6 +1119,11 @@ pub struct Window {
     active: Rc<Cell<bool>>,
     hovered: Rc<Cell<bool>>,
     pub(crate) needs_present: Rc<Cell<bool>>,
+    /// Generation of the retained scene. This advances only when layout and paint rebuild the
+    /// scene, not when the same scene is encoded into another host target.
+    scene_generation: u64,
+    /// Whether the most recent frame preparation rebuilt the retained scene.
+    scene_changed: bool,
     /// Tracks recent input event timestamps to determine if input is arriving at a high rate.
     /// Used to selectively enable VRR optimization only when input rate exceeds 60fps.
     pub(crate) input_rate_tracker: Rc<RefCell<InputRateTracker>>,
@@ -1623,25 +1628,10 @@ impl Window {
                 }
                 last_frame_time.set(Some(now));
 
-                let next_frame_callbacks = next_frame_callbacks.take();
-                if !next_frame_callbacks.is_empty() {
-                    handle
-                        .update(&mut cx, |_, window, cx| {
-                            for callback in next_frame_callbacks {
-                                callback(window, cx);
-                            }
-                        })
-                        .log_err();
-                }
-
-                // Keep presenting if input was recently arriving at a high rate (>= 60fps).
-                // Once high-rate input is detected, we sustain presentation for 1 second
-                // to prevent display underclocking during active input.
-                let needs_present = request_frame_options.require_presentation
-                    || needs_present.get()
-                    || input_rate_tracker.borrow_mut().is_high_rate();
-
-                if invalidator.is_dirty() || force_render {
+                if invalidator.is_dirty()
+                    || force_render
+                    || !next_frame_callbacks.borrow().is_empty()
+                {
                     measure("frame duration", || {
                         handle
                             .update(&mut cx, |_, window, cx| {
@@ -1650,15 +1640,29 @@ impl Window {
                                     // atlas tile references after a GPU device recovery.
                                     window.refresh();
                                 }
-                                let arena_clear_needed = window.draw(cx);
-                                window.present();
+                                let arena_clear_needed = window.prepare_frame(cx);
+                                // Keep presenting if input was recently arriving at a high rate
+                                // (>= 60fps). Once high-rate input is detected, we sustain
+                                // presentation for 1 second to prevent display underclocking
+                                // during active input.
+                                let needs_present = request_frame_options.require_presentation
+                                    || window.needs_redraw()
+                                    || input_rate_tracker.borrow_mut().is_high_rate();
+                                if needs_present {
+                                    window.present();
+                                }
                                 arena_clear_needed.clear(cx);
                             })
                             .log_err();
                     })
-                } else if needs_present {
+                } else if request_frame_options.require_presentation
+                    || needs_present.get()
+                    || input_rate_tracker.borrow_mut().is_high_rate()
+                {
                     handle
-                        .update(&mut cx, |_, window, _| window.present())
+                        .update(&mut cx, |_, window, _| {
+                            window.present();
+                        })
                         .log_err();
                 }
 
@@ -1867,6 +1871,8 @@ impl Window {
             active,
             hovered,
             needs_present,
+            scene_generation: 0,
+            scene_changed: false,
             input_rate_tracker,
             #[cfg(feature = "input-latency-histogram")]
             input_latency_tracker: InputLatencyTracker::new()?,
@@ -1906,6 +1912,22 @@ impl Window {
 pub struct DispatchEventResult {
     pub propagate: bool,
     pub default_prevented: bool,
+}
+
+/// The state of a window's retained frame after preparation.
+///
+/// A scene generation changes only when GPUI rebuilds layout and paint. The same generation may
+/// be encoded into many host-owned targets, so a host must acknowledge the generation it actually
+/// submitted rather than treating every encode as a new scene. An engine may update a registered
+/// viewport texture and re-encode this unchanged scene without forcing GPUI layout or paint.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct FrameStatus {
+    /// Generation of the retained scene.
+    pub scene_generation: u64,
+    /// Whether the most recent preparation rebuilt layout and paint.
+    pub scene_changed: bool,
+    /// Whether a successful host submission still requires presentation acknowledgement.
+    pub presentation_requested: bool,
 }
 
 /// Indicates which region of the window is visible. Content falling outside of this mask will not be
@@ -2804,7 +2826,8 @@ impl Window {
     }
 
     /// Produces a new frame and assigns it to `rendered_frame`. To actually show
-    /// the contents of the new [`Scene`], use [`Self::present`].
+    /// the contents of the new [`Scene`], present [`Self::rendered_scene`] and then call
+    /// [`Self::mark_presented`].
     #[profiling::function]
     pub fn draw(&mut self, cx: &mut App) -> ArenaClearNeeded {
         // Drain unconditionally so a stale first-invalidation timestamp can't
@@ -2917,6 +2940,8 @@ impl Window {
             self.refresh();
         }
         self.needs_present.set(true);
+        self.scene_generation = self.scene_generation.wrapping_add(1);
+        self.scene_changed = true;
 
         if let Some(draw_start) = draw_started_at {
             profiler::record_frame_timing(profiler::FrameTiming {
@@ -2931,6 +2956,75 @@ impl Window {
         // Exit the scope to obtain the arena-clear token this draw owes; the
         // scope's teardown itself happens in `ElementArenaScope::drop`.
         arena_scope.exit(&cx.element_arena)
+    }
+
+    /// Runs pending next-frame callbacks and prepares the next rendered frame when the window is
+    /// dirty. A clean window reuses its current scene generation; hosts may still encode that
+    /// scene when only an engine-owned viewport texture changed. The returned token must be
+    /// cleared after the frame has been presented.
+    pub fn prepare_frame(&mut self, cx: &mut App) -> ArenaClearNeeded {
+        self.scene_changed = false;
+        let callbacks = self.next_frame_callbacks.take();
+        for callback in callbacks {
+            callback(self, cx);
+        }
+
+        if self.invalidator.is_dirty() || self.scene_generation == 0 {
+            self.draw(cx)
+        } else {
+            let arena_scope = ElementArenaScope::enter(&cx.element_arena);
+            arena_scope.exit(&cx.element_arena)
+        }
+    }
+
+    /// Returns the scene retained from the most recently prepared frame.
+    pub fn rendered_scene(&self) -> &Scene {
+        &self.rendered_frame.scene
+    }
+
+    /// Returns whether the retained scene needs to be presented.
+    pub fn needs_redraw(&self) -> bool {
+        self.needs_present.get()
+    }
+
+    /// Returns whether GPUI is dirty and a future preparation may rebuild its scene.
+    pub fn is_dirty(&self) -> bool {
+        self.invalidator.is_dirty()
+    }
+
+    /// Returns the retained-frame state used by host-driven rendering.
+    pub fn frame_status(&self) -> FrameStatus {
+        FrameStatus {
+            scene_generation: self.scene_generation,
+            scene_changed: self.scene_changed,
+            presentation_requested: self.needs_present.get(),
+        }
+    }
+
+    /// Marks a retained scene generation as presented and completes frame bookkeeping.
+    ///
+    /// Returns `false` when the acknowledgement is stale. Hosts should pass the generation from
+    /// [`Self::frame_status`] that was encoded into their command buffer, and call this only after
+    /// every required target submission succeeds (and after swapchain presentation, when used).
+    #[profiling::function]
+    pub fn mark_presented(&mut self, scene_generation: u64) -> bool {
+        if scene_generation != self.scene_generation {
+            return false;
+        }
+        #[cfg(feature = "input-latency-histogram")]
+        self.input_latency_tracker.record_frame_presented();
+        self.needs_present.set(false);
+        profiling::finish_frame!();
+        true
+    }
+
+    /// Presents the retained scene through the native platform window and acknowledges the
+    /// generation immediately. Host-driven integrations must call [`Self::mark_presented`] only
+    /// after their own command submission instead.
+    fn present(&mut self) {
+        let scene_generation = self.scene_generation;
+        self.platform_window.draw(self.rendered_scene());
+        self.mark_presented(scene_generation);
     }
 
     fn record_entities_accessed(&mut self, cx: &mut App) {
@@ -2955,15 +3049,6 @@ impl Window {
         self.invalidator.replace_views(views);
     }
 
-    #[profiling::function]
-    fn present(&mut self) {
-        self.platform_window.draw(&self.rendered_frame.scene);
-        #[cfg(feature = "input-latency-histogram")]
-        self.input_latency_tracker.record_frame_presented();
-        self.needs_present.set(false);
-        profiling::finish_frame!();
-    }
-
     /// Presents the most recently drawn frame if it hasn't been presented yet.
     ///
     /// Benchmarks drive drawing synchronously rather than through a platform
@@ -2971,7 +3056,7 @@ impl Window {
     /// submit the frame like production presentation would.
     #[cfg(feature = "bench")]
     pub fn present_if_needed(&mut self) {
-        if self.needs_present.get() {
+        if self.needs_redraw() {
             self.present();
         }
     }
@@ -4652,6 +4737,24 @@ impl Window {
             texture,
             texture_size,
         });
+    }
+
+    /// Paints a host-owned external surface into the next scene at the current z-index.
+    ///
+    /// The host resolves `id` through its backend registry while encoding. The texture is sampled
+    /// in scene order, clipped by the current content mask, and never copied through CPU memory.
+    /// This method is valid on every platform and is intended for engine/editor viewport content.
+    pub fn paint_external_surface(&mut self, bounds: Bounds<Pixels>, id: crate::ExternalSurfaceId) {
+        self.invalidator.debug_assert_paint();
+        let bounds = self.snap_bounds(bounds);
+        self.next_frame
+            .scene
+            .insert_primitive(crate::scene::ExternalSurface {
+                order: 0,
+                bounds,
+                content_mask: self.snapped_content_mask(),
+                id,
+            });
     }
 
     /// Removes an image from the sprite atlas.

--- a/crates/gpui_embed/Cargo.toml
+++ b/crates/gpui_embed/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "gpui_embed"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+futures.workspace = true
+gpui.workspace = true
+gpui_wgpu.workspace = true
+uuid.workspace = true

--- a/crates/gpui_embed/Cargo.toml
+++ b/crates/gpui_embed/Cargo.toml
@@ -9,3 +9,6 @@ futures.workspace = true
 gpui.workspace = true
 gpui_wgpu.workspace = true
 uuid.workspace = true
+
+[dev-dependencies]
+winit = "0.30"

--- a/crates/gpui_embed/examples/mock_wgpu.rs
+++ b/crates/gpui_embed/examples/mock_wgpu.rs
@@ -404,7 +404,7 @@ fn main() -> gpui::Result<()> {
     let unpadded_bytes_per_row = WIDTH * 4;
     let non_background_pixels = mapped
         .chunks(bytes_per_row as usize)
-        .flat_map(|row| row[..unpadded_bytes_per_row as usize].chunks(4))
+        .flat_map(|row| row[..unpadded_bytes_per_row as usize].as_chunks::<4>().0)
         .filter(|pixel| pixel[0] > 20 || pixel[1] > 20 || pixel[2] > 20)
         .count();
     let bright_text_pixels = mapped
@@ -417,7 +417,7 @@ fn main() -> gpui::Result<()> {
     let triangle_pixels = viewport_readback
         .0
         .chunks(viewport_readback.1 as usize)
-        .flat_map(|row| row.chunks_exact(4))
+        .flat_map(|row| row.as_chunks::<4>().0)
         .filter(|pixel| {
             pixel
                 .iter()
@@ -429,7 +429,7 @@ fn main() -> gpui::Result<()> {
     let child_origin_y = viewport_device_bounds.origin.y.0.max(0) as u32;
     let external_green_pixels = mapped
         .chunks(bytes_per_row as usize)
-        .flat_map(|row| row[..unpadded_bytes_per_row as usize].chunks_exact(4))
+        .flat_map(|row| row[..unpadded_bytes_per_row as usize].as_chunks::<4>().0)
         .filter(|pixel| pixel[1] > 150 && pixel[0] < 180 && pixel[2] < 180)
         .count();
     let inside_viewport = pixel(
@@ -744,12 +744,12 @@ fn main() -> gpui::Result<()> {
     )?;
     let recovery_bright_text_pixels = recovery_pixels
         .chunks(recovery_stride as usize)
-        .flat_map(|row| row[..(WIDTH * 4) as usize].chunks_exact(4))
+        .flat_map(|row| row[..(WIDTH * 4) as usize].as_chunks::<4>().0)
         .filter(|pixel| pixel[0] > 180 && pixel[1] > 180 && pixel[2] > 180)
         .count();
     let recovery_red_pixels = recovery_pixels
         .chunks(recovery_stride as usize)
-        .flat_map(|row| row[..(WIDTH * 4) as usize].chunks_exact(4))
+        .flat_map(|row| row[..(WIDTH * 4) as usize].as_chunks::<4>().0)
         .filter(|pixel| pixel[0] > 180 && pixel[1] < 110 && pixel[2] < 110)
         .count();
     assert!(

--- a/crates/gpui_embed/examples/mock_wgpu.rs
+++ b/crates/gpui_embed/examples/mock_wgpu.rs
@@ -645,11 +645,52 @@ fn main() -> gpui::Result<()> {
     ui.set_window_metrics(metrics);
     let _ = ui.poll();
     let before_recovery = ui.prepare_frame()?;
+    let (replacement_device, replacement_queue) = block_on(
+        host_gpu.adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("gpui_embed_mock_recovery_device"),
+            required_features: requirements.features,
+            required_limits: wgpu::Limits::downlevel_defaults()
+                .using_resolution(host_gpu.adapter.limits())
+                .using_alignment(host_gpu.adapter.limits()),
+            memory_hints: wgpu::MemoryHints::MemoryUsage,
+            trace: wgpu::Trace::Off,
+            experimental_features: wgpu::ExperimentalFeatures::disabled(),
+        }),
+    )
+    .map_err(|error| {
+        std::io::Error::other(format!("failed to request recovery device: {error}"))
+    })?;
+    let replacement_device = Arc::new(replacement_device);
+    let replacement_queue = Arc::new(replacement_queue);
+    let replacement_host_gpu = HostGpu::new(
+        host_gpu.adapter.clone(),
+        replacement_device.clone(),
+        replacement_queue.clone(),
+        format,
+    );
     ui.replace_gpu_context(
         host_gpu.adapter.as_ref(),
-        host_gpu.device.clone(),
-        host_gpu.queue.clone(),
+        replacement_device.clone(),
+        replacement_queue.clone(),
+        Some(&external_registry),
     )?;
+    let stale_recovery_target = OffscreenTarget::new(&replacement_host_gpu, target_size);
+    let mut stale_recovery_encoder =
+        replacement_device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("mock_recovery_stale_registry_encoder"),
+        });
+    let stale_registry_error = ui
+        .encode_with_external_surfaces(
+            stale_recovery_target.target(wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)),
+            &mut stale_recovery_encoder,
+            &external_registry,
+        )
+        .expect_err("the old external view must be rejected after GPU recovery");
+    assert!(
+        stale_registry_error
+            .to_string()
+            .contains("must be replaced after GPU recovery")
+    );
     let _ = ui.poll();
     let recovery_status = ui.prepare_frame()?;
     assert!(
@@ -664,11 +705,13 @@ fn main() -> gpui::Result<()> {
         .expect("recovery did not export viewport bounds");
     let recovery_device_bounds =
         recovery_logical_bounds.to_device_pixels(recovery_scene.metrics.scale_factor);
-    viewport_target = OffscreenTarget::new(&host_gpu, recovery_device_bounds.size);
-    let recovery_pipeline = create_gpu_scene_pipeline(device.as_ref(), format);
-    let mut recovery_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-        label: Some("mock_recovery_encoder"),
-    });
+    viewport_target = OffscreenTarget::new(&replacement_host_gpu, recovery_device_bounds.size);
+    let recovery_pipeline = create_gpu_scene_pipeline(replacement_device.as_ref(), format);
+    let recovery_target = OffscreenTarget::new(&replacement_host_gpu, target_size);
+    let mut recovery_encoder =
+        replacement_device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("mock_recovery_encoder"),
+        });
     encode_engine_viewport(
         &mut recovery_encoder,
         &recovery_pipeline,
@@ -686,16 +729,18 @@ fn main() -> gpui::Result<()> {
             view: Arc::new(viewport_target.view().clone()),
         },
     ));
-    let recovery_target = OffscreenTarget::new(&host_gpu, target_size);
     ui.encode_with_external_surfaces(
         recovery_target.target(wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)),
         &mut recovery_encoder,
         &external_registry,
     )?;
-    queue.submit(Some(recovery_encoder.finish()));
+    replacement_queue.submit(Some(recovery_encoder.finish()));
     assert!(ui.mark_presented(recovery_status.scene_generation)?);
-    let (recovery_pixels, recovery_stride) =
-        readback_target(device.as_ref(), queue.as_ref(), &recovery_target)?;
+    let (recovery_pixels, recovery_stride) = readback_target(
+        replacement_device.as_ref(),
+        replacement_queue.as_ref(),
+        &recovery_target,
+    )?;
     let recovery_bright_text_pixels = recovery_pixels
         .chunks(recovery_stride as usize)
         .flat_map(|row| row[..(WIDTH * 4) as usize].chunks_exact(4))

--- a/crates/gpui_embed/examples/mock_wgpu.rs
+++ b/crates/gpui_embed/examples/mock_wgpu.rs
@@ -236,7 +236,7 @@ fn readback_target(
         .recv()
         .map_err(|error| std::io::Error::other(format!("GPU readback callback failed: {error}")))?
         .map_err(|error| std::io::Error::other(format!("GPU readback mapping failed: {error}")))?;
-    let mapped = slice.get_mapped_range().to_vec();
+    let mapped = slice.get_mapped_range()?.to_vec();
     readback.unmap();
     Ok((mapped, bytes_per_row))
 }
@@ -260,6 +260,7 @@ fn main() -> gpui::Result<()> {
         power_preference: wgpu::PowerPreference::LowPower,
         compatible_surface: None,
         force_fallback_adapter: false,
+        apply_limit_buckets: false,
     }))
     .map_err(|error| std::io::Error::other(format!("failed to request adapter: {error}")))?;
     let requirements = WgpuSceneRenderer::requirements(&adapter);

--- a/crates/gpui_embed/examples/mock_wgpu.rs
+++ b/crates/gpui_embed/examples/mock_wgpu.rs
@@ -1,0 +1,729 @@
+//! Offscreen host integration proof for `gpui_embed`.
+//!
+//! The host creates the instance, adapter, device, command encoder, target, submission, and
+//! readback buffer. A small GPU triangle is rendered into a layout-sized viewport texture first,
+//! then GPUI's retained UI scene samples that texture while encoding into the host target.
+
+use gpui::{
+    AppContext, Bounds, Context, DevicePixels, ExternalSurfaceId, ExternalSurfaceRegistry,
+    IntoElement, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, PlatformInput,
+    Render, Window, block_on, div, external_surface, point, prelude::*, px, rgb, size,
+};
+use gpui_embed::{EmbeddedConfig, EmbeddedGpui, HostGpu, OffscreenTarget, WindowMetrics};
+use gpui_wgpu::{WgpuExternalSurface, WgpuSceneRenderer, wgpu};
+use std::{cell::RefCell, rc::Rc, sync::Arc};
+
+const WIDTH: u32 = 320;
+const HEIGHT: u32 = 200;
+
+struct MockUi {
+    clicked: bool,
+    external_surface_id: ExternalSurfaceId,
+    viewport_bounds: Rc<RefCell<Option<Bounds<Pixels>>>>,
+}
+
+impl Render for MockUi {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let button_label = if self.clicked { "Clicked" } else { "Click me" };
+        let viewport_bounds = self.viewport_bounds.clone();
+        div()
+            .size_full()
+            .flex()
+            .flex_col()
+            .items_center()
+            .justify_center()
+            .gap_3()
+            .text_color(rgb(0xf8fafc))
+            .child(
+                div()
+                    .w(px(260.))
+                    .p_5()
+                    .rounded_lg()
+                    .bg(rgb(0x172554))
+                    .child(div().text_xl().child("GPUI embedded UI"))
+                    .child(
+                        div()
+                            .mt_2()
+                            .text_sm()
+                            .text_color(rgb(0xbfdbfe))
+                            .child("Retained layout and text over a host GPU scene"),
+                    )
+                    .child(
+                        div()
+                            .id("mock-button")
+                            .mt_4()
+                            .px_4()
+                            .py_2()
+                            .rounded_md()
+                            .cursor_pointer()
+                            .on_mouse_down(MouseButton::Left, |_, _, cx| {
+                                cx.stop_propagation();
+                            })
+                            .bg(rgb(0x2563eb))
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.clicked = true;
+                                cx.notify();
+                            }))
+                            .child(button_label),
+                    )
+                    .child(
+                        div()
+                            .mt_3()
+                            .w(px(120.))
+                            .h(px(24.))
+                            .overflow_hidden()
+                            .on_children_prepainted(move |children, _, _| {
+                                *viewport_bounds.borrow_mut() = children.into_iter().next();
+                            })
+                            .child(
+                                external_surface(self.external_surface_id)
+                                    .w(px(180.))
+                                    .h(px(24.)),
+                            ),
+                    ),
+            )
+    }
+}
+
+fn create_gpu_scene_pipeline(
+    device: &wgpu::Device,
+    format: wgpu::TextureFormat,
+) -> wgpu::RenderPipeline {
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("mock_gpu_scene_shader"),
+        source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(
+            r#"
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) color: vec3<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) index: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 3>(
+        vec2<f32>(-0.78, -0.55),
+        vec2<f32>( 0.00,  0.78),
+        vec2<f32>( 0.78, -0.55),
+    );
+    var colors = array<vec3<f32>, 3>(
+        vec3<f32>(0.14, 0.65, 0.95),
+        vec3<f32>(0.35, 0.95, 0.62),
+        vec3<f32>(0.96, 0.52, 0.25),
+    );
+    var output: VertexOutput;
+    output.position = vec4<f32>(positions[index], 0.0, 1.0);
+    output.color = colors[index];
+    return output;
+}
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    return vec4<f32>(input.color, 1.0);
+}
+"#,
+        )),
+    });
+    let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("mock_gpu_scene_pipeline_layout"),
+        bind_group_layouts: &[],
+        immediate_size: 0,
+    });
+    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some("mock_gpu_scene_pipeline"),
+        layout: Some(&layout),
+        vertex: wgpu::VertexState {
+            module: &shader,
+            entry_point: Some("vs_main"),
+            buffers: &[],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: &shader,
+            entry_point: Some("fs_main"),
+            targets: &[Some(wgpu::ColorTargetState {
+                format,
+                blend: None,
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        }),
+        primitive: wgpu::PrimitiveState::default(),
+        depth_stencil: None,
+        multisample: wgpu::MultisampleState::default(),
+        multiview_mask: None,
+        cache: None,
+    })
+}
+
+fn encode_engine_viewport(
+    encoder: &mut wgpu::CommandEncoder,
+    pipeline: &wgpu::RenderPipeline,
+    target: &OffscreenTarget,
+    clear: wgpu::Color,
+) {
+    let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+        label: Some("mock_engine_viewport_pass"),
+        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+            view: target.view(),
+            resolve_target: None,
+            ops: wgpu::Operations {
+                load: wgpu::LoadOp::Clear(clear),
+                store: wgpu::StoreOp::Store,
+            },
+            depth_slice: None,
+        })],
+        depth_stencil_attachment: None,
+        ..Default::default()
+    });
+    pass.set_pipeline(pipeline);
+    pass.draw(0..3, 0..1);
+}
+
+fn readback_target(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    target: &OffscreenTarget,
+) -> gpui::Result<(Vec<u8>, u32)> {
+    let size = target.size();
+    let width = size.width.0 as u32;
+    let height = size.height.0 as u32;
+    let unpadded_bytes_per_row = width * 4;
+    let bytes_per_row = unpadded_bytes_per_row.div_ceil(256) * 256;
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("mock_wgpu_readback"),
+        size: bytes_per_row as u64 * height as u64,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("mock_wgpu_readback_encoder"),
+    });
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo {
+            texture: target.texture(),
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(bytes_per_row),
+                rows_per_image: Some(height),
+            },
+        },
+        wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+    );
+    queue.submit(Some(encoder.finish()));
+
+    let slice = readback.slice(..);
+    let (sender, receiver) = std::sync::mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |result| {
+        let _ = sender.send(result);
+    });
+    device
+        .poll(wgpu::PollType::Wait {
+            submission_index: None,
+            timeout: None,
+        })
+        .map_err(|error| std::io::Error::other(format!("GPU readback poll failed: {error}")))?;
+    receiver
+        .recv()
+        .map_err(|error| std::io::Error::other(format!("GPU readback callback failed: {error}")))?
+        .map_err(|error| std::io::Error::other(format!("GPU readback mapping failed: {error}")))?;
+    let mapped = slice.get_mapped_range().to_vec();
+    readback.unmap();
+    Ok((mapped, bytes_per_row))
+}
+
+fn pixel(bytes: &[u8], bytes_per_row: u32, x: u32, y: u32) -> [u8; 4] {
+    let offset = y as usize * bytes_per_row as usize + x as usize * 4;
+    bytes[offset..offset + 4]
+        .try_into()
+        .expect("RGBA pixel is four bytes")
+}
+
+fn main() -> gpui::Result<()> {
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        backends: wgpu::Backends::all(),
+        flags: wgpu::InstanceFlags::default(),
+        backend_options: wgpu::BackendOptions::default(),
+        memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
+        display: None,
+    });
+    let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::LowPower,
+        compatible_surface: None,
+        force_fallback_adapter: false,
+    }))
+    .map_err(|error| std::io::Error::other(format!("failed to request adapter: {error}")))?;
+    let requirements = WgpuSceneRenderer::requirements(&adapter);
+    let (device, queue) = block_on(
+        adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("gpui_embed_mock_device"),
+            required_features: requirements.features,
+            required_limits: wgpu::Limits::downlevel_defaults()
+                .using_resolution(adapter.limits())
+                .using_alignment(adapter.limits()),
+            memory_hints: wgpu::MemoryHints::MemoryUsage,
+            trace: wgpu::Trace::Off,
+            experimental_features: wgpu::ExperimentalFeatures::disabled(),
+        }),
+    )
+    .map_err(|error| std::io::Error::other(format!("failed to request device: {error}")))?;
+
+    let format = wgpu::TextureFormat::Rgba8UnormSrgb;
+    let host_gpu = HostGpu::new(Arc::new(adapter), Arc::new(device), Arc::new(queue), format);
+    let device = host_gpu.device.clone();
+    let queue = host_gpu.queue.clone();
+    let metrics = WindowMetrics::new(size(px(WIDTH as f32), px(HEIGHT as f32)), 1.0);
+    let placeholder_target =
+        OffscreenTarget::new(&host_gpu, size(DevicePixels(1), DevicePixels(1)));
+    let mut external_registry = ExternalSurfaceRegistry::default();
+    let external_surface_id = external_registry.register(WgpuExternalSurface {
+        view: Arc::new(placeholder_target.view().clone()),
+    });
+    let config = EmbeddedConfig::new(host_gpu.clone()).with_metrics(metrics);
+    let root_entity = Rc::new(RefCell::new(None));
+    let root_entity_for_builder = root_entity.clone();
+    let viewport_bounds = Rc::new(RefCell::new(None));
+    let viewport_bounds_for_builder = viewport_bounds.clone();
+    let ui = EmbeddedGpui::new_with_root(config, move |_, cx| {
+        let entity = cx.new(|_| MockUi {
+            clicked: false,
+            external_surface_id,
+            viewport_bounds: viewport_bounds_for_builder,
+        });
+        *root_entity_for_builder.borrow_mut() = Some(entity.clone());
+        entity
+    })?;
+
+    let gpu_scene_pipeline = create_gpu_scene_pipeline(device.as_ref(), format);
+    let _ = ui.poll();
+    let frame_status = ui.prepare_frame()?;
+    assert!(frame_status.scene_generation > 0);
+    let rendered_scene = ui
+        .rendered_scene()
+        .expect("the embedded GPUI window did not produce a retained scene");
+    let viewport_logical_bounds = viewport_bounds
+        .borrow()
+        .expect("GPUI did not export the viewport child bounds");
+    let viewport_device_bounds =
+        viewport_logical_bounds.to_device_pixels(rendered_scene.metrics.scale_factor);
+    assert!(
+        viewport_device_bounds.size.width.0 > 0 && viewport_device_bounds.size.height.0 > 0,
+        "GPUI exported an empty viewport"
+    );
+
+    // GPUI layout is the source of truth for the host viewport. Render the engine scene into a
+    // texture sized from those device-pixel bounds, then replace the stable registry ID.
+    let mut viewport_target = OffscreenTarget::new(&host_gpu, viewport_device_bounds.size);
+    assert!(external_registry.replace(
+        external_surface_id,
+        WgpuExternalSurface {
+            view: Arc::new(viewport_target.view().clone()),
+        },
+    ));
+    assert_eq!(external_registry.generation(external_surface_id), Some(2));
+
+    let target_size = size(DevicePixels(WIDTH as i32), DevicePixels(HEIGHT as i32));
+    let target = OffscreenTarget::new(&host_gpu, target_size);
+
+    // Both failure modes are checked before the renderer writes atlas/uniform data or opens a
+    // render pass. A missing resource is never silently skipped.
+    let missing_registry_target = OffscreenTarget::new(&host_gpu, target_size);
+    let mut missing_registry_encoder =
+        device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("mock_missing_registry_encoder"),
+        });
+    let missing_registry_error = ui
+        .encode(
+            missing_registry_target.target(wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)),
+            &mut missing_registry_encoder,
+        )
+        .expect_err("external surfaces must require a registry");
+    assert!(missing_registry_error.to_string().contains("registry"));
+
+    let missing_id_target = OffscreenTarget::new(&host_gpu, target_size);
+    let mut missing_id_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("mock_missing_id_encoder"),
+    });
+    let missing_id_registry = ExternalSurfaceRegistry::<WgpuExternalSurface>::default();
+    let missing_id_error = ui
+        .encode_with_external_surfaces(
+            missing_id_target.target(wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)),
+            &mut missing_id_encoder,
+            &missing_id_registry,
+        )
+        .expect_err("missing external IDs must fail encoding");
+    assert!(
+        missing_id_error
+            .to_string()
+            .contains(&format!("ID {}", external_surface_id.value()))
+    );
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("gpui_embed_mock_encoder"),
+    });
+    encode_engine_viewport(
+        &mut encoder,
+        &gpu_scene_pipeline,
+        &viewport_target,
+        wgpu::Color {
+            r: 0.04,
+            g: 0.72,
+            b: 0.10,
+            a: 1.0,
+        },
+    );
+    let stats = ui.encode_with_external_surfaces(
+        target.target(wgpu::LoadOp::Clear(wgpu::Color {
+            r: 0.015,
+            g: 0.027,
+            b: 0.09,
+            a: 1.0,
+        })),
+        &mut encoder,
+        &external_registry,
+    )?;
+    assert!(
+        stats.instance_bytes > 0,
+        "the GPUI scene encoded no GPU instances"
+    );
+    queue.submit(Some(encoder.finish()));
+    assert!(ui.mark_presented(frame_status.scene_generation)?);
+    assert!(!ui.mark_presented(frame_status.scene_generation - 1)?);
+
+    let (mapped, bytes_per_row) = readback_target(device.as_ref(), queue.as_ref(), &target)?;
+    let unpadded_bytes_per_row = WIDTH * 4;
+    let non_background_pixels = mapped
+        .chunks(bytes_per_row as usize)
+        .flat_map(|row| row[..unpadded_bytes_per_row as usize].chunks(4))
+        .filter(|pixel| pixel[0] > 20 || pixel[1] > 20 || pixel[2] > 20)
+        .count();
+    let bright_text_pixels = mapped
+        .chunks(bytes_per_row as usize)
+        .flat_map(|row| row[..unpadded_bytes_per_row as usize].chunks(4))
+        .filter(|pixel| pixel[0] > 180 && pixel[1] > 180 && pixel[2] > 180)
+        .count();
+    let viewport_readback = readback_target(device.as_ref(), queue.as_ref(), &viewport_target)?;
+    let viewport_background = pixel(&viewport_readback.0, viewport_readback.1, 0, 0);
+    let triangle_pixels = viewport_readback
+        .0
+        .chunks(viewport_readback.1 as usize)
+        .flat_map(|row| row.chunks_exact(4))
+        .filter(|pixel| {
+            pixel
+                .iter()
+                .zip(viewport_background)
+                .any(|(value, background)| value.abs_diff(background) > 10)
+        })
+        .count();
+    let child_origin_x = viewport_device_bounds.origin.x.0.max(0) as u32;
+    let child_origin_y = viewport_device_bounds.origin.y.0.max(0) as u32;
+    let external_green_pixels = mapped
+        .chunks(bytes_per_row as usize)
+        .flat_map(|row| row[..unpadded_bytes_per_row as usize].chunks_exact(4))
+        .filter(|pixel| pixel[1] > 150 && pixel[0] < 180 && pixel[2] < 180)
+        .count();
+    let inside_viewport = pixel(
+        &mapped,
+        bytes_per_row,
+        (child_origin_x + 60).min(WIDTH - 1),
+        (child_origin_y + 12).min(HEIGHT - 1),
+    );
+    let clipped_viewport = pixel(
+        &mapped,
+        bytes_per_row,
+        (child_origin_x + 150).min(WIDTH - 1),
+        (child_origin_y + 12).min(HEIGHT - 1),
+    );
+    assert!(
+        non_background_pixels > 100,
+        "GPU scene and GPUI overlay did not produce readable pixels"
+    );
+    assert!(
+        bright_text_pixels > 10,
+        "GPUI text did not reach the host target"
+    );
+    assert!(
+        triangle_pixels > 20,
+        "the host GPU triangle did not render into the engine viewport texture"
+    );
+    assert!(
+        external_green_pixels > 100,
+        "the registered external viewport did not reach GPUI scene order"
+    );
+    assert!(
+        external_green_pixels < 180 * 24,
+        "the external viewport was not clipped by its GPUI layout parent"
+    );
+    assert!(
+        inside_viewport[1] > inside_viewport[0] + 20
+            || inside_viewport[2] > inside_viewport[0] + 20,
+        "the engine viewport did not reach the visible GPUI surface"
+    );
+    assert_ne!(
+        inside_viewport, clipped_viewport,
+        "the GPUI parent did not clip the external viewport"
+    );
+
+    // Normalized host events go to GPUI first. An unhandled event in the exported viewport is
+    // then translated with the same logical bounds the host used to size the engine texture.
+    let mut engine_events = Vec::new();
+    let engine_position = point(
+        viewport_logical_bounds.origin.x + px(8.),
+        viewport_logical_bounds.origin.y + px(8.),
+    );
+    let engine_input = PlatformInput::MouseMove(MouseMoveEvent {
+        position: engine_position,
+        pressed_button: None,
+        modifiers: Default::default(),
+    });
+    let engine_outcome = ui.dispatch_input(engine_input)?;
+    if engine_outcome.propagate
+        && !engine_outcome.pointer_capture
+        && viewport_logical_bounds.contains(&engine_position)
+    {
+        engine_events.push(point(
+            engine_position.x - viewport_logical_bounds.origin.x,
+            engine_position.y - viewport_logical_bounds.origin.y,
+        ));
+    }
+    assert_eq!(engine_events.len(), 1);
+    assert_eq!(engine_events[0], point(px(8.), px(8.)));
+
+    // The retained scene can be encoded into a fresh host target without rebuilding layout or
+    // paint. This is the normal path when the host acquires a new swapchain image.
+    let _ = ui.poll();
+    let unchanged_status = ui.prepare_frame()?;
+    assert_eq!(
+        unchanged_status.scene_generation,
+        frame_status.scene_generation
+    );
+    assert!(!unchanged_status.scene_changed);
+    let unchanged_target = OffscreenTarget::new(&host_gpu, target_size);
+    let mut unchanged_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("gpui_embed_mock_unchanged_encoder"),
+    });
+    let unchanged_stats = ui.encode_with_external_surfaces(
+        unchanged_target.target(wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)),
+        &mut unchanged_encoder,
+        &external_registry,
+    )?;
+    assert!(unchanged_stats.instance_bytes > 0);
+    queue.submit(Some(unchanged_encoder.finish()));
+    ui.mark_presented(unchanged_status.scene_generation)?;
+
+    // Drive a real GPUI click through the host input seam. The small grid keeps the proof
+    // independent of the exact font metrics used by the host while still exercising hit testing,
+    // capture, and the button's `on_click` listener.
+    let mut clicked = false;
+    let mut button_consumed = false;
+    'click_grid: for y in (40..=180).step_by(10) {
+        for x in (40..=280).step_by(10) {
+            let position = point(px(x as f32), px(y as f32));
+            let down_outcome = ui.dispatch_input(PlatformInput::MouseDown(MouseDownEvent {
+                button: MouseButton::Left,
+                position,
+                modifiers: Default::default(),
+                click_count: 1,
+                first_mouse: false,
+            }))?;
+            let up_outcome = ui.dispatch_input(PlatformInput::MouseUp(MouseUpEvent {
+                button: MouseButton::Left,
+                position,
+                modifiers: Default::default(),
+                click_count: 1,
+            }))?;
+            button_consumed |= !down_outcome.propagate || !up_outcome.propagate;
+            clicked = ui.update(|cx| {
+                cx.read_entity(
+                    root_entity.borrow().as_ref().expect("mock root entity"),
+                    |mock, _| mock.clicked,
+                )
+            });
+            if clicked {
+                break 'click_grid;
+            }
+        }
+    }
+    assert!(clicked, "host mouse input did not activate the GPUI button");
+    assert!(
+        button_consumed,
+        "the GPUI button did not consume its mouse event"
+    );
+    let _ = ui.poll();
+    let clicked_status = ui.prepare_frame()?;
+    assert!(clicked_status.scene_changed);
+    assert!(clicked_status.scene_generation > unchanged_status.scene_generation);
+    let clicked_target = OffscreenTarget::new(&host_gpu, target_size);
+    let mut clicked_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("gpui_embed_mock_clicked_encoder"),
+    });
+    ui.encode_with_external_surfaces(
+        clicked_target.target(wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)),
+        &mut clicked_encoder,
+        &external_registry,
+    )?;
+    queue.submit(Some(clicked_encoder.finish()));
+    ui.mark_presented(clicked_status.scene_generation)?;
+
+    // Exercise host-owned resize handling. The host skips encoding while minimized, then
+    // restores a positive target; every positive cycle submits before the next encode.
+    for (width, height) in [(96_u32, 64_u32), (256, 128), (WIDTH, HEIGHT)] {
+        ui.set_window_metrics(WindowMetrics::new(
+            size(px(width as f32), px(height as f32)),
+            1.0,
+        ));
+        let _ = ui.poll();
+        let resize_status = ui.prepare_frame()?;
+        let resize_scene = ui.rendered_scene().expect("resize did not retain a scene");
+        let resize_logical_bounds = viewport_bounds
+            .borrow()
+            .expect("resize did not export viewport bounds");
+        let resize_device_bounds =
+            resize_logical_bounds.to_device_pixels(resize_scene.metrics.scale_factor);
+        if resize_device_bounds.size != viewport_target.size() {
+            viewport_target = OffscreenTarget::new(&host_gpu, resize_device_bounds.size);
+            assert!(external_registry.replace(
+                external_surface_id,
+                WgpuExternalSurface {
+                    view: Arc::new(viewport_target.view().clone()),
+                },
+            ));
+        }
+        let resize_target = OffscreenTarget::new(
+            &host_gpu,
+            size(DevicePixels(width as i32), DevicePixels(height as i32)),
+        );
+        let mut resize_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("mock_resize_encoder"),
+        });
+        encode_engine_viewport(
+            &mut resize_encoder,
+            &gpu_scene_pipeline,
+            &viewport_target,
+            wgpu::Color {
+                r: 0.04,
+                g: 0.72,
+                b: 0.10,
+                a: 1.0,
+            },
+        );
+        ui.encode_with_external_surfaces(
+            resize_target.target(wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)),
+            &mut resize_encoder,
+            &external_registry,
+        )?;
+        queue.submit(Some(resize_encoder.finish()));
+        assert!(ui.mark_presented(resize_status.scene_generation)?);
+    }
+
+    let minimized_metrics = WindowMetrics::new(size(px(0.), px(0.)), 1.0);
+    ui.set_window_metrics(minimized_metrics);
+    let _ = ui.poll();
+    let minimized_status = ui.prepare_frame()?;
+    assert_eq!(
+        ui.rendered_scene()
+            .expect("minimized frame did not retain scene")
+            .metrics
+            .bounds
+            .size,
+        minimized_metrics.bounds.size
+    );
+    assert!(minimized_status.scene_generation > 0);
+
+    // Recreate the positive host target after minimization and exercise the recovery seam. The
+    // renderer keeps the atlas Arc, while the host recreates its viewport/final targets and
+    // replaces the external view under the same stable ID.
+    ui.set_window_metrics(metrics);
+    let _ = ui.poll();
+    let before_recovery = ui.prepare_frame()?;
+    ui.replace_gpu_context(
+        host_gpu.adapter.as_ref(),
+        host_gpu.device.clone(),
+        host_gpu.queue.clone(),
+    )?;
+    let _ = ui.poll();
+    let recovery_status = ui.prepare_frame()?;
+    assert!(
+        recovery_status.scene_generation >= before_recovery.scene_generation,
+        "recovery did not leave a retained frame available"
+    );
+    let recovery_scene = ui
+        .rendered_scene()
+        .expect("recovery did not retain a scene");
+    let recovery_logical_bounds = viewport_bounds
+        .borrow()
+        .expect("recovery did not export viewport bounds");
+    let recovery_device_bounds =
+        recovery_logical_bounds.to_device_pixels(recovery_scene.metrics.scale_factor);
+    viewport_target = OffscreenTarget::new(&host_gpu, recovery_device_bounds.size);
+    let recovery_pipeline = create_gpu_scene_pipeline(device.as_ref(), format);
+    let mut recovery_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("mock_recovery_encoder"),
+    });
+    encode_engine_viewport(
+        &mut recovery_encoder,
+        &recovery_pipeline,
+        &viewport_target,
+        wgpu::Color {
+            r: 0.88,
+            g: 0.03,
+            b: 0.03,
+            a: 1.0,
+        },
+    );
+    assert!(external_registry.replace(
+        external_surface_id,
+        WgpuExternalSurface {
+            view: Arc::new(viewport_target.view().clone()),
+        },
+    ));
+    let recovery_target = OffscreenTarget::new(&host_gpu, target_size);
+    ui.encode_with_external_surfaces(
+        recovery_target.target(wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)),
+        &mut recovery_encoder,
+        &external_registry,
+    )?;
+    queue.submit(Some(recovery_encoder.finish()));
+    assert!(ui.mark_presented(recovery_status.scene_generation)?);
+    let (recovery_pixels, recovery_stride) =
+        readback_target(device.as_ref(), queue.as_ref(), &recovery_target)?;
+    let recovery_bright_text_pixels = recovery_pixels
+        .chunks(recovery_stride as usize)
+        .flat_map(|row| row[..(WIDTH * 4) as usize].chunks_exact(4))
+        .filter(|pixel| pixel[0] > 180 && pixel[1] > 180 && pixel[2] > 180)
+        .count();
+    let recovery_red_pixels = recovery_pixels
+        .chunks(recovery_stride as usize)
+        .flat_map(|row| row[..(WIDTH * 4) as usize].chunks_exact(4))
+        .filter(|pixel| pixel[0] > 180 && pixel[1] < 110 && pixel[2] < 110)
+        .count();
+    assert!(
+        recovery_red_pixels > 100,
+        "the replacement external view did not change the composed pixels"
+    );
+    assert!(
+        recovery_bright_text_pixels > 10,
+        "GPUI text did not render after device recovery"
+    );
+
+    println!(
+        "mock_wgpu passed: {} GPUI instance bytes, {} non-background pixels, {} bright text pixels, {} engine triangle pixels, {} external viewport pixels, {} recovery pixels, {} recovery text pixels",
+        stats.instance_bytes,
+        non_background_pixels,
+        bright_text_pixels,
+        triangle_pixels,
+        external_green_pixels,
+        recovery_red_pixels,
+        recovery_bright_text_pixels
+    );
+    Ok(())
+}

--- a/crates/gpui_embed/examples/windowed_wgpu.rs
+++ b/crates/gpui_embed/examples/windowed_wgpu.rs
@@ -1,0 +1,744 @@
+//! Interactive windowed host proof for `gpui_embed`.
+//!
+//! This example owns the window, WGPU surface, event loop, input translation, command encoder,
+//! submission, and presentation. `gpui_embed` only prepares and encodes the retained GPUI scene.
+
+use gpui::{
+    AppContext, Bounds, Context, DevicePixels, ExternalSurfaceId, ExternalSurfaceRegistry,
+    IntoElement, Modifiers, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels,
+    PlatformInput, Render, Window, block_on, div, external_surface, point, prelude::*, px, rgb,
+    size,
+};
+use gpui_embed::{EmbeddedConfig, EmbeddedGpui, HostGpu, OffscreenTarget, WindowMetrics};
+use gpui_wgpu::{WgpuExternalSurface, WgpuSceneRenderer, wgpu};
+use std::{cell::RefCell, rc::Rc, sync::Arc, time::Instant};
+use winit::{
+    application::ApplicationHandler,
+    dpi::{LogicalSize, PhysicalPosition, PhysicalSize},
+    event::{ElementState, MouseButton as WinitMouseButton, WindowEvent},
+    event_loop::{ActiveEventLoop, EventLoop},
+    window::{Window as WinitWindow, WindowId},
+};
+
+const WINDOW_WIDTH: f64 = 960.0;
+const WINDOW_HEIGHT: f64 = 720.0;
+const VIEWPORT_WIDTH: f32 = 520.0;
+const VIEWPORT_HEIGHT: f32 = 240.0;
+
+struct DemoUi {
+    clicks: u32,
+    external_surface_id: ExternalSurfaceId,
+    viewport_bounds: Rc<RefCell<Option<Bounds<Pixels>>>>,
+}
+
+impl Render for DemoUi {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let button_label = format!("GPUI clicks: {}", self.clicks);
+        let viewport_bounds = self.viewport_bounds.clone();
+        div()
+            .size_full()
+            .flex()
+            .items_center()
+            .justify_center()
+            .bg(rgb(0x08111f))
+            .text_color(rgb(0xf8fafc))
+            .child(
+                div()
+                    .w(px(700.))
+                    .p_6()
+                    .rounded_lg()
+                    .bg(rgb(0x172554))
+                    .child(div().text_xl().child("Windowed GPUI + WGPU"))
+                    .child(
+                        div()
+                            .mt_2()
+                            .text_sm()
+                            .text_color(rgb(0xbfdbfe))
+                            .child("The triangle is host-rendered; this panel is GPUI-rendered."),
+                    )
+                    .child(
+                        div()
+                            .id("windowed-button")
+                            .mt_4()
+                            .px_4()
+                            .py_2()
+                            .rounded_md()
+                            .cursor_pointer()
+                            .on_mouse_down(MouseButton::Left, |_, _, cx| {
+                                cx.stop_propagation();
+                            })
+                            .bg(rgb(0x2563eb))
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.clicks = this.clicks.saturating_add(1);
+                                cx.notify();
+                            }))
+                            .child(button_label),
+                    )
+                    .child(
+                        div()
+                            .mt_5()
+                            .w(px(VIEWPORT_WIDTH))
+                            .h(px(VIEWPORT_HEIGHT))
+                            .overflow_hidden()
+                            .rounded_md()
+                            .on_children_prepainted(move |children, _, _| {
+                                *viewport_bounds.borrow_mut() = children.into_iter().next();
+                            })
+                            .child(
+                                external_surface(self.external_surface_id)
+                                    .w(px(VIEWPORT_WIDTH))
+                                    .h(px(VIEWPORT_HEIGHT)),
+                            ),
+                    ),
+            )
+    }
+}
+
+fn create_gpu_scene_pipeline(
+    device: &wgpu::Device,
+    format: wgpu::TextureFormat,
+) -> (wgpu::RenderPipeline, wgpu::Buffer, wgpu::BindGroup) {
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("windowed_gpu_scene_shader"),
+        source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(
+            r#"
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) color: vec3<f32>,
+};
+
+struct SceneUniforms {
+    pointer: vec2<f32>,
+    time: f32,
+    hovered: f32,
+};
+
+@group(0) @binding(0)
+var<uniform> scene: SceneUniforms;
+
+@vertex
+fn vs_main(@builtin(vertex_index) index: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 3>(
+        vec2<f32>(-0.78, -0.55),
+        vec2<f32>( 0.00,  0.78),
+        vec2<f32>( 0.78, -0.55),
+    );
+    var colors = array<vec3<f32>, 3>(
+        vec3<f32>(0.14, 0.65, 0.95),
+        vec3<f32>(0.35, 0.95, 0.62),
+        vec3<f32>(0.96, 0.52, 0.25),
+    );
+    let angle = scene.time * 0.9;
+    let rotation = mat2x2<f32>(
+        cos(angle), -sin(angle),
+        sin(angle),  cos(angle),
+    );
+    let pointer_offset = select(
+        vec2<f32>(0.0),
+        scene.pointer * vec2<f32>(0.12, 0.12),
+        scene.hovered > 0.5,
+    );
+    var output: VertexOutput;
+    output.position = vec4<f32>(rotation * positions[index] + pointer_offset, 0.0, 1.0);
+    output.color = colors[index];
+    return output;
+}
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    let pulse = 0.85 + 0.15 * sin(scene.time * 3.0);
+    let hover_boost = select(1.0, 1.18, scene.hovered > 0.5);
+    return vec4<f32>(input.color * pulse * hover_boost, 1.0);
+}
+"#,
+        )),
+    });
+    let uniform_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("windowed_gpu_scene_uniform_layout"),
+        entries: &[wgpu::BindGroupLayoutEntry {
+            binding: 0,
+            visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Uniform,
+                has_dynamic_offset: false,
+                min_binding_size: Some(wgpu::BufferSize::new(16).unwrap()),
+            },
+            count: None,
+        }],
+    });
+    let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("windowed_gpu_scene_pipeline_layout"),
+        bind_group_layouts: &[Some(&uniform_layout)],
+        immediate_size: 0,
+    });
+    let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some("windowed_gpu_scene_pipeline"),
+        layout: Some(&layout),
+        vertex: wgpu::VertexState {
+            module: &shader,
+            entry_point: Some("vs_main"),
+            buffers: &[],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: &shader,
+            entry_point: Some("fs_main"),
+            targets: &[Some(wgpu::ColorTargetState {
+                format,
+                blend: None,
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        }),
+        primitive: wgpu::PrimitiveState::default(),
+        depth_stencil: None,
+        multisample: wgpu::MultisampleState::default(),
+        multiview_mask: None,
+        cache: None,
+    });
+    let uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("windowed_gpu_scene_uniform_buffer"),
+        size: 16,
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("windowed_gpu_scene_bind_group"),
+        layout: &uniform_layout,
+        entries: &[wgpu::BindGroupEntry {
+            binding: 0,
+            resource: uniform_buffer.as_entire_binding(),
+        }],
+    });
+    (pipeline, uniform_buffer, bind_group)
+}
+
+fn encode_gpu_scene(
+    encoder: &mut wgpu::CommandEncoder,
+    pipeline: &wgpu::RenderPipeline,
+    bind_group: &wgpu::BindGroup,
+    target: &OffscreenTarget,
+    clear: wgpu::Color,
+) {
+    let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+        label: Some("windowed_gpu_scene_pass"),
+        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+            view: target.view(),
+            resolve_target: None,
+            ops: wgpu::Operations {
+                load: wgpu::LoadOp::Clear(clear),
+                store: wgpu::StoreOp::Store,
+            },
+            depth_slice: None,
+        })],
+        depth_stencil_attachment: None,
+        ..Default::default()
+    });
+    pass.set_pipeline(pipeline);
+    pass.set_bind_group(0, bind_group, &[]);
+    pass.draw(0..3, 0..1);
+}
+
+fn scene_uniform_bytes(pointer: [f32; 2], time: f32, hovered: bool) -> [u8; 16] {
+    let values = [pointer[0], pointer[1], time, hovered as u32 as f32];
+    let mut bytes = [0; 16];
+    for (index, value) in values.into_iter().enumerate() {
+        bytes[index * 4..(index + 1) * 4].copy_from_slice(&value.to_ne_bytes());
+    }
+    bytes
+}
+
+struct WindowedApp {
+    window: Option<Arc<WinitWindow>>,
+    instance: Option<wgpu::Instance>,
+    surface: Option<wgpu::Surface<'static>>,
+    surface_config: Option<wgpu::SurfaceConfiguration>,
+    host_gpu: Option<HostGpu>,
+    ui: Option<EmbeddedGpui>,
+    external_registry: ExternalSurfaceRegistry<WgpuExternalSurface>,
+    external_surface_id: Option<ExternalSurfaceId>,
+    viewport_target: Option<OffscreenTarget>,
+    viewport_pipeline: Option<wgpu::RenderPipeline>,
+    viewport_uniform_buffer: Option<wgpu::Buffer>,
+    viewport_bind_group: Option<wgpu::BindGroup>,
+    viewport_bounds: Rc<RefCell<Option<Bounds<Pixels>>>>,
+    animation_start: Instant,
+    cursor_position: gpui::Point<Pixels>,
+    modifiers: Modifiers,
+    pressed_button: Option<MouseButton>,
+}
+
+impl Default for WindowedApp {
+    fn default() -> Self {
+        Self {
+            window: None,
+            instance: None,
+            surface: None,
+            surface_config: None,
+            host_gpu: None,
+            ui: None,
+            external_registry: ExternalSurfaceRegistry::default(),
+            external_surface_id: None,
+            viewport_target: None,
+            viewport_pipeline: None,
+            viewport_uniform_buffer: None,
+            viewport_bind_group: None,
+            viewport_bounds: Rc::new(RefCell::new(None)),
+            animation_start: Instant::now(),
+            cursor_position: point(px(0.), px(0.)),
+            modifiers: Modifiers::default(),
+            pressed_button: None,
+        }
+    }
+}
+
+impl WindowedApp {
+    fn fail(&mut self, event_loop: &ActiveEventLoop, error: impl std::fmt::Display) {
+        eprintln!("windowed_wgpu failed: {error}");
+        event_loop.exit();
+    }
+
+    fn window(&self) -> Option<&Arc<WinitWindow>> {
+        self.window.as_ref()
+    }
+
+    fn update_metrics(&self) {
+        let (Some(window), Some(ui)) = (self.window(), self.ui.as_ref()) else {
+            return;
+        };
+        let scale_factor = window.scale_factor();
+        let physical_size = window.inner_size();
+        let logical_size = physical_size.to_logical::<f64>(scale_factor);
+        ui.set_window_metrics(WindowMetrics::new(
+            size(
+                px(logical_size.width as f32),
+                px(logical_size.height as f32),
+            ),
+            scale_factor as f32,
+        ));
+    }
+
+    fn viewport_device_size(&self) -> gpui::Size<DevicePixels> {
+        let scale_factor = self
+            .window()
+            .map(|window| window.scale_factor())
+            .unwrap_or(1.0);
+        size(
+            DevicePixels((VIEWPORT_WIDTH as f64 * scale_factor).round() as i32),
+            DevicePixels((VIEWPORT_HEIGHT as f64 * scale_factor).round() as i32),
+        )
+    }
+
+    fn ensure_viewport_target(&mut self) {
+        let (Some(gpu), Some(id)) = (self.host_gpu.as_ref(), self.external_surface_id) else {
+            return;
+        };
+        let desired_size = self.viewport_device_size();
+        let needs_replacement = self
+            .viewport_target
+            .as_ref()
+            .is_none_or(|target| target.size() != desired_size);
+        if !needs_replacement {
+            return;
+        }
+
+        let target = OffscreenTarget::new(gpu, desired_size);
+        if self.external_registry.get(id).is_some() {
+            let replaced = self.external_registry.replace(
+                id,
+                WgpuExternalSurface {
+                    view: Arc::new(target.view().clone()),
+                },
+            );
+            assert!(replaced, "windowed external surface disappeared");
+        }
+        self.viewport_target = Some(target);
+    }
+
+    fn configure_surface(&mut self, physical_size: PhysicalSize<u32>) {
+        let (Some(surface), Some(gpu), Some(config)) = (
+            self.surface.as_ref(),
+            self.host_gpu.as_ref(),
+            self.surface_config.as_mut(),
+        ) else {
+            return;
+        };
+        config.width = physical_size.width.max(1);
+        config.height = physical_size.height.max(1);
+        surface.configure(&gpu.device, config);
+    }
+
+    fn dispatch_input(&self, input: PlatformInput) {
+        let Some(ui) = self.ui.as_ref() else {
+            return;
+        };
+        match ui.dispatch_input(input) {
+            Ok(outcome) if outcome.redraw_requested => {
+                if let Some(window) = self.window() {
+                    window.request_redraw();
+                }
+            }
+            Ok(_) => {}
+            Err(error) => eprintln!("input dispatch failed: {error:#}"),
+        }
+    }
+
+    fn logical_cursor_position(&self, position: PhysicalPosition<f64>) -> gpui::Point<Pixels> {
+        let scale_factor = self
+            .window()
+            .map(|window| window.scale_factor())
+            .unwrap_or(1.0);
+        let logical = position.to_logical::<f64>(scale_factor);
+        point(px(logical.x as f32), px(logical.y as f32))
+    }
+
+    fn viewport_pointer(&self) -> ([f32; 2], bool) {
+        let Some(bounds) = self.viewport_bounds.borrow().as_ref().copied() else {
+            return ([0.0, 0.0], false);
+        };
+        let local_x = f32::from(self.cursor_position.x) - f32::from(bounds.origin.x);
+        let local_y = f32::from(self.cursor_position.y) - f32::from(bounds.origin.y);
+        let width = f32::from(bounds.size.width).max(f32::EPSILON);
+        let height = f32::from(bounds.size.height).max(f32::EPSILON);
+        let hovered = local_x >= 0.0 && local_x <= width && local_y >= 0.0 && local_y <= height;
+        (
+            [
+                (local_x / width).clamp(0.0, 1.0) * 2.0 - 1.0,
+                (local_y / height).clamp(0.0, 1.0) * 2.0 - 1.0,
+            ],
+            hovered,
+        )
+    }
+
+    fn gpui_mouse_button(button: WinitMouseButton) -> Option<MouseButton> {
+        match button {
+            WinitMouseButton::Left => Some(MouseButton::Left),
+            WinitMouseButton::Right => Some(MouseButton::Right),
+            WinitMouseButton::Middle => Some(MouseButton::Middle),
+            WinitMouseButton::Back => Some(MouseButton::Navigate(gpui::NavigationDirection::Back)),
+            WinitMouseButton::Forward => {
+                Some(MouseButton::Navigate(gpui::NavigationDirection::Forward))
+            }
+            WinitMouseButton::Other(_) => None,
+        }
+    }
+
+    fn render(&mut self, event_loop: &ActiveEventLoop) {
+        if self.window.is_none()
+            || self.surface.is_none()
+            || self.host_gpu.is_none()
+            || self.ui.is_none()
+            || self.surface_config.is_none()
+        {
+            return;
+        }
+
+        self.ensure_viewport_target();
+        let window = self.window.as_ref().unwrap().clone();
+        let (width, height, format) = {
+            let config = self.surface_config.as_ref().unwrap();
+            (config.width, config.height, config.format)
+        };
+        if width == 0 || height == 0 {
+            return;
+        }
+
+        let surface_result = self.surface.as_ref().unwrap().get_current_texture();
+        let frame = match surface_result {
+            wgpu::CurrentSurfaceTexture::Success(frame)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(frame) => frame,
+            wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated => {
+                self.configure_surface(window.inner_size());
+                window.request_redraw();
+                return;
+            }
+            wgpu::CurrentSurfaceTexture::Timeout | wgpu::CurrentSurfaceTexture::Occluded => {
+                return;
+            }
+            wgpu::CurrentSurfaceTexture::Validation => {
+                self.configure_surface(window.inner_size());
+                window.request_redraw();
+                return;
+            }
+        };
+
+        let gpu = self.host_gpu.as_ref().unwrap().clone();
+        let ui = self.ui.as_ref().unwrap();
+        let _ = ui.poll();
+        let frame_status = match ui.prepare_frame() {
+            Ok(status) => status,
+            Err(error) => {
+                eprintln!("windowed_wgpu failed to prepare a frame: {error}");
+                event_loop.exit();
+                return;
+            }
+        };
+        let (pointer, hovered) = self.viewport_pointer();
+        let uniform_bytes = scene_uniform_bytes(
+            pointer,
+            self.animation_start.elapsed().as_secs_f32(),
+            hovered,
+        );
+        if let Some(uniform_buffer) = self.viewport_uniform_buffer.as_ref() {
+            gpu.queue.write_buffer(uniform_buffer, 0, &uniform_bytes);
+        }
+        let view = frame
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder = gpu
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("windowed_wgpu_frame_encoder"),
+            });
+        if let (Some(viewport_target), Some(viewport_pipeline), Some(viewport_bind_group)) = (
+            self.viewport_target.as_ref(),
+            self.viewport_pipeline.as_ref(),
+            self.viewport_bind_group.as_ref(),
+        ) {
+            encode_gpu_scene(
+                &mut encoder,
+                viewport_pipeline,
+                viewport_bind_group,
+                viewport_target,
+                wgpu::Color {
+                    r: 0.02,
+                    g: 0.08,
+                    b: 0.18,
+                    a: 1.0,
+                },
+            );
+        }
+        let target = gpui_wgpu::WgpuRenderTarget {
+            view: &view,
+            size: size(DevicePixels(width as i32), DevicePixels(height as i32)),
+            format,
+            load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+        };
+        if let Err(error) =
+            ui.encode_with_external_surfaces(target, &mut encoder, &self.external_registry)
+        {
+            frame.present();
+            eprintln!("windowed_wgpu failed to encode a frame: {error}");
+            event_loop.exit();
+            return;
+        }
+        gpu.queue.submit(Some(encoder.finish()));
+        frame.present();
+        if let Err(error) = ui.mark_presented(frame_status.scene_generation) {
+            eprintln!("windowed_wgpu failed to acknowledge a frame: {error}");
+            event_loop.exit();
+            return;
+        }
+        window.request_redraw();
+    }
+
+    fn initialize(&mut self, event_loop: &ActiveEventLoop) -> Result<(), String> {
+        let window = Arc::new(
+            event_loop
+                .create_window(
+                    WinitWindow::default_attributes()
+                        .with_title("GPUI Embed — click the button")
+                        .with_inner_size(LogicalSize::new(WINDOW_WIDTH, WINDOW_HEIGHT)),
+                )
+                .map_err(|error| error.to_string())?,
+        );
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            flags: wgpu::InstanceFlags::default(),
+            backend_options: wgpu::BackendOptions::default(),
+            memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
+            display: None,
+        });
+        let surface = instance
+            .create_surface(window.clone())
+            .map_err(|error| format!("failed to create WGPU surface: {error}"))?;
+        let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            compatible_surface: Some(&surface),
+            force_fallback_adapter: false,
+        }))
+        .map_err(|error| format!("failed to request WGPU adapter: {error}"))?;
+        let surface_caps = surface.get_capabilities(&adapter);
+        let format = surface_caps
+            .formats
+            .iter()
+            .copied()
+            .find(wgpu::TextureFormat::is_srgb)
+            .unwrap_or(surface_caps.formats[0]);
+        let requirements = WgpuSceneRenderer::requirements(&adapter);
+        let (device, queue) = block_on(
+            adapter.request_device(&wgpu::DeviceDescriptor {
+                label: Some("windowed_gpui_embed_device"),
+                required_features: requirements.features,
+                required_limits: wgpu::Limits::downlevel_defaults()
+                    .using_resolution(adapter.limits())
+                    .using_alignment(adapter.limits()),
+                memory_hints: wgpu::MemoryHints::MemoryUsage,
+                trace: wgpu::Trace::Off,
+                experimental_features: wgpu::ExperimentalFeatures::disabled(),
+            }),
+        )
+        .map_err(|error| format!("failed to request WGPU device: {error}"))?;
+        let host_gpu = HostGpu::new(Arc::new(adapter), Arc::new(device), Arc::new(queue), format);
+        let physical_size = window.inner_size();
+        let surface_config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format,
+            width: physical_size.width.max(1),
+            height: physical_size.height.max(1),
+            present_mode: if surface_caps
+                .present_modes
+                .contains(&wgpu::PresentMode::Mailbox)
+            {
+                wgpu::PresentMode::Mailbox
+            } else {
+                wgpu::PresentMode::Fifo
+            },
+            desired_maximum_frame_latency: 2,
+            alpha_mode: surface_caps.alpha_modes[0],
+            view_formats: vec![],
+        };
+        surface.configure(&host_gpu.device, &surface_config);
+
+        let scale_factor = window.scale_factor();
+        let logical_size = physical_size.to_logical::<f64>(scale_factor);
+        let metrics = WindowMetrics::new(
+            size(
+                px(logical_size.width as f32),
+                px(logical_size.height as f32),
+            ),
+            scale_factor as f32,
+        );
+        let viewport_size = size(
+            DevicePixels((VIEWPORT_WIDTH as f64 * scale_factor).round() as i32),
+            DevicePixels((VIEWPORT_HEIGHT as f64 * scale_factor).round() as i32),
+        );
+        let viewport_target = OffscreenTarget::new(&host_gpu, viewport_size);
+        let external_surface_id = self.external_registry.register(WgpuExternalSurface {
+            view: Arc::new(viewport_target.view().clone()),
+        });
+        let config = EmbeddedConfig::new(host_gpu.clone()).with_metrics(metrics);
+        let viewport_bounds = self.viewport_bounds.clone();
+        let ui = EmbeddedGpui::new_with_root(config, move |_, cx| {
+            cx.new(|_| DemoUi {
+                clicks: 0,
+                external_surface_id,
+                viewport_bounds,
+            })
+        })
+        .map_err(|error| format!("failed to initialize embedded GPUI: {error}"))?;
+        let (viewport_pipeline, viewport_uniform_buffer, viewport_bind_group) =
+            create_gpu_scene_pipeline(&host_gpu.device, format);
+
+        self.window = Some(window);
+        self.instance = Some(instance);
+        self.surface = Some(surface);
+        self.surface_config = Some(surface_config);
+        self.host_gpu = Some(host_gpu);
+        self.ui = Some(ui);
+        self.external_surface_id = Some(external_surface_id);
+        self.viewport_target = Some(viewport_target);
+        self.viewport_pipeline = Some(viewport_pipeline);
+        self.viewport_uniform_buffer = Some(viewport_uniform_buffer);
+        self.viewport_bind_group = Some(viewport_bind_group);
+        Ok(())
+    }
+}
+
+impl ApplicationHandler for WindowedApp {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        if self.window.is_some() {
+            return;
+        }
+        if let Err(error) = self.initialize(event_loop) {
+            self.fail(event_loop, error);
+            return;
+        }
+        self.update_metrics();
+        if let Some(window) = self.window() {
+            window.request_redraw();
+        }
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        if self.window().is_none_or(|window| window.id() != window_id) {
+            return;
+        }
+        match event {
+            WindowEvent::CloseRequested => event_loop.exit(),
+            WindowEvent::RedrawRequested => self.render(event_loop),
+            WindowEvent::Resized(size) => {
+                self.configure_surface(size);
+                self.update_metrics();
+                self.ensure_viewport_target();
+                if let Some(window) = self.window() {
+                    window.request_redraw();
+                }
+            }
+            WindowEvent::ScaleFactorChanged { .. } => {
+                self.update_metrics();
+                self.ensure_viewport_target();
+                if let Some(window) = self.window().cloned() {
+                    self.configure_surface(window.inner_size());
+                    window.request_redraw();
+                }
+            }
+            WindowEvent::CursorMoved { position, .. } => {
+                self.cursor_position = self.logical_cursor_position(position);
+                self.dispatch_input(PlatformInput::MouseMove(MouseMoveEvent {
+                    position: self.cursor_position,
+                    pressed_button: self.pressed_button,
+                    modifiers: self.modifiers,
+                }));
+            }
+            WindowEvent::MouseInput { state, button, .. } => {
+                let Some(button) = Self::gpui_mouse_button(button) else {
+                    return;
+                };
+                match state {
+                    ElementState::Pressed => {
+                        self.pressed_button = Some(button);
+                        self.dispatch_input(PlatformInput::MouseDown(MouseDownEvent {
+                            button,
+                            position: self.cursor_position,
+                            modifiers: self.modifiers,
+                            click_count: 1,
+                            first_mouse: true,
+                        }));
+                    }
+                    ElementState::Released => {
+                        self.dispatch_input(PlatformInput::MouseUp(MouseUpEvent {
+                            button,
+                            position: self.cursor_position,
+                            modifiers: self.modifiers,
+                            click_count: 1,
+                        }));
+                        self.pressed_button = None;
+                    }
+                }
+                if let Some(window) = self.window() {
+                    window.request_redraw();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
+        if let Some(window) = self.window() {
+            window.request_redraw();
+        }
+    }
+}
+
+fn main() -> gpui::Result<()> {
+    let event_loop = EventLoop::new().map_err(|error| std::io::Error::other(error.to_string()))?;
+    event_loop
+        .run_app(&mut WindowedApp::default())
+        .map_err(|error| std::io::Error::other(error.to_string()).into())
+}

--- a/crates/gpui_embed/examples/windowed_wgpu.rs
+++ b/crates/gpui_embed/examples/windowed_wgpu.rs
@@ -517,13 +517,13 @@ impl WindowedApp {
         if let Err(error) =
             ui.encode_with_external_surfaces(target, &mut encoder, &self.external_registry)
         {
-            frame.present();
+            gpu.queue.present(frame);
             eprintln!("windowed_wgpu failed to encode a frame: {error}");
             event_loop.exit();
             return;
         }
         gpu.queue.submit(Some(encoder.finish()));
-        frame.present();
+        gpu.queue.present(frame);
         if let Err(error) = ui.mark_presented(frame_status.scene_generation) {
             eprintln!("windowed_wgpu failed to acknowledge a frame: {error}");
             event_loop.exit();
@@ -556,6 +556,7 @@ impl WindowedApp {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .map_err(|error| format!("failed to request WGPU adapter: {error}"))?;
         let surface_caps = surface.get_capabilities(&adapter);
@@ -596,6 +597,7 @@ impl WindowedApp {
             },
             desired_maximum_frame_latency: 2,
             alpha_mode: surface_caps.alpha_modes[0],
+            color_space: wgpu::SurfaceColorSpace::Auto,
             view_formats: vec![],
         };
         surface.configure(&host_gpu.device, &surface_config);

--- a/crates/gpui_embed/src/dispatcher.rs
+++ b/crates/gpui_embed/src/dispatcher.rs
@@ -1,0 +1,130 @@
+use gpui::{PlatformDispatcher, Priority, RunnableVariant};
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex, mpsc},
+    thread::ThreadId,
+    time::{Duration, Instant},
+};
+
+struct QueuedRunnable {
+    ready_at: Instant,
+    runnable: RunnableVariant,
+}
+
+/// The work and deadline result returned by an explicit host polling phase.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PollOutcome {
+    /// Number of foreground tasks run by the poll.
+    pub tasks_run: usize,
+    /// Earliest queued deadline, if one remains pending.
+    pub next_deadline: Option<Instant>,
+}
+
+/// A main-thread dispatcher driven by [`crate::EmbeddedGpui::poll`].
+pub(crate) struct EmbeddedDispatcher {
+    main_thread: ThreadId,
+    queue: Mutex<VecDeque<QueuedRunnable>>,
+    background_sender: mpsc::Sender<RunnableVariant>,
+    wake: Option<Arc<dyn Fn() + Send + Sync>>,
+}
+
+impl EmbeddedDispatcher {
+    pub(crate) fn new(wake: Option<Arc<dyn Fn() + Send + Sync>>) -> Arc<Self> {
+        let (background_sender, background_receiver) = mpsc::channel::<RunnableVariant>();
+        let background_receiver = Arc::new(Mutex::new(background_receiver));
+        let worker_count = std::thread::available_parallelism().map_or(1, |count| count.get());
+
+        for _ in 0..worker_count {
+            let background_receiver = background_receiver.clone();
+            std::thread::spawn(move || {
+                loop {
+                    let runnable = {
+                        let receiver = background_receiver
+                            .lock()
+                            .expect("embedded background receiver poisoned");
+                        receiver.recv()
+                    };
+                    let Ok(runnable) = runnable else { break };
+                    runnable.run();
+                }
+            });
+        }
+
+        Arc::new(Self {
+            main_thread: std::thread::current().id(),
+            queue: Mutex::new(VecDeque::new()),
+            background_sender,
+            wake,
+        })
+    }
+
+    pub(crate) fn poll(&self) -> PollOutcome {
+        let mut ran = 0;
+        loop {
+            let now = Instant::now();
+            let runnable = {
+                let mut queue = self
+                    .queue
+                    .lock()
+                    .expect("embedded dispatcher queue poisoned");
+                queue
+                    .iter()
+                    .position(|item| item.ready_at <= now)
+                    .and_then(|index| queue.remove(index))
+            };
+            let Some(item) = runnable else { break };
+            item.runnable.run();
+            ran += 1;
+        }
+        let next_deadline = self
+            .queue
+            .lock()
+            .expect("embedded dispatcher queue poisoned")
+            .iter()
+            .map(|item| item.ready_at)
+            .min();
+        PollOutcome {
+            tasks_run: ran,
+            next_deadline,
+        }
+    }
+
+    fn enqueue(&self, runnable: RunnableVariant, ready_at: Instant) {
+        self.queue
+            .lock()
+            .expect("embedded dispatcher queue poisoned")
+            .push_back(QueuedRunnable { ready_at, runnable });
+        self.wake_now();
+    }
+
+    fn wake_now(&self) {
+        if let Some(wake) = &self.wake {
+            wake();
+        }
+    }
+}
+
+impl PlatformDispatcher for EmbeddedDispatcher {
+    fn is_main_thread(&self) -> bool {
+        std::thread::current().id() == self.main_thread
+    }
+
+    fn dispatch(&self, runnable: RunnableVariant, _priority: Priority) {
+        if self.background_sender.send(runnable).is_ok() {
+            self.wake_now();
+        }
+    }
+
+    fn dispatch_on_main_thread(&self, runnable: RunnableVariant, _priority: Priority) {
+        self.enqueue(runnable, Instant::now());
+    }
+
+    fn dispatch_after(&self, duration: Duration, runnable: RunnableVariant) {
+        let deadline = Instant::now() + duration;
+        self.enqueue(runnable, deadline);
+    }
+
+    fn spawn_realtime(&self, f: Box<dyn FnOnce() + Send>) {
+        std::thread::spawn(f);
+    }
+}

--- a/crates/gpui_embed/src/lib.rs
+++ b/crates/gpui_embed/src/lib.rs
@@ -1,0 +1,53 @@
+//! A small, surface-free host adapter for driving GPUI from an embedding run loop.
+//!
+//! The adapter owns GPUI's virtual window and dispatcher, while the host owns
+//! the GPU command encoder and decides when to submit it.  No native window
+//! handles, surfaces, submissions, or presentation are used here.
+//!
+//! A host frame follows this order:
+//!
+//! ```rust,ignore
+//! let input = ui.dispatch_input(platform_input)?;
+//! if input.propagate && !input.pointer_capture {
+//!     route_to_engine_viewport(platform_input, viewport_bounds);
+//! }
+//!
+//! let poll = ui.poll();
+//! let frame = ui.prepare_frame()?;
+//! update_viewport_texture_from_layout();
+//! render_engine_viewport(&mut encoder);
+//! ui.encode_with_external_surfaces(
+//!     HostRenderTarget {
+//!         view: &frame_view,
+//!         size: drawable_size,
+//!         format: surface_format,
+//!         load: wgpu::LoadOp::Load,
+//!     },
+//!     &mut encoder,
+//!     &external_registry,
+//! )?;
+//! queue.submit([encoder.finish()]);
+//! surface_frame.present();
+//! ui.mark_presented(frame.scene_generation)?;
+//! schedule_next_wake(poll.next_deadline);
+//! apply_commands(ui.take_host_commands());
+//! ```
+//!
+//! `HostRenderTarget` is a borrowed, single-sample, positive-size target in the configured
+//! format. GPUI always stores its output. Skip encoding while the host is minimized. After GPU
+//! recovery, recreate host targets and replace registered external views under their stable IDs
+//! before encoding again.
+
+#![warn(missing_docs)]
+
+mod dispatcher;
+mod platform;
+mod renderer;
+
+pub use dispatcher::PollOutcome;
+pub use gpui::FrameStatus;
+pub use platform::{
+    EmbeddedConfig, EmbeddedGpui, HostCommand, HostServices, InputOutcome, RenderedScene,
+    WindowMetrics,
+};
+pub use renderer::{HostGpu, HostRenderTarget, OffscreenTarget};

--- a/crates/gpui_embed/src/lib.rs
+++ b/crates/gpui_embed/src/lib.rs
@@ -27,7 +27,7 @@
 //!     &external_registry,
 //! )?;
 //! queue.submit([encoder.finish()]);
-//! surface_frame.present();
+//! queue.present(surface_frame);
 //! ui.mark_presented(frame.scene_generation)?;
 //! schedule_next_wake(poll.next_deadline);
 //! apply_commands(ui.take_host_commands());

--- a/crates/gpui_embed/src/platform.rs
+++ b/crates/gpui_embed/src/platform.rs
@@ -1,0 +1,1228 @@
+use crate::{HostGpu, HostRenderTarget, OffscreenTarget, dispatcher::EmbeddedDispatcher};
+use gpui::{
+    AnyWindowHandle, AppContext, BackgroundExecutor, Bounds, Capslock, ClipboardItem, CursorStyle,
+    DevicePixels, DispatchEventResult, DisplayId, DummyKeyboardMapper, ForegroundExecutor, Keymap,
+    MacActivationPolicy, Modifiers, PathPromptOptions, Pixels, Platform, PlatformAtlas,
+    PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformKeyboardLayout,
+    PlatformKeyboardMapper, PlatformTextSystem, PlatformWindow, Point, PromptButton, PromptLevel,
+    Render, RequestFrameOptions, Scene, Size, Task, ThermalState, Window, WindowAppearance,
+    WindowBackgroundAppearance, WindowBounds, WindowControlArea, WindowDecorations, WindowInsets,
+    WindowKind, WindowOptions, WindowParams, div,
+};
+use gpui_wgpu::wgpu::rwh::{HandleError, HasDisplayHandle, HasWindowHandle};
+use gpui_wgpu::{CosmicTextSystem, WgpuAtlas};
+use std::{
+    cell::{Cell, RefCell},
+    collections::VecDeque,
+    path::{Path, PathBuf},
+    rc::Rc,
+    sync::{Arc, Mutex},
+};
+use uuid::Uuid;
+
+/// The logical and device geometry supplied by the host.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct WindowMetrics {
+    /// Window bounds in logical GPUI pixels.
+    pub bounds: Bounds<Pixels>,
+    /// Logical-to-device scale factor.
+    pub scale_factor: f32,
+    /// Whether the host considers the virtual window active.
+    pub active: bool,
+    /// Whether the host considers the virtual window hovered.
+    pub hovered: bool,
+    /// The host's current appearance preference.
+    pub appearance: WindowAppearance,
+}
+
+/// Host callbacks for services that GPUI cannot provide without an OS window.
+#[derive(Clone, Default)]
+pub struct HostServices {
+    /// Reads the current clipboard contents synchronously.
+    pub read_clipboard: Option<Arc<dyn Fn() -> Option<ClipboardItem> + Send + Sync>>,
+    /// Replaces the current clipboard contents.
+    pub write_clipboard: Option<Arc<dyn Fn(ClipboardItem) + Send + Sync>>,
+}
+
+impl WindowMetrics {
+    /// Creates metrics for a window whose origin is `(0, 0)`.
+    pub fn new(size: Size<Pixels>, scale_factor: f32) -> Self {
+        Self {
+            bounds: Bounds::new(gpui::point(gpui::px(0.), gpui::px(0.)), size),
+            scale_factor: scale_factor.max(f32::EPSILON),
+            active: true,
+            hovered: false,
+            appearance: WindowAppearance::Light,
+        }
+    }
+
+    /// Returns the backing size in device pixels.
+    pub fn device_size(self) -> Size<DevicePixels> {
+        self.bounds.size.to_device_pixels(self.scale_factor)
+    }
+}
+
+impl Default for WindowMetrics {
+    fn default() -> Self {
+        Self::new(gpui::size(gpui::px(800.), gpui::px(600.)), 1.0)
+    }
+}
+
+/// Configuration for an embedded GPUI instance.
+#[derive(Clone)]
+pub struct EmbeddedConfig {
+    /// Host-owned GPU objects used for the atlas and render targets.
+    pub gpu: HostGpu,
+    /// Initial virtual-window metrics.
+    pub metrics: WindowMetrics,
+    /// Host callbacks for clipboard and other optional services.
+    pub services: HostServices,
+    /// Optional callback used to wake the host run loop when GPUI queues work.
+    pub wake: Option<Arc<dyn Fn() + Send + Sync>>,
+}
+
+impl EmbeddedConfig {
+    /// Creates a configuration with default window metrics.
+    pub fn new(gpu: HostGpu) -> Self {
+        Self {
+            gpu,
+            metrics: WindowMetrics::default(),
+            services: HostServices::default(),
+            wake: None,
+        }
+    }
+
+    /// Replaces the initial window metrics.
+    pub fn with_metrics(mut self, metrics: WindowMetrics) -> Self {
+        self.metrics = metrics;
+        self
+    }
+
+    /// Installs a callback that wakes the host run loop when work is queued.
+    pub fn with_wake(mut self, wake: impl Fn() + Send + Sync + 'static) -> Self {
+        self.wake = Some(Arc::new(wake));
+        self
+    }
+
+    /// Installs synchronous clipboard callbacks supplied by the host.
+    pub fn with_clipboard(
+        mut self,
+        read: impl Fn() -> Option<ClipboardItem> + Send + Sync + 'static,
+        write: impl Fn(ClipboardItem) + Send + Sync + 'static,
+    ) -> Self {
+        self.services.read_clipboard = Some(Arc::new(read));
+        self.services.write_clipboard = Some(Arc::new(write));
+        self
+    }
+}
+
+/// Commands emitted by GPUI for the embedding host to apply.
+#[derive(Clone, Debug, PartialEq)]
+pub enum HostCommand {
+    /// Set the host cursor style for the embedded window.
+    SetCursor(CursorStyle),
+    /// Move the host IME candidate rectangle.
+    SetImePosition(Bounds<Pixels>),
+}
+
+/// The result of dispatching one input event to the virtual window.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct InputOutcome {
+    /// Whether the host should continue routing the original event.
+    pub propagate: bool,
+    /// Whether a GPUI handler prevented the event's default action.
+    pub default_prevented: bool,
+    /// Whether GPUI invalidated the virtual window and needs another encoded frame.
+    pub redraw_requested: bool,
+    /// Whether GPUI retained pointer capture for this event stream.
+    pub pointer_capture: bool,
+}
+
+/// A description of the last scene prepared for the host.
+///
+/// GPUI keeps the scene's storage inside its window. The scene itself must be
+/// encoded during the host's frame callback; this value is stable metadata for checking whether a
+/// frame is available after that callback.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct RenderedScene {
+    /// Retained scene generation used for presentation acknowledgements.
+    pub frame_id: u64,
+    /// Number of paint operations in the scene.
+    pub primitive_count: usize,
+    /// Metrics used for the frame.
+    pub metrics: WindowMetrics,
+}
+
+/// The virtual display exposed to GPUI.
+#[derive(Debug)]
+struct EmbeddedDisplay {
+    bounds: Mutex<Bounds<Pixels>>,
+}
+
+impl EmbeddedDisplay {
+    fn new(bounds: Bounds<Pixels>) -> Self {
+        Self {
+            bounds: Mutex::new(bounds),
+        }
+    }
+
+    fn set_bounds(&self, bounds: Bounds<Pixels>) {
+        *self.bounds.lock().expect("embedded display poisoned") = bounds;
+    }
+}
+
+impl PlatformDisplay for EmbeddedDisplay {
+    fn id(&self) -> DisplayId {
+        DisplayId::new(1)
+    }
+
+    fn uuid(&self) -> gpui::Result<Uuid> {
+        Ok(Uuid::from_u128(1))
+    }
+
+    fn bounds(&self) -> Bounds<Pixels> {
+        *self.bounds.lock().expect("embedded display poisoned")
+    }
+}
+
+struct EmbeddedWindowState {
+    handle: AnyWindowHandle,
+    metrics: WindowMetrics,
+    display: Rc<EmbeddedDisplay>,
+    atlas: Arc<dyn PlatformAtlas>,
+    host_commands: Arc<Mutex<VecDeque<HostCommand>>>,
+    input_handler: Option<PlatformInputHandler>,
+    input_callback: Option<Box<dyn FnMut(PlatformInput) -> DispatchEventResult>>,
+    request_frame_callback: Option<Box<dyn FnMut(RequestFrameOptions)>>,
+    resize_callback: Option<ResizeCallback>,
+    active_callback: Option<Box<dyn FnMut(bool)>>,
+    hover_callback: Option<Box<dyn FnMut(bool)>>,
+    moved_callback: Option<Box<dyn FnMut()>>,
+    should_close_callback: Option<Box<dyn FnMut() -> bool>>,
+    hit_test_callback: Option<Box<dyn FnMut() -> Option<WindowControlArea>>>,
+    close_callback: Option<Box<dyn FnOnce()>>,
+    appearance_callback: Option<Box<dyn FnMut()>>,
+    title: String,
+    background: WindowBackgroundAppearance,
+    appearance: WindowAppearance,
+    active: bool,
+    hovered: bool,
+    mouse_position: Point<Pixels>,
+    modifiers: Modifiers,
+    capslock: Capslock,
+    fullscreen: bool,
+    rendered_scene: Option<RenderedScene>,
+}
+
+type ResizeCallback = Box<dyn FnMut(Size<Pixels>, f32)>;
+
+/// The single virtual GPUI window owned by [`EmbeddedGpui`].
+#[derive(Clone)]
+struct EmbeddedWindow {
+    state: Rc<Mutex<EmbeddedWindowState>>,
+}
+
+impl EmbeddedWindow {
+    fn new(
+        handle: AnyWindowHandle,
+        metrics: WindowMetrics,
+        display: Rc<EmbeddedDisplay>,
+        atlas: Arc<WgpuAtlas>,
+        host_commands: Arc<Mutex<VecDeque<HostCommand>>>,
+    ) -> Self {
+        Self {
+            state: Rc::new(Mutex::new(EmbeddedWindowState {
+                handle,
+                metrics,
+                display,
+                atlas,
+                host_commands,
+                input_handler: None,
+                input_callback: None,
+                request_frame_callback: None,
+                resize_callback: None,
+                active_callback: None,
+                hover_callback: None,
+                moved_callback: None,
+                should_close_callback: None,
+                hit_test_callback: None,
+                close_callback: None,
+                appearance_callback: None,
+                title: String::new(),
+                background: WindowBackgroundAppearance::Opaque,
+                appearance: metrics.appearance,
+                active: metrics.active,
+                hovered: metrics.hovered,
+                mouse_position: Point::default(),
+                modifiers: Modifiers::default(),
+                capslock: Capslock::default(),
+                fullscreen: false,
+                rendered_scene: None,
+            })),
+        }
+    }
+
+    /// Returns the GPUI handle for this virtual window.
+    fn handle(&self) -> AnyWindowHandle {
+        self.state.lock().expect("embedded window poisoned").handle
+    }
+
+    /// Updates metrics and invokes GPUI's resize callback.
+    fn set_metrics(&self, metrics: WindowMetrics) {
+        let (resize_callback, active_callback, hover_callback, appearance_callback) = {
+            let mut state = self.state.lock().expect("embedded window poisoned");
+            state.metrics = metrics;
+            state.display.set_bounds(metrics.bounds);
+            state.active = metrics.active;
+            state.hovered = metrics.hovered;
+            state.appearance = metrics.appearance;
+            (
+                state.resize_callback.take(),
+                state.active_callback.take(),
+                state.hover_callback.take(),
+                state.appearance_callback.take(),
+            )
+        };
+        if let Some(mut callback) = resize_callback {
+            callback(metrics.bounds.size, metrics.scale_factor);
+            self.state
+                .lock()
+                .expect("embedded window poisoned")
+                .resize_callback = Some(callback);
+        }
+        if let Some(mut callback) = active_callback {
+            callback(metrics.active);
+            self.state
+                .lock()
+                .expect("embedded window poisoned")
+                .active_callback = Some(callback);
+        }
+        if let Some(mut callback) = hover_callback {
+            callback(metrics.hovered);
+            self.state
+                .lock()
+                .expect("embedded window poisoned")
+                .hover_callback = Some(callback);
+        }
+        if let Some(mut callback) = appearance_callback {
+            callback();
+            self.state
+                .lock()
+                .expect("embedded window poisoned")
+                .appearance_callback = Some(callback);
+        }
+    }
+
+    /// Dispatches host input to GPUI.
+    fn dispatch_input(&self, input: PlatformInput) -> gpui::Result<DispatchEventResult> {
+        self.update_input_state(&input);
+        let callback = {
+            self.state
+                .lock()
+                .expect("embedded window poisoned")
+                .input_callback
+                .take()
+        };
+        let Some(mut callback) = callback else {
+            return Err(std::io::Error::other("embedded window has no input callback").into());
+        };
+        let result = callback(input);
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .input_callback = Some(callback);
+        Ok(result)
+    }
+
+    fn update_input_state(&self, input: &PlatformInput) {
+        let mut state = self.state.lock().expect("embedded window poisoned");
+        match input {
+            PlatformInput::MouseDown(event) => {
+                state.mouse_position = event.position;
+                state.modifiers = event.modifiers;
+            }
+            PlatformInput::MouseUp(event) => {
+                state.mouse_position = event.position;
+                state.modifiers = event.modifiers;
+            }
+            PlatformInput::MouseMove(event) => {
+                state.mouse_position = event.position;
+                state.modifiers = event.modifiers;
+            }
+            PlatformInput::MousePressure(event) => {
+                state.mouse_position = event.position;
+                state.modifiers = event.modifiers;
+            }
+            PlatformInput::MouseExited(event) => {
+                state.mouse_position = event.position;
+                state.modifiers = event.modifiers;
+                state.hovered = false;
+            }
+            PlatformInput::ScrollWheel(event) => {
+                state.mouse_position = event.position;
+                state.modifiers = event.modifiers;
+            }
+            PlatformInput::Pinch(event) => {
+                state.mouse_position = event.position;
+                state.modifiers = event.modifiers;
+            }
+            PlatformInput::ModifiersChanged(event) => {
+                state.modifiers = event.modifiers;
+                state.capslock = event.capslock;
+            }
+            PlatformInput::Touch(event) => {
+                state.mouse_position = event.position;
+            }
+            PlatformInput::KeyDown(_) | PlatformInput::KeyUp(_) | PlatformInput::FileDrop(_) => {}
+        }
+    }
+
+    fn with_input_handler<R>(&self, f: impl FnOnce(&mut PlatformInputHandler) -> R) -> Option<R> {
+        let mut handler = self
+            .state
+            .lock()
+            .expect("embedded window poisoned")
+            .input_handler
+            .take()?;
+        let result = f(&mut handler);
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .input_handler = Some(handler);
+        Some(result)
+    }
+
+    /// Inserts committed text into the active GPUI input handler.
+    fn insert_text(&self, text: &str) -> bool {
+        self.with_input_handler(|handler| handler.replace_text_in_range(None, text))
+            .is_some()
+    }
+
+    /// Replaces or updates the marked IME composition.
+    fn set_marked_text(
+        &self,
+        range_utf16: Option<std::ops::Range<usize>>,
+        text: &str,
+        selected_range: Option<std::ops::Range<usize>>,
+    ) -> bool {
+        self.with_input_handler(|handler| {
+            handler.replace_and_mark_text_in_range(range_utf16, text, selected_range)
+        })
+        .is_some()
+    }
+
+    /// Ends the active IME composition.
+    fn unmark_text(&self) -> bool {
+        self.with_input_handler(|handler| handler.unmark_text())
+            .is_some()
+    }
+
+    /// Returns the active UTF-16 selection, if GPUI has an input handler.
+    fn selected_text_range(&self) -> Option<gpui::UTF16Selection> {
+        self.with_input_handler(|handler| handler.selected_text_range(true))
+            .flatten()
+    }
+
+    /// Returns the active marked-text range, if GPUI has an input handler.
+    fn marked_text_range(&self) -> Option<std::ops::Range<usize>> {
+        self.with_input_handler(|handler| handler.marked_text_range())
+            .flatten()
+    }
+
+    /// Returns the host-space candidate bounds for the active IME composition.
+    fn ime_candidate_bounds(&self) -> Option<Bounds<Pixels>> {
+        self.with_input_handler(|handler| handler.ime_candidate_bounds())
+            .flatten()
+    }
+
+    fn record_scene(&self, scene: &Scene, status: gpui::FrameStatus) {
+        let mut state = self.state.lock().expect("embedded window poisoned");
+        state.rendered_scene = Some(RenderedScene {
+            frame_id: status.scene_generation,
+            primitive_count: scene.len(),
+            metrics: state.metrics,
+        });
+    }
+
+    /// Returns metadata for the last rendered scene.
+    fn rendered_scene(&self) -> Option<RenderedScene> {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .rendered_scene
+    }
+}
+
+impl HasWindowHandle for EmbeddedWindow {
+    fn window_handle(&self) -> Result<gpui_wgpu::wgpu::rwh::WindowHandle<'_>, HandleError> {
+        Err(HandleError::NotSupported)
+    }
+}
+
+impl HasDisplayHandle for EmbeddedWindow {
+    fn display_handle(&self) -> Result<gpui_wgpu::wgpu::rwh::DisplayHandle<'_>, HandleError> {
+        Err(HandleError::NotSupported)
+    }
+}
+
+impl PlatformWindow for EmbeddedWindow {
+    fn bounds(&self) -> Bounds<Pixels> {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .metrics
+            .bounds
+    }
+
+    fn is_maximized(&self) -> bool {
+        false
+    }
+
+    fn window_bounds(&self) -> WindowBounds {
+        WindowBounds::Windowed(self.bounds())
+    }
+
+    fn content_size(&self) -> Size<Pixels> {
+        self.bounds().size
+    }
+
+    fn resize(&mut self, size: Size<Pixels>) {
+        let mut state = self.state.lock().expect("embedded window poisoned");
+        state.metrics.bounds.size = size;
+    }
+
+    fn scale_factor(&self) -> f32 {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .metrics
+            .scale_factor
+    }
+
+    fn appearance(&self) -> WindowAppearance {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .appearance
+    }
+
+    fn display(&self) -> Option<Rc<dyn PlatformDisplay>> {
+        Some(
+            self.state
+                .lock()
+                .expect("embedded window poisoned")
+                .display
+                .clone(),
+        )
+    }
+
+    fn mouse_position(&self) -> Point<Pixels> {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .mouse_position
+    }
+    fn modifiers(&self) -> Modifiers {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .modifiers
+    }
+    fn capslock(&self) -> Capslock {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .capslock
+    }
+
+    fn set_input_handler(&mut self, input_handler: PlatformInputHandler) {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .input_handler = Some(input_handler);
+    }
+
+    fn take_input_handler(&mut self) -> Option<PlatformInputHandler> {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .input_handler
+            .take()
+    }
+
+    fn prompt(
+        &self,
+        _level: PromptLevel,
+        _msg: &str,
+        _detail: Option<&str>,
+        _answers: &[PromptButton],
+    ) -> Option<futures::channel::oneshot::Receiver<usize>> {
+        None
+    }
+
+    fn activate(&self) {
+        let callback = {
+            let mut state = self.state.lock().expect("embedded window poisoned");
+            state.active = true;
+            state.active_callback.take()
+        };
+        if let Some(mut callback) = callback {
+            callback(true);
+            self.state
+                .lock()
+                .expect("embedded window poisoned")
+                .active_callback = Some(callback);
+        }
+    }
+
+    fn is_active(&self) -> bool {
+        self.state.lock().expect("embedded window poisoned").active
+    }
+    fn is_hovered(&self) -> bool {
+        self.state.lock().expect("embedded window poisoned").hovered
+    }
+    fn background_appearance(&self) -> WindowBackgroundAppearance {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .background
+    }
+    fn set_title(&mut self, title: &str) {
+        self.state.lock().expect("embedded window poisoned").title = title.to_owned();
+    }
+    fn set_background_appearance(&self, background: WindowBackgroundAppearance) {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .background = background;
+    }
+    fn minimize(&self) {}
+    fn zoom(&self) {}
+    fn toggle_fullscreen(&self) {
+        let mut state = self.state.lock().expect("embedded window poisoned");
+        state.fullscreen = !state.fullscreen;
+    }
+    fn is_fullscreen(&self) -> bool {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .fullscreen
+    }
+
+    fn on_request_frame(&self, callback: Box<dyn FnMut(RequestFrameOptions)>) {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .request_frame_callback = Some(callback);
+    }
+    fn on_input(&self, callback: Box<dyn FnMut(PlatformInput) -> DispatchEventResult>) {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .input_callback = Some(callback);
+    }
+    fn on_active_status_change(&self, callback: Box<dyn FnMut(bool)>) {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .active_callback = Some(callback);
+    }
+    fn on_hover_status_change(&self, callback: Box<dyn FnMut(bool)>) {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .hover_callback = Some(callback);
+    }
+    fn on_resize(&self, callback: Box<dyn FnMut(Size<Pixels>, f32)>) {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .resize_callback = Some(callback);
+    }
+    fn on_moved(&self, callback: Box<dyn FnMut()>) {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .moved_callback = Some(callback);
+    }
+    fn on_should_close(&self, callback: Box<dyn FnMut() -> bool>) {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .should_close_callback = Some(callback);
+    }
+    fn on_hit_test_window_control(&self, callback: Box<dyn FnMut() -> Option<WindowControlArea>>) {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .hit_test_callback = Some(callback);
+    }
+    fn on_close(&self, callback: Box<dyn FnOnce()>) {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .close_callback = Some(callback);
+    }
+    fn on_appearance_changed(&self, callback: Box<dyn FnMut()>) {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .appearance_callback = Some(callback);
+    }
+
+    fn draw(&self, scene: &Scene) {
+        self.record_scene(scene, gpui::FrameStatus::default());
+    }
+
+    fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .atlas
+            .clone()
+    }
+    fn is_subpixel_rendering_supported(&self) -> bool {
+        false
+    }
+    fn show_character_palette(&self) {}
+    fn gpu_specs(&self) -> Option<gpui::GpuSpecs> {
+        None
+    }
+    fn update_ime_position(&self, bounds: Bounds<Pixels>) {
+        self.state
+            .lock()
+            .expect("embedded window poisoned")
+            .host_commands
+            .lock()
+            .expect("host command queue poisoned")
+            .push_back(HostCommand::SetImePosition(bounds));
+    }
+    fn insets(&self) -> WindowInsets {
+        WindowInsets::default()
+    }
+}
+
+/// The GPUI platform implementation used by the embedded adapter.
+struct EmbeddedPlatform {
+    dispatcher: Arc<EmbeddedDispatcher>,
+    background_executor: BackgroundExecutor,
+    foreground_executor: ForegroundExecutor,
+    text_system: Arc<dyn PlatformTextSystem>,
+    display: Rc<EmbeddedDisplay>,
+    atlas: Arc<WgpuAtlas>,
+    host_commands: Arc<Mutex<VecDeque<HostCommand>>>,
+    services: HostServices,
+    metrics: WindowMetrics,
+    window: RefCell<Option<EmbeddedWindow>>,
+    active_window: RefCell<Option<AnyWindowHandle>>,
+    quit: Cell<bool>,
+}
+
+impl EmbeddedPlatform {
+    /// Creates an embedded platform. The caller normally uses [`EmbeddedGpui::new`].
+    fn new(config: &EmbeddedConfig, atlas: Arc<WgpuAtlas>) -> Rc<Self> {
+        let dispatcher = EmbeddedDispatcher::new(config.wake.clone());
+        let dispatcher_for_background: Arc<dyn gpui::PlatformDispatcher> = dispatcher.clone();
+        let dispatcher_for_foreground: Arc<dyn gpui::PlatformDispatcher> = dispatcher.clone();
+        Rc::new(Self {
+            background_executor: BackgroundExecutor::new(dispatcher_for_background),
+            foreground_executor: ForegroundExecutor::new(dispatcher_for_foreground),
+            text_system: Arc::new(CosmicTextSystem::new("sans-serif")),
+            display: Rc::new(EmbeddedDisplay::new(config.metrics.bounds)),
+            atlas,
+            host_commands: Arc::new(Mutex::new(VecDeque::new())),
+            services: config.services.clone(),
+            metrics: config.metrics,
+            window: RefCell::new(None),
+            active_window: RefCell::new(None),
+            quit: Cell::new(false),
+            dispatcher,
+        })
+    }
+
+    fn poll(&self) -> crate::PollOutcome {
+        self.dispatcher.poll()
+    }
+
+    /// Returns the single virtual window, once the application has launched.
+    fn window(&self) -> Option<EmbeddedWindow> {
+        self.window.borrow().clone()
+    }
+
+    /// Drains host-owned cursor and IME commands.
+    fn take_host_commands(&self) -> Vec<HostCommand> {
+        self.host_commands
+            .lock()
+            .expect("host command queue poisoned")
+            .drain(..)
+            .collect()
+    }
+}
+
+impl Platform for EmbeddedPlatform {
+    fn background_executor(&self) -> BackgroundExecutor {
+        self.background_executor.clone()
+    }
+    fn foreground_executor(&self) -> ForegroundExecutor {
+        self.foreground_executor.clone()
+    }
+    fn text_system(&self) -> Arc<dyn PlatformTextSystem> {
+        self.text_system.clone()
+    }
+
+    fn set_mac_activation_policy(&self, _policy: MacActivationPolicy) {}
+    fn run(&self, on_finish_launching: Box<dyn FnOnce()>) {
+        on_finish_launching();
+    }
+    fn quit(&self) {
+        self.quit.set(true);
+    }
+    fn restart(&self, _binary_path: Option<PathBuf>) {}
+    fn activate(&self, _ignoring_other_apps: bool) {
+        if let Some(window) = self.window() {
+            window.activate();
+        }
+    }
+    fn hide(&self) {}
+    fn hide_other_apps(&self) {}
+    fn unhide_other_apps(&self) {}
+
+    fn displays(&self) -> Vec<Rc<dyn PlatformDisplay>> {
+        vec![self.display.clone()]
+    }
+    fn primary_display(&self) -> Option<Rc<dyn PlatformDisplay>> {
+        Some(self.display.clone())
+    }
+    fn active_window(&self) -> Option<AnyWindowHandle> {
+        *self.active_window.borrow()
+    }
+
+    fn open_window(
+        &self,
+        handle: AnyWindowHandle,
+        options: WindowParams,
+    ) -> gpui::Result<Box<dyn PlatformWindow>> {
+        if self.window.borrow().is_some() {
+            return Err(std::io::Error::other("EmbeddedGpui supports one virtual window").into());
+        }
+        let window = EmbeddedWindow::new(
+            handle,
+            WindowMetrics {
+                bounds: options.bounds,
+                scale_factor: self.metrics.scale_factor,
+                active: self.metrics.active,
+                hovered: self.metrics.hovered,
+                appearance: self.metrics.appearance,
+            },
+            self.display.clone(),
+            self.atlas.clone(),
+            self.host_commands.clone(),
+        );
+        self.active_window.replace(Some(handle));
+        self.window.replace(Some(window.clone()));
+        Ok(Box::new(window))
+    }
+
+    fn window_appearance(&self) -> WindowAppearance {
+        WindowAppearance::Light
+    }
+    fn open_url(&self, _url: &str) {}
+    fn on_open_urls(&self, _callback: Box<dyn FnMut(Vec<String>)>) {}
+    fn register_url_scheme(&self, _url: &str) -> Task<gpui::Result<()>> {
+        Task::ready(Ok(()))
+    }
+
+    fn prompt_for_paths(
+        &self,
+        _options: PathPromptOptions,
+    ) -> futures::channel::oneshot::Receiver<gpui::Result<Option<Vec<PathBuf>>>> {
+        let (sender, receiver) = futures::channel::oneshot::channel();
+        let _ = sender.send(Err(std::io::Error::other(
+            "embedded platform does not provide file prompts",
+        )
+        .into()));
+        receiver
+    }
+    fn prompt_for_new_path(
+        &self,
+        _directory: &Path,
+        _suggested_name: Option<&str>,
+    ) -> futures::channel::oneshot::Receiver<gpui::Result<Option<PathBuf>>> {
+        let (sender, receiver) = futures::channel::oneshot::channel();
+        let _ = sender.send(Err(std::io::Error::other(
+            "embedded platform does not provide file prompts",
+        )
+        .into()));
+        receiver
+    }
+    fn can_select_mixed_files_and_dirs(&self) -> bool {
+        false
+    }
+    fn reveal_path(&self, _path: &Path) {}
+    fn open_with_system(&self, _path: &Path) {}
+    fn on_quit(&self, _callback: Box<dyn FnMut()>) {}
+    fn on_reopen(&self, _callback: Box<dyn FnMut()>) {}
+    fn on_system_wake(&self, _callback: Box<dyn FnMut()>) {}
+
+    fn set_menus(&self, _menus: Vec<gpui::Menu>, _keymap: &Keymap) {}
+    fn set_dock_menu(&self, _menu: Vec<gpui::MenuItem>, _keymap: &Keymap) {}
+    fn on_app_menu_action(&self, _callback: Box<dyn FnMut(&dyn gpui::Action)>) {}
+    fn on_will_open_app_menu(&self, _callback: Box<dyn FnMut()>) {}
+    fn on_validate_app_menu_command(&self, _callback: Box<dyn FnMut(&dyn gpui::Action) -> bool>) {}
+    fn thermal_state(&self) -> ThermalState {
+        ThermalState::Nominal
+    }
+    fn on_thermal_state_change(&self, _callback: Box<dyn FnMut()>) {}
+
+    fn app_path(&self) -> gpui::Result<PathBuf> {
+        Ok(std::env::current_exe()?)
+    }
+    fn path_for_auxiliary_executable(&self, name: &str) -> gpui::Result<PathBuf> {
+        Ok(std::env::current_exe()?.with_file_name(name))
+    }
+    fn set_cursor_style(&self, style: CursorStyle) {
+        self.host_commands
+            .lock()
+            .expect("host command queue poisoned")
+            .push_back(HostCommand::SetCursor(style));
+    }
+    fn hide_cursor_until_mouse_moves(&self) {}
+    fn is_cursor_visible(&self) -> bool {
+        true
+    }
+    fn should_auto_hide_scrollbars(&self) -> bool {
+        false
+    }
+    fn read_from_clipboard(&self) -> Option<ClipboardItem> {
+        self.services
+            .read_clipboard
+            .as_ref()
+            .and_then(|read| read())
+    }
+    fn write_to_clipboard(&self, item: ClipboardItem) {
+        if let Some(write) = &self.services.write_clipboard {
+            write(item);
+        }
+    }
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    fn read_from_primary(&self) -> Option<ClipboardItem> {
+        None
+    }
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    fn write_to_primary(&self, _item: ClipboardItem) {}
+    #[cfg(target_os = "macos")]
+    fn read_from_find_pasteboard(&self) -> Option<ClipboardItem> {
+        None
+    }
+    #[cfg(target_os = "macos")]
+    fn write_to_find_pasteboard(&self, _item: ClipboardItem) {}
+    fn write_credentials(
+        &self,
+        _url: &str,
+        _username: &str,
+        _password: &[u8],
+    ) -> Task<gpui::Result<()>> {
+        Task::ready(Ok(()))
+    }
+    fn read_credentials(&self, _url: &str) -> Task<gpui::Result<Option<(String, Vec<u8>)>>> {
+        Task::ready(Ok(None))
+    }
+    fn delete_credentials(&self, _url: &str) -> Task<gpui::Result<()>> {
+        Task::ready(Ok(()))
+    }
+    fn keyboard_layout(&self) -> Box<dyn PlatformKeyboardLayout> {
+        Box::new(EmbeddedKeyboardLayout)
+    }
+    fn keyboard_mapper(&self) -> Rc<dyn PlatformKeyboardMapper> {
+        Rc::new(DummyKeyboardMapper)
+    }
+    fn on_keyboard_layout_change(&self, _callback: Box<dyn FnMut()>) {}
+}
+
+struct EmbeddedKeyboardLayout;
+impl PlatformKeyboardLayout for EmbeddedKeyboardLayout {
+    fn id(&self) -> &str {
+        "gpui-embedded"
+    }
+    fn name(&self) -> &str {
+        "Embedded"
+    }
+}
+
+struct EmptyRoot;
+impl Render for EmptyRoot {
+    fn render(
+        &mut self,
+        _window: &mut Window,
+        _cx: &mut gpui::Context<Self>,
+    ) -> impl gpui::IntoElement {
+        div()
+    }
+}
+
+/// The host-facing GPUI application handle.
+pub struct EmbeddedGpui {
+    platform: Rc<EmbeddedPlatform>,
+    application: gpui::ApplicationHandle,
+    window: EmbeddedWindow,
+    renderer: RefCell<gpui_wgpu::WgpuSceneRenderer>,
+}
+
+impl EmbeddedGpui {
+    /// Creates an inaccessible GPUI app with one virtual window.
+    pub fn new(config: EmbeddedConfig) -> gpui::Result<Self> {
+        Self::new_with_root(config, |_, cx| cx.new(|_| EmptyRoot))
+    }
+
+    /// Creates an inaccessible GPUI app and installs the supplied root view in its virtual window.
+    pub fn new_with_root<V>(
+        config: EmbeddedConfig,
+        build_root_view: impl FnOnce(&mut Window, &mut gpui::App) -> gpui::Entity<V> + 'static,
+    ) -> gpui::Result<Self>
+    where
+        V: 'static + Render,
+    {
+        let metrics = config.metrics;
+        let scene_renderer = config.gpu.scene_renderer(metrics.device_size(), false)?;
+        let platform = EmbeddedPlatform::new(&config, scene_renderer.sprite_atlas().clone());
+        let launch_error = Rc::new(RefCell::new(None));
+        let launch_error_for_callback = launch_error.clone();
+        let platform_for_callback = platform.clone();
+        let application =
+            gpui::Application::new_inaccessible(platform.clone()).run_embedded(move |cx| {
+                let options = WindowOptions {
+                    window_bounds: Some(WindowBounds::Windowed(metrics.bounds)),
+                    titlebar: None,
+                    kind: WindowKind::Normal,
+                    window_decorations: Some(WindowDecorations::Client),
+                    ..Default::default()
+                };
+                if let Err(error) = cx.open_window(options, build_root_view) {
+                    *launch_error_for_callback.borrow_mut() = Some(error.to_string());
+                }
+                let _ = platform_for_callback.window();
+            });
+        if let Some(error) = launch_error.take() {
+            return Err(std::io::Error::other(error).into());
+        }
+        let window = platform
+            .window()
+            .ok_or_else(|| std::io::Error::other("embedded window was not created"))?;
+        Ok(Self {
+            platform,
+            application,
+            window,
+            renderer: RefCell::new(scene_renderer),
+        })
+    }
+
+    /// Runs the explicit foreground task phase and returns the next host wake deadline.
+    ///
+    /// Background workers remain GPUI-owned. The host should call this method from its event-loop
+    /// update phase, then schedule one wake for [`crate::PollOutcome::next_deadline`].
+    pub fn poll(&self) -> crate::PollOutcome {
+        self.platform.poll()
+    }
+
+    /// Updates the virtual window metrics.
+    pub fn set_window_metrics(&self, metrics: WindowMetrics) {
+        self.window.set_metrics(metrics);
+    }
+    /// Dispatches one host input event.
+    pub fn dispatch_input(&self, input: PlatformInput) -> gpui::Result<InputOutcome> {
+        let result = self.window.dispatch_input(input)?;
+        let (redraw_requested, pointer_capture) = self.application.update(|cx| {
+            self.window.handle().update(cx, |_, window, _| {
+                (
+                    window.is_dirty() || window.needs_redraw(),
+                    window.captured_hitbox().is_some(),
+                )
+            })
+        })?;
+        Ok(InputOutcome {
+            propagate: result.propagate,
+            default_prevented: result.default_prevented,
+            redraw_requested,
+            pointer_capture,
+        })
+    }
+    /// Inserts committed text into the active input handler.
+    pub fn insert_text(&self, text: &str) -> bool {
+        self.window.insert_text(text)
+    }
+
+    /// Updates marked text using UTF-16 indices for both ranges.
+    ///
+    /// A host adapter that receives byte-indexed preedit ranges must convert them to UTF-16
+    /// offsets before calling this method.
+    pub fn set_marked_text(
+        &self,
+        range_utf16: Option<std::ops::Range<usize>>,
+        text: &str,
+        selected_range_utf16: Option<std::ops::Range<usize>>,
+    ) -> bool {
+        self.window
+            .set_marked_text(range_utf16, text, selected_range_utf16)
+    }
+
+    /// Ends the active marked-text composition.
+    pub fn unmark_text(&self) -> bool {
+        self.window.unmark_text()
+    }
+
+    /// Returns the active UTF-16 selection range.
+    pub fn selected_text_range(&self) -> Option<gpui::UTF16Selection> {
+        self.window.selected_text_range()
+    }
+
+    /// Returns the active marked-text range in UTF-16 indices.
+    pub fn marked_text_range(&self) -> Option<std::ops::Range<usize>> {
+        self.window.marked_text_range()
+    }
+
+    /// Returns the host-space candidate bounds for the active IME composition.
+    pub fn ime_candidate_bounds(&self) -> Option<Bounds<Pixels>> {
+        self.window.ime_candidate_bounds()
+    }
+
+    /// Requests GPUI to build its next frame.
+    ///
+    /// Task polling is an explicit preceding host phase; this method never calls [`Self::poll`]
+    /// implicitly.
+    pub fn prepare_frame(&self) -> gpui::Result<gpui::FrameStatus> {
+        self.application.update(|cx| {
+            self.window.handle().update(cx, |_, window, cx| {
+                let clear = window.prepare_frame(cx);
+                let status = window.frame_status();
+                self.window.record_scene(window.rendered_scene(), status);
+                clear.clear(cx);
+                status
+            })
+        })
+    }
+    /// Returns metadata for the last frame.
+    pub fn rendered_scene(&self) -> Option<RenderedScene> {
+        self.window.rendered_scene()
+    }
+    /// Encodes the rendered frame through the host-owned target.
+    pub fn encode(
+        &self,
+        target: HostRenderTarget<'_>,
+        encoder: &mut gpui_wgpu::wgpu::CommandEncoder,
+    ) -> gpui::Result<gpui_wgpu::RenderStats> {
+        let mut renderer = self.renderer.borrow_mut();
+        self.application.update(|cx| {
+            self.window.handle().update(cx, |_, window, _| {
+                renderer.encode(window.rendered_scene(), encoder, target)
+            })
+        })?
+    }
+
+    /// Encodes the rendered frame into the convenience target allocated by this crate.
+    pub fn encode_offscreen(
+        &self,
+        target: &OffscreenTarget,
+        encoder: &mut gpui_wgpu::wgpu::CommandEncoder,
+    ) -> gpui::Result<gpui_wgpu::RenderStats> {
+        self.encode(
+            target.target(gpui_wgpu::wgpu::LoadOp::Clear(
+                gpui_wgpu::wgpu::Color::TRANSPARENT,
+            )),
+            encoder,
+        )
+    }
+
+    /// Encodes the rendered frame and registered engine viewports into a host target.
+    pub fn encode_with_external_surfaces(
+        &self,
+        target: HostRenderTarget<'_>,
+        encoder: &mut gpui_wgpu::wgpu::CommandEncoder,
+        registry: &gpui::ExternalSurfaceRegistry<gpui_wgpu::WgpuExternalSurface>,
+    ) -> gpui::Result<gpui_wgpu::RenderStats> {
+        let mut renderer = self.renderer.borrow_mut();
+        self.application.update(|cx| {
+            self.window.handle().update(cx, |_, window, _| {
+                renderer.encode_with_external_surfaces(
+                    window.rendered_scene(),
+                    encoder,
+                    target,
+                    registry,
+                )
+            })
+        })?
+    }
+
+    /// Marks the retained frame as presented after the host submits its command buffer.
+    ///
+    /// Do not call this after an acquire, encode, submit, or present failure. Returns `false` when
+    /// the acknowledgement refers to a stale scene generation.
+    pub fn mark_presented(&self, scene_generation: u64) -> gpui::Result<bool> {
+        self.application.update(|cx| {
+            self.window
+                .handle()
+                .update(cx, |_, window, _| window.mark_presented(scene_generation))
+        })
+    }
+
+    /// Rebuilds the surface-free renderer after host device recovery.
+    ///
+    /// The platform atlas keeps its identity and is rebound in place. The host must recreate
+    /// borrowed render targets and replace every registered external-surface view before the
+    /// next encode.
+    pub fn replace_gpu_context(
+        &self,
+        adapter: &gpui_wgpu::wgpu::Adapter,
+        device: Arc<gpui_wgpu::wgpu::Device>,
+        queue: Arc<gpui_wgpu::wgpu::Queue>,
+    ) -> gpui::Result<()> {
+        self.renderer
+            .borrow_mut()
+            .replace_gpu_context(adapter, device, queue)?;
+        self.application.update(|cx| {
+            self.window.handle().update(cx, |_, window, _| {
+                window.refresh();
+            })
+        })
+    }
+    /// Drains cursor and IME commands for the host to apply.
+    pub fn take_host_commands(&self) -> Vec<HostCommand> {
+        self.platform.take_host_commands()
+    }
+    /// Updates GPUI application state.
+    pub fn update<R>(&self, f: impl FnOnce(&mut gpui::App) -> R) -> R {
+        self.application.update(f)
+    }
+    /// Returns the virtual window's GPUI handle.
+    pub fn window_handle(&self) -> AnyWindowHandle {
+        self.window.handle()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metrics_convert_logical_size_to_device_size() {
+        let metrics = WindowMetrics::new(gpui::size(gpui::px(320.), gpui::px(180.)), 2.0);
+        assert_eq!(
+            metrics.device_size(),
+            gpui::size(DevicePixels(640), DevicePixels(360))
+        );
+    }
+
+    #[test]
+    fn input_outcome_distinguishes_consumed_and_propagated_events() {
+        let consumed = InputOutcome {
+            propagate: false,
+            ..Default::default()
+        };
+        let propagated = InputOutcome {
+            propagate: true,
+            ..Default::default()
+        };
+        assert!(!consumed.propagate);
+        assert!(propagated.propagate);
+        assert_ne!(consumed, propagated);
+    }
+}

--- a/crates/gpui_embed/src/platform.rs
+++ b/crates/gpui_embed/src/platform.rs
@@ -1167,17 +1167,22 @@ impl EmbeddedGpui {
     /// Rebuilds the surface-free renderer after host device recovery.
     ///
     /// The platform atlas keeps its identity and is rebound in place. The host must recreate
-    /// borrowed render targets and replace every registered external-surface view before the
-    /// next encode.
+    /// borrowed render targets. Pass the external-surface registry when the host has registered
+    /// external surfaces; their generations are snapshotted and each view must be replaced
+    /// before that ID is encoded again. Hosts without external surfaces may pass `None`.
     pub fn replace_gpu_context(
         &self,
         adapter: &gpui_wgpu::wgpu::Adapter,
         device: Arc<gpui_wgpu::wgpu::Device>,
         queue: Arc<gpui_wgpu::wgpu::Queue>,
+        external_surfaces: Option<&gpui::ExternalSurfaceRegistry<gpui_wgpu::WgpuExternalSurface>>,
     ) -> gpui::Result<()> {
-        self.renderer
-            .borrow_mut()
-            .replace_gpu_context(adapter, device, queue)?;
+        self.renderer.borrow_mut().replace_gpu_context(
+            adapter,
+            device,
+            queue,
+            external_surfaces,
+        )?;
         self.application.update(|cx| {
             self.window.handle().update(cx, |_, window, _| {
                 window.refresh();

--- a/crates/gpui_embed/src/renderer.rs
+++ b/crates/gpui_embed/src/renderer.rs
@@ -1,0 +1,135 @@
+use gpui::{DevicePixels, Scene, Size};
+use gpui_wgpu::wgpu;
+use std::sync::Arc;
+
+/// A borrowed single-sample target supplied by the host.
+pub type HostRenderTarget<'a> = gpui_wgpu::WgpuRenderTarget<'a>;
+
+/// GPU objects supplied and owned by the embedding host.
+#[derive(Clone)]
+pub struct HostGpu {
+    /// The adapter that created the host device.
+    pub adapter: Arc<wgpu::Adapter>,
+    /// The host's device.
+    pub device: Arc<wgpu::Device>,
+    /// The host's queue. The adapter never submits to it.
+    pub queue: Arc<wgpu::Queue>,
+    /// The format used by GPUI atlas textures and render targets.
+    pub color_format: wgpu::TextureFormat,
+}
+
+impl HostGpu {
+    /// Creates a host GPU description from an existing device and queue.
+    pub fn new(
+        adapter: Arc<wgpu::Adapter>,
+        device: Arc<wgpu::Device>,
+        queue: Arc<wgpu::Queue>,
+        color_format: wgpu::TextureFormat,
+    ) -> Self {
+        Self {
+            adapter,
+            device,
+            queue,
+            color_format,
+        }
+    }
+
+    /// Creates the shared surface-free GPUI scene renderer.
+    pub fn scene_renderer(
+        &self,
+        size: Size<DevicePixels>,
+        transparent: bool,
+    ) -> gpui::Result<gpui_wgpu::WgpuSceneRenderer> {
+        gpui_wgpu::WgpuSceneRenderer::from_host(
+            &self.adapter,
+            self.device.clone(),
+            self.queue.clone(),
+            gpui_wgpu::WgpuSceneRendererConfig {
+                size,
+                format: self.color_format,
+                transparent,
+            },
+        )
+    }
+}
+
+/// A host-owned offscreen WGPU color target for headless proofs and simple integrations.
+pub struct OffscreenTarget {
+    texture: wgpu::Texture,
+    view: wgpu::TextureView,
+    size: Size<DevicePixels>,
+    format: wgpu::TextureFormat,
+}
+
+impl OffscreenTarget {
+    /// Allocates an offscreen target. Allocation does not submit or present.
+    pub fn new(gpu: &HostGpu, size: Size<DevicePixels>) -> Self {
+        let texture = gpu.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("gpui_embed_render_target"),
+            size: wgpu::Extent3d {
+                width: size.width.0.max(1) as u32,
+                height: size.height.0.max(1) as u32,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: gpu.color_format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        Self {
+            texture,
+            view,
+            size,
+            format: gpu.color_format,
+        }
+    }
+
+    /// Returns the target texture view for host-owned encoding.
+    pub fn view(&self) -> &wgpu::TextureView {
+        &self.view
+    }
+
+    /// Returns the target texture.
+    pub fn texture(&self) -> &wgpu::Texture {
+        &self.texture
+    }
+
+    /// Returns the target size in device pixels.
+    pub fn size(&self) -> Size<DevicePixels> {
+        self.size
+    }
+
+    /// Returns the target format.
+    pub fn format(&self) -> wgpu::TextureFormat {
+        self.format
+    }
+
+    /// Encodes a rendered GPUI scene into a host command encoder.
+    pub fn target(&self, load: wgpu::LoadOp<wgpu::Color>) -> HostRenderTarget<'_> {
+        HostRenderTarget {
+            view: &self.view,
+            size: self.size,
+            format: self.format,
+            load,
+        }
+    }
+
+    /// Encodes a rendered GPUI scene into this convenience target.
+    pub fn encode_scene(
+        &self,
+        renderer: &mut gpui_wgpu::WgpuSceneRenderer,
+        scene: &Scene,
+        encoder: &mut wgpu::CommandEncoder,
+    ) -> gpui::Result<gpui_wgpu::RenderStats> {
+        renderer.encode(
+            scene,
+            encoder,
+            self.target(wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)),
+        )
+    }
+}

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -1090,6 +1090,10 @@ impl MetalRenderer {
                     viewport_size,
                     command_encoder,
                 ),
+                // External surfaces are host-registered WGPU resources. Native Metal windows do
+                // not receive that registry, so retain the scene ordering while leaving the
+                // primitive for a native viewport integration to consume later.
+                PrimitiveBatch::ExternalSurfaces(_) => true,
                 PrimitiveBatch::BackdropFilters(range) => {
                     command_encoder.end_encoding();
                     if let (Some(ping), Some(pong)) =

--- a/crates/gpui_wgpu/src/gpui_wgpu.rs
+++ b/crates/gpui_wgpu/src/gpui_wgpu.rs
@@ -7,4 +7,7 @@ pub use cosmic_text_system::*;
 pub use wgpu;
 pub use wgpu_atlas::*;
 pub use wgpu_context::*;
-pub use wgpu_renderer::{GpuContext, WgpuRenderer, WgpuSurfaceConfig};
+pub use wgpu_renderer::{
+    GpuContext, RenderStats, WgpuExternalSurface, WgpuRenderTarget, WgpuRenderer,
+    WgpuSceneRenderer, WgpuSceneRendererConfig, WgpuSurfaceConfig,
+};

--- a/crates/gpui_wgpu/src/wgpu_atlas.rs
+++ b/crates/gpui_wgpu/src/wgpu_atlas.rs
@@ -427,6 +427,7 @@ mod tests {
                     power_preference: wgpu::PowerPreference::LowPower,
                     compatible_surface: None,
                     force_fallback_adapter: false,
+                    apply_limit_buckets: false,
                 })
                 .await
                 .map_err(|error| anyhow::anyhow!("failed to request adapter: {error}"))?;

--- a/crates/gpui_wgpu/src/wgpu_atlas.rs
+++ b/crates/gpui_wgpu/src/wgpu_atlas.rs
@@ -91,13 +91,21 @@ impl WgpuAtlas {
         lock.pending_uploads.clear();
     }
 
-    /// Handles device lost by clearing all textures and cached tiles.
-    /// The atlas will lazily recreate textures as needed on subsequent frames.
-    pub fn handle_device_lost(&self, context: &WgpuContext) {
+    /// Rebinds this atlas to a replacement device without changing its identity.
+    ///
+    /// Atlas allocations belong to the old device, so they are discarded and rebuilt lazily on
+    /// the replacement device. Callers keep the same [`Arc<WgpuAtlas>`] in every GPUI window.
+    pub fn replace_gpu_context(
+        &self,
+        device: Arc<wgpu::Device>,
+        queue: Arc<wgpu::Queue>,
+        color_texture_format: wgpu::TextureFormat,
+    ) {
         let mut lock = self.0.lock();
-        lock.device = context.device.clone();
-        lock.queue = context.queue.clone();
-        lock.color_texture_format = context.color_texture_format();
+        lock.device = device;
+        lock.queue = queue;
+        lock.max_texture_size = lock.device.limits().max_texture_dimension_2d;
+        lock.color_texture_format = color_texture_format;
         lock.storage = WgpuAtlasStorage::default();
         lock.tiles_by_key.clear();
         lock.pending_uploads.clear();

--- a/crates/gpui_wgpu/src/wgpu_context.rs
+++ b/crates/gpui_wgpu/src/wgpu_context.rs
@@ -132,6 +132,7 @@ impl WgpuContext {
                 power_preference: wgpu::PowerPreference::HighPerformance,
                 compatible_surface: None,
                 force_fallback_adapter: false,
+                apply_limit_buckets: false,
             })
             .await
             .map_err(|e| anyhow::anyhow!("Failed to request GPU adapter: {e}"))?;
@@ -409,6 +410,7 @@ impl WgpuContext {
             present_mode: wgpu::PresentMode::Fifo,
             desired_maximum_frame_latency: 2,
             alpha_mode: caps.alpha_modes[0],
+            color_space: wgpu::SurfaceColorSpace::Auto,
             view_formats: vec![],
         };
 

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -2493,8 +2493,11 @@ fn create_surface(
 /// recovery. The reusable scene renderer below it only owns GPUI GPU resources and command
 /// encoding.
 pub struct WgpuRenderer {
+    #[cfg(not(target_family = "wasm"))]
     context: Option<GpuContext>,
+    #[cfg(not(target_family = "wasm"))]
     compositor_gpu: Option<CompositorGpuHint>,
+    #[cfg(not(target_family = "wasm"))]
     extra_requirements: Option<WgpuDeviceRequirements>,
     scene: WgpuSceneRenderer,
     surface: Option<wgpu::Surface<'static>>,
@@ -2579,12 +2582,12 @@ impl WgpuRenderer {
     }
 
     fn new_internal(
-        context_handle: Option<GpuContext>,
+        _context_handle: Option<GpuContext>,
         context: &WgpuContext,
         surface: wgpu::Surface<'static>,
         config: WgpuSurfaceConfig,
-        compositor_gpu: Option<CompositorGpuHint>,
-        extra_requirements: Option<WgpuDeviceRequirements>,
+        _compositor_gpu: Option<CompositorGpuHint>,
+        _extra_requirements: Option<WgpuDeviceRequirements>,
         atlas: Arc<WgpuAtlas>,
     ) -> anyhow::Result<Self> {
         let surface_caps = surface.get_capabilities(&context.adapter);
@@ -2674,9 +2677,12 @@ impl WgpuRenderer {
         let last_error = Arc::new(Mutex::new(None));
         scene.install_error_handler(last_error.clone());
         Ok(Self {
-            context: context_handle,
-            compositor_gpu,
-            extra_requirements,
+            #[cfg(not(target_family = "wasm"))]
+            context: _context_handle,
+            #[cfg(not(target_family = "wasm"))]
+            compositor_gpu: _compositor_gpu,
+            #[cfg(not(target_family = "wasm"))]
+            extra_requirements: _extra_requirements,
             scene,
             surface: Some(surface),
             surface_config,

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -2653,6 +2653,7 @@ impl WgpuRenderer {
                 .unwrap_or(wgpu::PresentMode::Fifo),
             desired_maximum_frame_latency: 2,
             alpha_mode,
+            color_space: wgpu::SurfaceColorSpace::Auto,
             view_formats: vec![],
         };
         surface.configure(&context.device, &surface_config);
@@ -2758,12 +2759,12 @@ impl WgpuRenderer {
         match result {
             Ok(_) => {
                 queue.submit(Some(encoder.finish()));
-                frame.present();
+                queue.present(frame);
                 true
             }
             Err(error) => {
                 log::error!("failed to encode GPUI scene: {error:#}");
-                frame.present();
+                queue.present(frame);
                 false
             }
         }
@@ -3116,6 +3117,7 @@ mod tests {
             power_preference: wgpu::PowerPreference::LowPower,
             compatible_surface: None,
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .map_err(|error| anyhow::anyhow!("failed to request adapter: {error}"))?;
         let requirements = WgpuSceneRenderer::requirements(&adapter);
@@ -3169,6 +3171,7 @@ mod tests {
             power_preference: wgpu::PowerPreference::LowPower,
             compatible_surface: None,
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .map_err(|error| anyhow::anyhow!("failed to request adapter: {error}"))?;
         let requirements = WgpuSceneRenderer::requirements(&adapter);

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -1,10 +1,10 @@
 use crate::{CompositorGpuHint, WgpuAtlas, WgpuContext, WgpuDeviceRequirements};
 use bytemuck::{Pod, Zeroable};
 use gpui::{
-    AtlasTextureId, BackdropFilter, Background, Bounds, DevicePixels, FilterBoundary, GpuSpecs,
-    MonochromeSprite, PaintSurface, Path, Point, PolychromeSprite, PrimitiveBatch, Quad,
-    ScaledFilter, ScaledPixels, Scene, Shadow, Size, SubpixelSprite, Underline,
-    get_gamma_correction_ratios,
+    AtlasTextureId, BackdropFilter, Background, Bounds, DevicePixels, ExternalSurface,
+    ExternalSurfaceId, ExternalSurfaceRegistry, FilterBoundary, GpuSpecs, MonochromeSprite,
+    PaintSurface, Path, Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledFilter, ScaledPixels,
+    Scene, Shadow, Size, SubpixelSprite, Underline, get_gamma_correction_ratios,
 };
 use log::warn;
 
@@ -22,6 +22,7 @@ fn max_blur_radius(filters: &[ScaledFilter]) -> f32 {
 #[cfg(not(target_family = "wasm"))]
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::num::NonZeroU64;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
@@ -126,6 +127,50 @@ pub struct WgpuSurfaceConfig {
     pub preferred_present_mode: Option<wgpu::PresentMode>,
 }
 
+/// Configuration for a renderer that records GPUI scene commands into a host-owned target.
+///
+/// The renderer does not create or configure a surface. The host is responsible for creating a
+/// single-sample texture view with this format and size and passing it to [`WgpuSceneRenderer::encode`].
+#[derive(Clone, Copy, Debug)]
+pub struct WgpuSceneRendererConfig {
+    pub size: Size<DevicePixels>,
+    pub format: wgpu::TextureFormat,
+    pub transparent: bool,
+}
+
+/// A host-owned color target for [`WgpuSceneRenderer::encode`].
+///
+/// The target must be a single-sample view created with the format supplied to
+/// [`WgpuSceneRendererConfig`]. The host owns the texture and decides when the command encoder is
+/// submitted. Dimensions must be positive. GPUI always stores the final color attachment; the
+/// host chooses only whether the first pass loads or clears the target. MSAA, arbitrary formats,
+/// and embedded filter backgrounds are outside this contract.
+pub struct WgpuRenderTarget<'a> {
+    pub view: &'a wgpu::TextureView,
+    pub size: Size<DevicePixels>,
+    /// The format of `view`.
+    pub format: wgpu::TextureFormat,
+    /// The load operation for the target's first UI pass.
+    pub load: wgpu::LoadOp<wgpu::Color>,
+}
+
+/// Basic information about the work recorded for a scene.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RenderStats {
+    /// Bytes reserved in the renderer's instance buffer for this scene.
+    pub instance_bytes: u64,
+}
+
+/// A WGPU view registered for a backend-neutral GPUI external surface.
+#[derive(Clone)]
+pub struct WgpuExternalSurface {
+    /// The host-owned single-sample texture view sampled during GPUI encoding.
+    ///
+    /// The view must be recreated and replaced in the external-surface registry after host GPU
+    /// device recovery; the surface ID remains stable while the registry generation advances.
+    pub view: Arc<wgpu::TextureView>,
+}
+
 struct WgpuPipelines {
     quads: wgpu::RenderPipeline,
     shadows: wgpu::RenderPipeline,
@@ -162,7 +207,6 @@ pub type GpuContext = Rc<RefCell<Option<WgpuContext>>>;
 struct WgpuResources {
     device: Arc<wgpu::Device>,
     queue: Arc<wgpu::Queue>,
-    surface: wgpu::Surface<'static>,
     pipelines: WgpuPipelines,
     bind_group_layouts: WgpuBindGroupLayouts,
     atlas_sampler: wgpu::Sampler,
@@ -225,19 +269,13 @@ const MAX_FILTER_DEPTH: usize = 2;
 /// Number of [`BlurParams`] slots in the shared blur-params buffer (one per blur pass per frame).
 /// Each frame uses 4 passes per backdrop/group plus one blit; 256 covers dozens of filters.
 const BLUR_PARAMS_SLOTS: u64 = 256;
+/// Initial number of surface draw uniforms reserved in one command encoder. The buffer grows
+/// before encoding a larger scene so every surface in one host submission gets a distinct slot.
+const INITIAL_SURFACE_UNIFORM_SLOTS: u64 = 256;
 
-pub struct WgpuRenderer {
-    /// Shared GPU context for device recovery coordination (unused on WASM).
-    #[allow(dead_code)]
-    context: Option<GpuContext>,
-    /// Compositor GPU hint for adapter selection (unused on WASM).
-    #[allow(dead_code)]
-    compositor_gpu: Option<CompositorGpuHint>,
-    /// Application-requested extra wgpu features/limits, stored for device recovery.
-    #[allow(dead_code)]
-    extra_requirements: Option<WgpuDeviceRequirements>,
+pub struct WgpuSceneRenderer {
     resources: Option<WgpuResources>,
-    surface_config: wgpu::SurfaceConfiguration,
+    config: WgpuSceneRendererConfig,
     atlas: Arc<WgpuAtlas>,
     path_globals_offset: u64,
     gamma_offset: u64,
@@ -252,17 +290,15 @@ pub struct WgpuRenderer {
     is_bgr: bool,
     dual_source_blending: bool,
     adapter_info: wgpu::AdapterInfo,
-    transparent_alpha_mode: wgpu::CompositeAlphaMode,
-    opaque_alpha_mode: wgpu::CompositeAlphaMode,
     max_texture_size: u32,
-    last_error: Arc<Mutex<Option<String>>>,
-    failed_frame_count: u32,
-    device_lost: std::sync::Arc<std::sync::atomic::AtomicBool>,
-    surface_configured: bool,
-    needs_redraw: bool,
+    surface_uniform_stride: u64,
+    surface_uniform_capacity: u64,
+    surface_uniform_slot: std::cell::Cell<u64>,
+    external_surface_generations: HashMap<ExternalSurfaceId, u64>,
+    external_surfaces_need_replacement: bool,
 }
 
-impl WgpuRenderer {
+impl WgpuSceneRenderer {
     fn resources(&self) -> &WgpuResources {
         self.resources
             .as_ref()
@@ -275,197 +311,80 @@ impl WgpuRenderer {
             .expect("GPU resources not available")
     }
 
-    /// Creates a new WgpuRenderer from raw window handles.
-    ///
-    /// The `gpu_context` is a shared reference that coordinates GPU context across
-    /// multiple windows. The first window to create a renderer will initialize the
-    /// context; subsequent windows will share it.
-    ///
-    /// # Safety
-    /// The caller must ensure that the window handle remains valid for the lifetime
-    /// of the returned renderer.
-    #[cfg(not(target_family = "wasm"))]
-    pub fn new<W>(
-        gpu_context: GpuContext,
-        window: &W,
-        config: WgpuSurfaceConfig,
-        compositor_gpu: Option<CompositorGpuHint>,
-        extra_requirements: Option<WgpuDeviceRequirements>,
-    ) -> anyhow::Result<Self>
-    where
-        W: HasWindowHandle + HasDisplayHandle + std::fmt::Debug + Send + Sync + Clone + 'static,
-    {
-        let window_handle = window
-            .window_handle()
-            .map_err(|e| anyhow::anyhow!("Failed to get window handle: {e}"))?;
-
-        let target = wgpu::SurfaceTargetUnsafe::RawHandle {
-            // Fall back to the display handle already provided via InstanceDescriptor::display.
-            raw_display_handle: None,
-            raw_window_handle: window_handle.as_raw(),
-        };
-
-        // Use the existing context's instance if available, otherwise create a new one.
-        // The surface must be created with the same instance that will be used for
-        // adapter selection, otherwise wgpu will panic.
-        let instance = gpu_context
-            .borrow()
-            .as_ref()
-            .map(|ctx| ctx.instance.clone())
-            .unwrap_or_else(|| WgpuContext::instance(Box::new(window.clone())));
-
-        // Safety: The caller guarantees that the window handle is valid for the
-        // lifetime of this renderer. In practice, the RawWindow struct is created
-        // from the native window handles and the surface is dropped before the window.
-        let surface = unsafe {
-            instance
-                .create_surface_unsafe(target)
-                .map_err(|e| anyhow::anyhow!("Failed to create surface: {e}"))?
-        };
-
-        let mut ctx_ref = gpu_context.borrow_mut();
-        let context = match ctx_ref.as_mut() {
-            Some(context) => {
-                context.check_compatible_with_surface(&surface)?;
-                context
-            }
-            None => ctx_ref.insert(WgpuContext::new(
-                instance,
-                &surface,
-                compositor_gpu,
-                extra_requirements.as_ref(),
-            )?),
-        };
-
-        let atlas = Arc::new(WgpuAtlas::from_context(context));
-
-        Self::new_internal(
-            Some(Rc::clone(&gpu_context)),
-            context,
-            surface,
-            config,
-            compositor_gpu,
-            extra_requirements,
-            atlas,
-        )
+    /// Returns optional device features used by GPUI's subpixel text pipeline.
+    pub fn requirements(adapter: &wgpu::Adapter) -> WgpuDeviceRequirements {
+        let mut requirements = WgpuDeviceRequirements::default();
+        if adapter
+            .features()
+            .contains(wgpu::Features::DUAL_SOURCE_BLENDING)
+        {
+            requirements.features |= wgpu::Features::DUAL_SOURCE_BLENDING;
+        }
+        requirements
     }
 
-    #[cfg(target_family = "wasm")]
-    pub fn new_from_canvas(
-        context: &WgpuContext,
-        canvas: &web_sys::HtmlCanvasElement,
-        config: WgpuSurfaceConfig,
+    /// Creates a surface-free scene renderer from host-owned GPU handles.
+    pub fn from_host(
+        adapter: &wgpu::Adapter,
+        device: Arc<wgpu::Device>,
+        queue: Arc<wgpu::Queue>,
+        config: WgpuSceneRendererConfig,
     ) -> anyhow::Result<Self> {
-        let surface = context
-            .instance
-            .create_surface(wgpu::SurfaceTarget::Canvas(canvas.clone()))
-            .map_err(|e| anyhow::anyhow!("Failed to create surface: {e}"))?;
-
-        let atlas = Arc::new(WgpuAtlas::from_context(context));
-
-        Self::new_internal(None, context, surface, config, None, None, atlas)
+        anyhow::ensure!(
+            config.size.width.0 >= 0 && config.size.height.0 >= 0,
+            "host render target dimensions must be non-negative"
+        );
+        anyhow::ensure!(
+            config.size.width.0 as u32 <= device.limits().max_texture_dimension_2d
+                && config.size.height.0 as u32 <= device.limits().max_texture_dimension_2d,
+            "host render target size {:?} exceeds device limit {}",
+            config.size,
+            device.limits().max_texture_dimension_2d
+        );
+        Self::validate_host_target_format(adapter, config.format)?;
+        let atlas = Arc::new(WgpuAtlas::new(device.clone(), queue.clone(), config.format));
+        Self::from_parts(adapter, device, queue, config, atlas)
     }
 
-    fn new_internal(
-        gpu_context: Option<GpuContext>,
-        context: &WgpuContext,
-        surface: wgpu::Surface<'static>,
-        config: WgpuSurfaceConfig,
-        compositor_gpu: Option<CompositorGpuHint>,
-        extra_requirements: Option<WgpuDeviceRequirements>,
+    fn validate_host_target_format(
+        adapter: &wgpu::Adapter,
+        format: wgpu::TextureFormat,
+    ) -> anyhow::Result<()> {
+        let format_features = adapter.get_texture_format_features(format);
+        anyhow::ensure!(
+            format_features.allowed_usages.contains(
+                wgpu::TextureUsages::RENDER_ATTACHMENT
+                    | wgpu::TextureUsages::TEXTURE_BINDING
+                    | wgpu::TextureUsages::COPY_DST
+            ),
+            "host target format {:?} does not support GPUI render and atlas usages",
+            format
+        );
+        Ok(())
+    }
+
+    fn from_parts(
+        adapter: &wgpu::Adapter,
+        device: Arc<wgpu::Device>,
+        queue: Arc<wgpu::Queue>,
+        config: WgpuSceneRendererConfig,
         atlas: Arc<WgpuAtlas>,
     ) -> anyhow::Result<Self> {
-        let surface_caps = surface.get_capabilities(&context.adapter);
-        let preferred_formats = [
-            wgpu::TextureFormat::Bgra8Unorm,
-            wgpu::TextureFormat::Rgba8Unorm,
-        ];
-        let surface_format = preferred_formats
-            .iter()
-            .find(|f| surface_caps.formats.contains(f))
-            .copied()
-            .or_else(|| surface_caps.formats.iter().find(|f| !f.is_srgb()).copied())
-            .or_else(|| surface_caps.formats.first().copied())
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Surface reports no supported texture formats for adapter {:?}",
-                    context.adapter.get_info().name
-                )
-            })?;
-
-        let pick_alpha_mode =
-            |preferences: &[wgpu::CompositeAlphaMode]| -> anyhow::Result<wgpu::CompositeAlphaMode> {
-                preferences
-                    .iter()
-                    .find(|p| surface_caps.alpha_modes.contains(p))
-                    .copied()
-                    .or_else(|| surface_caps.alpha_modes.first().copied())
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "Surface reports no supported alpha modes for adapter {:?}",
-                            context.adapter.get_info().name
-                        )
-                    })
-            };
-
-        let transparent_alpha_mode = pick_alpha_mode(&[
-            wgpu::CompositeAlphaMode::PreMultiplied,
-            wgpu::CompositeAlphaMode::Inherit,
-        ])?;
-
-        let opaque_alpha_mode = pick_alpha_mode(&[
-            wgpu::CompositeAlphaMode::Opaque,
-            wgpu::CompositeAlphaMode::Inherit,
-        ])?;
-
-        let alpha_mode = if config.transparent {
-            transparent_alpha_mode
-        } else {
-            opaque_alpha_mode
-        };
-
-        let device = Arc::clone(&context.device);
         let max_texture_size = device.limits().max_texture_dimension_2d;
-
-        let requested_width = config.size.width.0 as u32;
-        let requested_height = config.size.height.0 as u32;
-        let clamped_width = requested_width.min(max_texture_size);
-        let clamped_height = requested_height.min(max_texture_size);
-
-        if clamped_width != requested_width || clamped_height != requested_height {
-            warn!(
-                "Requested surface size ({}, {}) exceeds maximum texture dimension {}. \
-                 Clamping to ({}, {}). Window content may not fill the entire window.",
-                requested_width, requested_height, max_texture_size, clamped_width, clamped_height
-            );
-        }
-
-        let surface_config = wgpu::SurfaceConfiguration {
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            format: surface_format,
-            width: clamped_width.max(1),
-            height: clamped_height.max(1),
-            present_mode: config
-                .preferred_present_mode
-                .filter(|mode| surface_caps.present_modes.contains(mode))
-                .unwrap_or(wgpu::PresentMode::Fifo),
-            desired_maximum_frame_latency: 2,
-            alpha_mode,
-            view_formats: vec![],
+        let alpha_mode = if config.transparent {
+            wgpu::CompositeAlphaMode::PreMultiplied
+        } else {
+            wgpu::CompositeAlphaMode::Opaque
         };
-        // Configure the surface immediately. The adapter selection process already validated
-        // that this adapter can successfully configure this surface.
-        surface.configure(&context.device, &surface_config);
-
-        let queue = Arc::clone(&context.queue);
-        let dual_source_blending = context.supports_dual_source_blending();
-
-        let rendering_params = RenderingParameters::new(&context.adapter, surface_format);
+        let dual_source_blending = device
+            .features()
+            .contains(wgpu::Features::DUAL_SOURCE_BLENDING);
+        let rendering_params = RenderingParameters::new(adapter, config.format);
         let bind_group_layouts = Self::create_bind_group_layouts(&device);
         let pipelines = Self::create_pipelines(
             &device,
             &bind_group_layouts,
-            surface_format,
+            config.format,
             alpha_mode,
             rendering_params.path_sample_count,
             dual_source_blending,
@@ -485,15 +404,16 @@ impl WgpuRenderer {
             ..Default::default()
         });
 
+        let uniform_alignment = device.limits().min_uniform_buffer_offset_alignment as u64;
+        let surface_uniform_stride =
+            (std::mem::size_of::<SurfaceParams>() as u64).next_multiple_of(uniform_alignment);
         let surface_uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("surface_uniform_buffer"),
-            size: std::mem::size_of::<SurfaceParams>() as u64,
+            size: surface_uniform_stride * INITIAL_SURFACE_UNIFORM_SLOTS,
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 
-        let uniform_alignment = device.limits().min_uniform_buffer_offset_alignment as u64;
-        // Shared blur-params buffer: BLUR_PARAMS_SLOTS slots, each one alignment stride apart.
         let blur_params_stride =
             (std::mem::size_of::<BlurParams>() as u64).next_multiple_of(uniform_alignment);
         let blur_params_buffer = device.create_buffer(&wgpu::BufferDescriptor {
@@ -507,7 +427,6 @@ impl WgpuRenderer {
         let gamma_size = std::mem::size_of::<GammaParams>() as u64;
         let path_globals_offset = globals_size.next_multiple_of(uniform_alignment);
         let gamma_offset = (path_globals_offset + globals_size).next_multiple_of(uniform_alignment);
-
         let globals_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("globals_buffer"),
             size: gamma_offset + gamma_size,
@@ -518,6 +437,10 @@ impl WgpuRenderer {
         let max_buffer_size = device.limits().max_buffer_size;
         let storage_buffer_alignment = device.limits().min_storage_buffer_offset_alignment as u64;
         let initial_instance_buffer_capacity = 2 * 1024 * 1024;
+        anyhow::ensure!(
+            initial_instance_buffer_capacity <= max_buffer_size,
+            "device max buffer size is too small for GPUI's instance buffer"
+        );
         let instance_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("instance_buffer"),
             size: initial_instance_buffer_capacity,
@@ -547,7 +470,6 @@ impl WgpuRenderer {
                 },
             ],
         });
-
         let path_globals_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("path_globals_bind_group"),
             layout: &bind_group_layouts.globals,
@@ -571,19 +493,11 @@ impl WgpuRenderer {
             ],
         });
 
-        let adapter_info = context.adapter.get_info();
-
-        let last_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
-        let last_error_clone = Arc::clone(&last_error);
-        device.on_uncaptured_error(Arc::new(move |error| {
-            let mut guard = last_error_clone.lock().unwrap();
-            *guard = Some(error.to_string());
-        }));
+        let adapter_info = adapter.get_info();
 
         let resources = WgpuResources {
             device,
             queue,
-            surface,
             pipelines,
             bind_group_layouts,
             atlas_sampler,
@@ -594,8 +508,6 @@ impl WgpuRenderer {
             globals_bind_group,
             path_globals_bind_group,
             instance_buffer,
-            // Defer intermediate texture creation to first draw call via ensure_intermediate_textures().
-            // This avoids panics when the device/surface is in an invalid state during initialization.
             path_intermediate_texture: None,
             path_intermediate_view: None,
             path_msaa_texture: None,
@@ -611,11 +523,8 @@ impl WgpuRenderer {
         };
 
         Ok(Self {
-            context: gpu_context,
-            compositor_gpu,
-            extra_requirements,
             resources: Some(resources),
-            surface_config,
+            config,
             atlas,
             path_globals_offset,
             gamma_offset,
@@ -628,15 +537,20 @@ impl WgpuRenderer {
             is_bgr: false,
             dual_source_blending,
             adapter_info,
-            transparent_alpha_mode,
-            opaque_alpha_mode,
             max_texture_size,
-            last_error,
-            failed_frame_count: 0,
-            device_lost: context.device_lost_flag(),
-            surface_configured: true,
-            needs_redraw: false,
+            surface_uniform_stride,
+            surface_uniform_capacity: INITIAL_SURFACE_UNIFORM_SLOTS,
+            surface_uniform_slot: std::cell::Cell::new(0),
+            external_surface_generations: HashMap::new(),
+            external_surfaces_need_replacement: false,
         })
+    }
+
+    fn install_error_handler(&self, last_error: Arc<Mutex<Option<String>>>) {
+        let device = self.resources().device.clone();
+        device.on_uncaptured_error(Arc::new(move |error| {
+            *last_error.lock().unwrap() = Some(error.to_string());
+        }));
     }
 
     fn create_bind_group_layouts(device: &wgpu::Device) -> WgpuBindGroupLayouts {
@@ -1170,10 +1084,12 @@ impl WgpuRenderer {
     }
 
     pub fn update_drawable_size(&mut self, size: Size<DevicePixels>) {
-        let width = size.width.0 as u32;
-        let height = size.height.0 as u32;
+        let width = size.width.0.max(0) as u32;
+        let height = size.height.0.max(0) as u32;
+        let current_width = self.config.size.width.0.max(0) as u32;
+        let current_height = self.config.size.height.0.max(0) as u32;
 
-        if width != self.surface_config.width || height != self.surface_config.height {
+        if width != current_width || height != current_height {
             let clamped_width = width.min(self.max_texture_size);
             let clamped_height = height.min(self.max_texture_size);
 
@@ -1185,52 +1101,16 @@ impl WgpuRenderer {
                 );
             }
 
-            self.surface_config.width = clamped_width.max(1);
-            self.surface_config.height = clamped_height.max(1);
-            let surface_config = self.surface_config.clone();
-
-            // GPU resources may not exist yet, skip rather than panicking
-            let Some(resources) = self.resources.as_mut() else {
-                return;
+            self.config.size = Size {
+                width: DevicePixels(clamped_width as i32),
+                height: DevicePixels(clamped_height as i32),
             };
 
-            // Wait for any in-flight GPU work to complete before destroying textures
-            if let Err(e) = resources.device.poll(wgpu::PollType::Wait {
-                submission_index: None,
-                timeout: None,
-            }) {
-                warn!("Failed to poll device during resize: {e:?}");
+            // Dropping renderer-owned intermediate handles is the lifetime boundary. The host
+            // owns device polling and decides when old GPU work is retired.
+            if let Some(resources) = self.resources.as_mut() {
+                resources.invalidate_intermediate_textures();
             }
-
-            // Destroy old textures before allocating new ones to avoid GPU memory spikes
-            if let Some(ref texture) = resources.path_intermediate_texture {
-                texture.destroy();
-            }
-            if let Some(ref texture) = resources.path_msaa_texture {
-                texture.destroy();
-            }
-            for texture in [
-                &resources.scene_color_texture,
-                &resources.blur_ping_texture,
-                &resources.blur_pong_texture,
-            ]
-            .into_iter()
-            .flatten()
-            {
-                texture.destroy();
-            }
-            for texture in &resources.group_textures {
-                texture.destroy();
-            }
-
-            resources
-                .surface
-                .configure(&resources.device, &surface_config);
-
-            // Invalidate intermediate textures - they will be lazily recreated
-            // in draw() after we confirm the surface is healthy. This avoids
-            // panics when the device/surface is in an invalid state during resize.
-            resources.invalidate_intermediate_textures();
         }
     }
 
@@ -1239,9 +1119,9 @@ impl WgpuRenderer {
             return;
         }
 
-        let format = self.surface_config.format;
-        let width = self.surface_config.width;
-        let height = self.surface_config.height;
+        let format = self.config.format;
+        let width = self.config.size.width.0.max(1) as u32;
+        let height = self.config.size.height.0.max(1) as u32;
         let path_sample_count = self.rendering_params.path_sample_count;
         let resources = self.resources_mut();
 
@@ -1270,9 +1150,9 @@ impl WgpuRenderer {
         if self.resources().scene_color_texture.is_some() {
             return;
         }
-        let format = self.surface_config.format;
-        let width = self.surface_config.width;
-        let height = self.surface_config.height;
+        let format = self.config.format;
+        let width = self.config.size.width.0.max(1) as u32;
+        let height = self.config.size.height.0.max(1) as u32;
         let blur_width = (width / 2).max(1);
         let blur_height = (height / 2).max(1);
         let resources = self.resources_mut();
@@ -1301,28 +1181,19 @@ impl WgpuRenderer {
     }
 
     pub fn update_transparency(&mut self, transparent: bool) {
-        let new_alpha_mode = if transparent {
-            self.transparent_alpha_mode
-        } else {
-            self.opaque_alpha_mode
-        };
-
-        if new_alpha_mode != self.surface_config.alpha_mode {
-            self.surface_config.alpha_mode = new_alpha_mode;
-            let surface_config = self.surface_config.clone();
+        if transparent != self.config.transparent {
+            self.config.transparent = transparent;
+            let alpha_mode = self.alpha_mode();
             let path_sample_count = self.rendering_params.path_sample_count;
             let dual_source_blending = self.dual_source_blending;
             let Some(resources) = self.resources.as_mut() else {
                 return;
             };
-            resources
-                .surface
-                .configure(&resources.device, &surface_config);
             resources.pipelines = Self::create_pipelines(
                 &resources.device,
                 &resources.bind_group_layouts,
-                surface_config.format,
-                surface_config.alpha_mode,
+                self.config.format,
+                alpha_mode,
                 path_sample_count,
                 dual_source_blending,
             );
@@ -1331,9 +1202,46 @@ impl WgpuRenderer {
 
     #[allow(dead_code)]
     pub fn viewport_size(&self) -> Size<DevicePixels> {
-        Size {
-            width: DevicePixels(self.surface_config.width as i32),
-            height: DevicePixels(self.surface_config.height as i32),
+        self.config.size
+    }
+
+    /// Returns the format required for encoded targets.
+    pub fn target_format(&self) -> wgpu::TextureFormat {
+        self.config.format
+    }
+
+    /// Rebuilds all GPUI GPU resources for a replacement host device and queue.
+    ///
+    /// Construction is transactional: the live renderer and its shared atlas remain untouched
+    /// until replacement resources have been built successfully. The atlas [`Arc`] itself is
+    /// preserved so the GPUI window keeps the same platform-atlas identity. The renderer format
+    /// is fixed for its lifetime; the host must recreate its render targets and replace every
+    /// registered external-surface view after device loss before encoding again.
+    pub fn replace_gpu_context(
+        &mut self,
+        adapter: &wgpu::Adapter,
+        device: Arc<wgpu::Device>,
+        queue: Arc<wgpu::Queue>,
+    ) -> anyhow::Result<()> {
+        let config = self.config;
+        Self::validate_host_target_format(adapter, config.format)?;
+        let atlas = self.atlas.clone();
+        let previous_external_surface_generations = self.external_surface_generations.clone();
+        let replacement_device = device.clone();
+        let replacement_queue = queue.clone();
+        let mut replacement = Self::from_parts(adapter, device, queue, config, atlas.clone())?;
+        atlas.replace_gpu_context(replacement_device, replacement_queue, config.format);
+        replacement.external_surface_generations = previous_external_surface_generations;
+        replacement.external_surfaces_need_replacement = true;
+        *self = replacement;
+        Ok(())
+    }
+
+    fn alpha_mode(&self) -> wgpu::CompositeAlphaMode {
+        if self.config.transparent {
+            wgpu::CompositeAlphaMode::PreMultiplied
+        } else {
+            wgpu::CompositeAlphaMode::Opaque
         }
     }
 
@@ -1363,85 +1271,175 @@ impl WgpuRenderer {
         self.max_texture_size
     }
 
-    pub fn draw(&mut self, scene: &Scene) -> bool {
-        // Bail out early if the surface has been unconfigured (e.g. during
-        // Android background/rotation transitions).  Attempting to acquire
-        // a texture from an unconfigured surface can block indefinitely on
-        // some drivers (Adreno).
-        if !self.surface_configured {
-            return false;
-        }
-
-        let last_error = self.last_error.lock().unwrap().take();
-        if let Some(error) = last_error {
-            self.failed_frame_count += 1;
-            log::error!(
-                "GPU error during frame (failure {} of 10): {error}",
-                self.failed_frame_count
+    fn ensure_host_instance_capacity(&mut self, required: u64) -> anyhow::Result<()> {
+        while required > self.instance_buffer_capacity {
+            anyhow::ensure!(
+                self.instance_buffer_capacity < self.max_buffer_size,
+                "GPUI scene requires {required} bytes, exceeding the device buffer limit"
             );
+            self.grow_instance_buffer();
+        }
+        Ok(())
+    }
 
-            // TBD. Does retrying more actually help?
-            if self.failed_frame_count > 10 {
-                panic!("Too many consecutive GPU errors. Last error: {error}");
-            } else if self.failed_frame_count > 5 {
-                if let Some(res) = self.resources.as_mut() {
-                    res.invalidate_intermediate_textures();
-                }
-                self.atlas.clear();
-                self.needs_redraw = true;
-                self.failed_frame_count = 0;
-                return false;
-            }
-        } else {
-            self.failed_frame_count = 0;
+    fn ensure_surface_uniform_capacity(&mut self, required: u64) -> anyhow::Result<()> {
+        if required <= self.surface_uniform_capacity {
+            return Ok(());
         }
 
-        self.atlas.before_frame();
+        let mut capacity = self.surface_uniform_capacity;
+        while capacity < required {
+            capacity = capacity
+                .checked_mul(2)
+                .ok_or_else(|| anyhow::anyhow!("surface uniform capacity overflow"))?;
+        }
+        let buffer_size = self
+            .surface_uniform_stride
+            .checked_mul(capacity)
+            .ok_or_else(|| anyhow::anyhow!("surface uniform buffer size overflow"))?;
+        anyhow::ensure!(
+            buffer_size <= self.resources().device.limits().max_buffer_size,
+            "GPUI scene requires {buffer_size} bytes for external surface uniforms, exceeding the device buffer limit"
+        );
+        let resources = self.resources_mut();
+        resources.surface_uniform_buffer =
+            resources.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("surface_uniform_buffer"),
+                size: buffer_size,
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+        self.surface_uniform_capacity = capacity;
+        Ok(())
+    }
 
-        let frame = match self.resources().surface.get_current_texture() {
-            wgpu::CurrentSurfaceTexture::Success(frame) => frame,
-            wgpu::CurrentSurfaceTexture::Suboptimal(frame) => {
-                // Textures must be destroyed before the surface can be reconfigured.
-                drop(frame);
-                let surface_config = self.surface_config.clone();
-                let resources = self.resources_mut();
-                resources
-                    .surface
-                    .configure(&resources.device, &surface_config);
-                return false;
-            }
-            wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated => {
-                let surface_config = self.surface_config.clone();
-                let resources = self.resources_mut();
-                resources
-                    .surface
-                    .configure(&resources.device, &surface_config);
-                return false;
-            }
-            wgpu::CurrentSurfaceTexture::Timeout | wgpu::CurrentSurfaceTexture::Occluded => {
-                return false;
-            }
-            wgpu::CurrentSurfaceTexture::Validation => {
-                *self.last_error.lock().unwrap() =
-                    Some("Surface texture validation error".to_string());
-                return false;
-            }
+    fn required_host_instance_bytes(&self, scene: &Scene) -> u64 {
+        let mut total: u64 = 0;
+        let alignment = self.storage_buffer_alignment;
+        let mut add = |bytes: usize| {
+            let bytes = (bytes as u64).max(16);
+            total = total.next_multiple_of(alignment).saturating_add(bytes);
         };
 
-        // Now that we know the surface is healthy, ensure intermediate textures exist
-        self.ensure_intermediate_textures();
+        for batch in scene.batches() {
+            match batch {
+                PrimitiveBatch::Quads(range) => add(std::mem::size_of_val(&scene.quads[range])),
+                PrimitiveBatch::Shadows(range) => add(std::mem::size_of_val(&scene.shadows[range])),
+                PrimitiveBatch::Paths(range) => {
+                    let paths = &scene.paths[range];
+                    let vertex_count = paths.iter().map(|path| path.vertices.len()).sum::<usize>();
+                    add(std::mem::size_of::<PathRasterizationVertex>() * vertex_count);
+                    add(std::mem::size_of::<PathSprite>() * paths.len());
+                }
+                PrimitiveBatch::Underlines(range) => {
+                    add(std::mem::size_of_val(&scene.underlines[range]))
+                }
+                PrimitiveBatch::MonochromeSprites { range, .. } => {
+                    add(std::mem::size_of_val(&scene.monochrome_sprites[range]))
+                }
+                PrimitiveBatch::SubpixelSprites { range, .. } => {
+                    add(std::mem::size_of_val(&scene.subpixel_sprites[range]))
+                }
+                PrimitiveBatch::PolychromeSprites { range, .. } => {
+                    add(std::mem::size_of_val(&scene.polychrome_sprites[range]))
+                }
+                PrimitiveBatch::Surfaces(_)
+                | PrimitiveBatch::ExternalSurfaces(_)
+                | PrimitiveBatch::BackdropFilters(_)
+                | PrimitiveBatch::FilterBoundary(_) => {}
+            }
+        }
+        total
+    }
 
-        // Blur is the only thing that needs the offscreen scene texture; allocate it (and the
-        // ping/pong/group targets) lazily so non-blurring apps pay no extra VRAM or blit.
+    /// Records a retained GPUI scene into the supplied host-owned target.
+    ///
+    /// Submit the host encoder before calling this again on the same renderer. GPUI reuses its
+    /// instance and uniform buffers, and the queue uploads for a later frame must not overwrite
+    /// data referenced by an earlier unsubmitted command buffer.
+    pub fn encode(
+        &mut self,
+        scene: &Scene,
+        encoder: &mut wgpu::CommandEncoder,
+        target: WgpuRenderTarget<'_>,
+    ) -> anyhow::Result<RenderStats> {
+        self.encode_scene(scene, encoder, target, false, None)
+    }
+
+    /// Records a scene and samples registered host-owned external surfaces in scene order.
+    pub fn encode_with_external_surfaces(
+        &mut self,
+        scene: &Scene,
+        encoder: &mut wgpu::CommandEncoder,
+        target: WgpuRenderTarget<'_>,
+        registry: &ExternalSurfaceRegistry<WgpuExternalSurface>,
+    ) -> anyhow::Result<RenderStats> {
+        self.encode_scene(scene, encoder, target, false, Some(registry))
+    }
+
+    fn encode_native(
+        &mut self,
+        scene: &Scene,
+        encoder: &mut wgpu::CommandEncoder,
+        target: WgpuRenderTarget<'_>,
+    ) -> anyhow::Result<RenderStats> {
+        self.encode_scene(scene, encoder, target, true, None)
+    }
+
+    fn invalidate_intermediate_textures(&mut self) {
+        if let Some(resources) = self.resources.as_mut() {
+            resources.invalidate_intermediate_textures();
+        }
+    }
+
+    fn encode_scene(
+        &mut self,
+        scene: &Scene,
+        encoder: &mut wgpu::CommandEncoder,
+        target: WgpuRenderTarget<'_>,
+        allow_filters: bool,
+        external_surfaces: Option<&ExternalSurfaceRegistry<WgpuExternalSurface>>,
+    ) -> anyhow::Result<RenderStats> {
+        anyhow::ensure!(
+            target.size.width.0 > 0 && target.size.height.0 > 0,
+            "host render target dimensions must be positive; skip encoding while minimized"
+        );
+        anyhow::ensure!(
+            target.size.width.0 as u32 <= self.max_texture_size
+                && target.size.height.0 as u32 <= self.max_texture_size,
+            "host render target size {:?} exceeds device limit {}",
+            target.size,
+            self.max_texture_size
+        );
+        anyhow::ensure!(
+            target.format == self.config.format,
+            "host target format {:?} does not match renderer format {:?}",
+            target.format,
+            self.config.format
+        );
+        if !allow_filters {
+            anyhow::ensure!(
+                scene.backdrop_filters.is_empty() && scene.filter_boundaries.is_empty(),
+                "backdrop and content filters require a host-provided sampleable background target"
+            );
+        }
+        self.validate_external_surfaces(scene, external_surfaces)?;
+
+        let width = target.size.width.0 as u32;
+        let height = target.size.height.0 as u32;
+        self.update_drawable_size(target.size);
+
+        self.atlas.before_frame();
+        self.ensure_intermediate_textures();
         let use_offscreen =
             !scene.backdrop_filters.is_empty() || !scene.filter_boundaries.is_empty();
         if use_offscreen {
             self.ensure_blur_textures();
         }
-
-        let frame_view = frame
-            .texture
-            .create_view(&wgpu::TextureViewDescriptor::default());
+        self.ensure_host_instance_capacity(self.required_host_instance_bytes(scene))?;
+        self.ensure_surface_uniform_capacity(
+            (scene.surfaces.len() + scene.external_surfaces.len()) as u64,
+        )?;
 
         let gamma_params = GammaParams {
             gamma_ratios: self.rendering_params.gamma_ratios,
@@ -1450,27 +1448,19 @@ impl WgpuRenderer {
             is_bgr: self.is_bgr as u32,
             _pad: 0,
         };
-
         let globals = GlobalParams {
-            viewport_size: [
-                self.surface_config.width as f32,
-                self.surface_config.height as f32,
-            ],
-            premultiplied_alpha: if self.surface_config.alpha_mode
-                == wgpu::CompositeAlphaMode::PreMultiplied
-            {
+            viewport_size: [width as f32, height as f32],
+            premultiplied_alpha: if self.alpha_mode() == wgpu::CompositeAlphaMode::PreMultiplied {
                 1
             } else {
                 0
             },
             pad: 0,
         };
-
         let path_globals = GlobalParams {
             premultiplied_alpha: 0,
             ..globals
         };
-
         {
             let resources = self.resources();
             resources.queue.write_buffer(
@@ -1490,274 +1480,227 @@ impl WgpuRenderer {
             );
         }
 
-        loop {
-            let mut instance_offset: u64 = 0;
-            // Reset the blur-params bump cursor each (re)render of the scene.
-            self.blur_params_slot.set(0);
-            let mut overflow = false;
-
-            let mut encoder =
+        let mut instance_offset = 0;
+        self.blur_params_slot.set(0);
+        self.surface_uniform_slot.set(0);
+        let scene_color_view = if use_offscreen {
+            Some(
                 self.resources()
-                    .device
-                    .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                        label: Some("main_encoder"),
+                    .scene_color_view
+                    .as_ref()
+                    .expect("scene color allocated for filtered scene")
+                    .clone(),
+            )
+        } else {
+            None
+        };
+        let mut current_target = scene_color_view
+            .clone()
+            .unwrap_or_else(|| target.view.clone());
+        let group_views = if use_offscreen {
+            self.resources().group_views.clone()
+        } else {
+            Vec::new()
+        };
+        let mut filter_stack: Vec<(FilterBoundary, wgpu::TextureView, bool)> = Vec::new();
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some(if use_offscreen {
+                "gpui_native_scene"
+            } else {
+                "gpui_host_scene"
+            }),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &current_target,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: if use_offscreen {
+                        wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)
+                    } else {
+                        target.load
+                    },
+                    store: wgpu::StoreOp::Store,
+                },
+                depth_slice: None,
+            })],
+            depth_stencil_attachment: None,
+            ..Default::default()
+        });
+
+        for batch in scene.batches() {
+            let ok = match batch {
+                PrimitiveBatch::Quads(range) => {
+                    self.draw_quads(&scene.quads[range], &mut instance_offset, &mut pass)
+                }
+                PrimitiveBatch::Shadows(range) => {
+                    self.draw_shadows(&scene.shadows[range], &mut instance_offset, &mut pass)
+                }
+                PrimitiveBatch::Paths(range) => {
+                    let paths = &scene.paths[range];
+                    if paths.is_empty() {
+                        continue;
+                    }
+                    drop(pass);
+                    let did_draw =
+                        self.draw_paths_to_intermediate(encoder, paths, &mut instance_offset);
+                    pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                        label: Some("gpui_scene_continued"),
+                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                            view: &current_target,
+                            resolve_target: None,
+                            ops: wgpu::Operations {
+                                load: wgpu::LoadOp::Load,
+                                store: wgpu::StoreOp::Store,
+                            },
+                            depth_slice: None,
+                        })],
+                        depth_stencil_attachment: None,
+                        ..Default::default()
                     });
-
-            // When the scene contains blur filters, render into the offscreen scene texture (so
-            // filters can sample already-painted content mid-frame) and blit to the swapchain at
-            // the end; otherwise render straight to the swapchain. `use_offscreen` and the blur
-            // textures were computed/allocated above.
-            let scene_color_view = if use_offscreen {
-                Some(
-                    self.resources()
-                        .scene_color_view
-                        .as_ref()
-                        .expect("scene_color_view allocated by ensure_blur_textures")
-                        .clone(),
-                )
-            } else {
-                None
-            };
-            // The active render target. While inside a content-filter (`filter`) group it points
-            // at a group texture so the group renders in isolation.
-            let mut current_target = match &scene_color_view {
-                Some(view) => view.clone(),
-                None => frame_view.clone(),
-            };
-            // One group texture per nesting depth; empty when not blurring.
-            let group_views = if use_offscreen {
-                self.resources().group_views.clone()
-            } else {
-                Vec::new()
-            };
-            // (boundary, parent target to composite back into, whether this level is isolated).
-            let mut filter_stack: Vec<(FilterBoundary, wgpu::TextureView, bool)> = Vec::new();
-
-            {
-                let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                    label: Some("main_pass"),
-                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                        view: &current_target,
-                        resolve_target: None,
-                        ops: wgpu::Operations {
-                            load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
-                            store: wgpu::StoreOp::Store,
-                        },
-                        depth_slice: None,
-                    })],
-                    depth_stencil_attachment: None,
-                    ..Default::default()
-                });
-
-                for batch in scene.batches() {
-                    let ok = match batch {
-                        PrimitiveBatch::Quads(range) => {
-                            self.draw_quads(&scene.quads[range], &mut instance_offset, &mut pass)
-                        }
-                        PrimitiveBatch::Shadows(range) => self.draw_shadows(
-                            &scene.shadows[range],
-                            &mut instance_offset,
-                            &mut pass,
-                        ),
-                        PrimitiveBatch::Paths(range) => {
-                            let paths = &scene.paths[range];
-                            if paths.is_empty() {
-                                continue;
-                            }
-
-                            drop(pass);
-
-                            let did_draw = self.draw_paths_to_intermediate(
-                                &mut encoder,
-                                paths,
-                                &mut instance_offset,
-                            );
-
-                            pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                                label: Some("main_pass_continued"),
-                                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                                    view: &current_target,
-                                    resolve_target: None,
-                                    ops: wgpu::Operations {
-                                        load: wgpu::LoadOp::Load,
-                                        store: wgpu::StoreOp::Store,
-                                    },
-                                    depth_slice: None,
-                                })],
-                                depth_stencil_attachment: None,
-                                ..Default::default()
-                            });
-
-                            if did_draw {
-                                self.draw_paths_from_intermediate(
-                                    paths,
-                                    &mut instance_offset,
-                                    &mut pass,
-                                )
-                            } else {
-                                false
-                            }
-                        }
-                        PrimitiveBatch::Underlines(range) => self.draw_underlines(
-                            &scene.underlines[range],
-                            &mut instance_offset,
-                            &mut pass,
-                        ),
-                        PrimitiveBatch::MonochromeSprites { texture_id, range } => self
-                            .draw_monochrome_sprites(
-                                &scene.monochrome_sprites[range],
-                                texture_id,
-                                &mut instance_offset,
-                                &mut pass,
-                            ),
-                        PrimitiveBatch::SubpixelSprites { texture_id, range } => self
-                            .draw_subpixel_sprites(
-                                &scene.subpixel_sprites[range],
-                                texture_id,
-                                &mut instance_offset,
-                                &mut pass,
-                            ),
-                        PrimitiveBatch::PolychromeSprites { texture_id, range } => self
-                            .draw_polychrome_sprites(
-                                &scene.polychrome_sprites[range],
-                                texture_id,
-                                &mut instance_offset,
-                                &mut pass,
-                            ),
-                        PrimitiveBatch::Surfaces(range) => {
-                            self.draw_surfaces(&scene.surfaces[range], &mut pass)
-                        }
-                        PrimitiveBatch::BackdropFilters(range) => {
-                            // Interrupt the current pass, blur the content painted so far behind
-                            // each backdrop's rounded rect, then resume drawing on top.
-                            drop(pass);
-                            for filter in &scene.backdrop_filters[range] {
-                                self.draw_backdrop_filter(&mut encoder, filter, &current_target);
-                            }
-                            pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                                label: Some("main_pass_continued"),
-                                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                                    view: &current_target,
-                                    resolve_target: None,
-                                    ops: wgpu::Operations {
-                                        load: wgpu::LoadOp::Load,
-                                        store: wgpu::StoreOp::Store,
-                                    },
-                                    depth_slice: None,
-                                })],
-                                depth_stencil_attachment: None,
-                                ..Default::default()
-                            });
-                            true
-                        }
-                        PrimitiveBatch::FilterBoundary(ix) => {
-                            let boundary = scene.filter_boundaries[ix].clone();
-                            if boundary.is_start {
-                                // Each isolated nesting level uses its own group texture from the
-                                // pool (indexed by current isolation depth). Beyond the pool size
-                                // (MAX_FILTER_DEPTH) deeper filters render inline without isolation
-                                // rather than corrupting an outer group.
-                                let depth = filter_stack.iter().filter(|entry| entry.2).count();
-                                if depth < group_views.len() {
-                                    drop(pass);
-                                    let parent = current_target.clone();
-                                    current_target = group_views[depth].clone();
-                                    filter_stack.push((boundary, parent, true));
-                                    pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                                        label: Some("filter_group"),
-                                        color_attachments: &[Some(
-                                            wgpu::RenderPassColorAttachment {
-                                                view: &current_target,
-                                                resolve_target: None,
-                                                ops: wgpu::Operations {
-                                                    load: wgpu::LoadOp::Clear(
-                                                        wgpu::Color::TRANSPARENT,
-                                                    ),
-                                                    store: wgpu::StoreOp::Store,
-                                                },
-                                                depth_slice: None,
-                                            },
-                                        )],
-                                        depth_stencil_attachment: None,
-                                        ..Default::default()
-                                    });
-                                } else {
-                                    filter_stack.push((boundary, current_target.clone(), false));
-                                }
-                            } else if let Some((boundary, parent, isolated)) = filter_stack.pop() {
-                                if isolated {
-                                    drop(pass);
-                                    self.blur_and_composite(
-                                        &mut encoder,
-                                        &current_target,
-                                        &parent,
-                                        boundary.bounds,
-                                        boundary.content_mask.bounds,
-                                        [
-                                            boundary.corner_radii.top_left.0,
-                                            boundary.corner_radii.top_right.0,
-                                            boundary.corner_radii.bottom_right.0,
-                                            boundary.corner_radii.bottom_left.0,
-                                        ],
-                                        max_blur_radius(&boundary.filters),
-                                        boundary.opacity,
-                                        false,
-                                    );
-                                    current_target = parent;
-                                    pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                                        label: Some("main_pass_continued"),
-                                        color_attachments: &[Some(
-                                            wgpu::RenderPassColorAttachment {
-                                                view: &current_target,
-                                                resolve_target: None,
-                                                ops: wgpu::Operations {
-                                                    load: wgpu::LoadOp::Load,
-                                                    store: wgpu::StoreOp::Store,
-                                                },
-                                                depth_slice: None,
-                                            },
-                                        )],
-                                        depth_stencil_attachment: None,
-                                        ..Default::default()
-                                    });
-                                }
-                            }
-                            true
-                        }
-                    };
-                    if !ok {
-                        overflow = true;
-                        break;
+                    if did_draw {
+                        self.draw_paths_from_intermediate(paths, &mut instance_offset, &mut pass)
+                    } else {
+                        false
                     }
                 }
-            }
-
-            if overflow {
-                drop(encoder);
-                if self.instance_buffer_capacity >= self.max_buffer_size {
-                    log::error!(
-                        "instance buffer size grew too large: {}",
-                        self.instance_buffer_capacity
-                    );
-                    frame.present();
-                    return true;
+                PrimitiveBatch::Underlines(range) => {
+                    self.draw_underlines(&scene.underlines[range], &mut instance_offset, &mut pass)
                 }
-                self.grow_instance_buffer();
-                continue;
+                PrimitiveBatch::MonochromeSprites { texture_id, range } => self
+                    .draw_monochrome_sprites(
+                        &scene.monochrome_sprites[range],
+                        texture_id,
+                        &mut instance_offset,
+                        &mut pass,
+                    ),
+                PrimitiveBatch::SubpixelSprites { texture_id, range } => self
+                    .draw_subpixel_sprites(
+                        &scene.subpixel_sprites[range],
+                        texture_id,
+                        &mut instance_offset,
+                        &mut pass,
+                    ),
+                PrimitiveBatch::PolychromeSprites { texture_id, range } => self
+                    .draw_polychrome_sprites(
+                        &scene.polychrome_sprites[range],
+                        texture_id,
+                        &mut instance_offset,
+                        &mut pass,
+                    ),
+                PrimitiveBatch::Surfaces(range) => {
+                    self.draw_surfaces(&scene.surfaces[range], &mut pass)
+                }
+                PrimitiveBatch::ExternalSurfaces(range) => {
+                    let registry = external_surfaces
+                        .expect("external surfaces were validated before encoding");
+                    self.draw_external_surfaces(
+                        &scene.external_surfaces[range],
+                        registry,
+                        &mut pass,
+                    )?;
+                    true
+                }
+                PrimitiveBatch::BackdropFilters(range) => {
+                    drop(pass);
+                    for filter in &scene.backdrop_filters[range] {
+                        self.draw_backdrop_filter(encoder, filter, &current_target);
+                    }
+                    pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                        label: Some("gpui_scene_continued"),
+                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                            view: &current_target,
+                            resolve_target: None,
+                            ops: wgpu::Operations {
+                                load: wgpu::LoadOp::Load,
+                                store: wgpu::StoreOp::Store,
+                            },
+                            depth_slice: None,
+                        })],
+                        depth_stencil_attachment: None,
+                        ..Default::default()
+                    });
+                    true
+                }
+                PrimitiveBatch::FilterBoundary(ix) => {
+                    let boundary = scene.filter_boundaries[ix].clone();
+                    if boundary.is_start {
+                        let depth = filter_stack.iter().filter(|entry| entry.2).count();
+                        if depth < group_views.len() {
+                            drop(pass);
+                            let parent = current_target.clone();
+                            current_target = group_views[depth].clone();
+                            filter_stack.push((boundary, parent, true));
+                            pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                                label: Some("gpui_filter_group"),
+                                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                                    view: &current_target,
+                                    resolve_target: None,
+                                    ops: wgpu::Operations {
+                                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                                        store: wgpu::StoreOp::Store,
+                                    },
+                                    depth_slice: None,
+                                })],
+                                depth_stencil_attachment: None,
+                                ..Default::default()
+                            });
+                        } else {
+                            filter_stack.push((boundary, current_target.clone(), false));
+                        }
+                    } else if let Some((boundary, parent, isolated)) = filter_stack.pop() {
+                        if isolated {
+                            drop(pass);
+                            self.blur_and_composite(
+                                encoder,
+                                &current_target,
+                                &parent,
+                                boundary.bounds,
+                                boundary.content_mask.bounds,
+                                [
+                                    boundary.corner_radii.top_left.0,
+                                    boundary.corner_radii.top_right.0,
+                                    boundary.corner_radii.bottom_right.0,
+                                    boundary.corner_radii.bottom_left.0,
+                                ],
+                                max_blur_radius(&boundary.filters),
+                                boundary.opacity,
+                                false,
+                            );
+                            current_target = parent;
+                            pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                                label: Some("gpui_scene_continued"),
+                                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                                    view: &current_target,
+                                    resolve_target: None,
+                                    ops: wgpu::Operations {
+                                        load: wgpu::LoadOp::Load,
+                                        store: wgpu::StoreOp::Store,
+                                    },
+                                    depth_slice: None,
+                                })],
+                                depth_stencil_attachment: None,
+                                ..Default::default()
+                            });
+                        }
+                    }
+                    true
+                }
+            };
+            if !ok {
+                drop(pass);
+                return Err(anyhow::anyhow!(
+                    "GPUI host scene exceeded its instance-buffer capacity"
+                ));
             }
-
-            // Present the offscreen scene by copying it into the swapchain texture. Skipped when
-            // rendering went straight to the swapchain (no filters this frame).
-            if let Some(scene_color_view) = &scene_color_view {
-                self.blit_to_frame(&mut encoder, scene_color_view, &frame_view);
-            }
-
-            self.resources()
-                .queue
-                .submit(std::iter::once(encoder.finish()));
-            frame.present();
-            return true;
         }
+        drop(pass);
+
+        if let Some(scene_color_view) = &scene_color_view {
+            self.blit_to_frame(encoder, scene_color_view, target.view);
+        }
+
+        Ok(RenderStats {
+            instance_bytes: instance_offset,
+        })
     }
 
     fn draw_quads(
@@ -1854,48 +1797,19 @@ impl WgpuRenderer {
 
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     fn draw_surfaces(&self, surfaces: &[PaintSurface], pass: &mut wgpu::RenderPass<'_>) -> bool {
-        let resources = self.resources();
         for surface in surfaces {
             let Some(wgpu_texture) = surface.texture.downcast_ref::<wgpu::Texture>() else {
                 continue;
             };
 
             let texture_view = wgpu_texture.create_view(&wgpu::TextureViewDescriptor::default());
-
             let params = SurfaceParams {
                 bounds: surface.bounds.into(),
                 content_mask: surface.content_mask.bounds.into(),
             };
-
-            resources.queue.write_buffer(
-                &resources.surface_uniform_buffer,
-                0,
-                bytemuck::bytes_of(&params),
-            );
-
-            let bind_group = resources
-                .device
-                .create_bind_group(&wgpu::BindGroupDescriptor {
-                    label: Some("surface_bind_group"),
-                    layout: &resources.bind_group_layouts.surfaces,
-                    entries: &[
-                        wgpu::BindGroupEntry {
-                            binding: 0,
-                            resource: resources.surface_uniform_buffer.as_entire_binding(),
-                        },
-                        wgpu::BindGroupEntry {
-                            binding: 1,
-                            resource: wgpu::BindingResource::TextureView(&texture_view),
-                        },
-                        wgpu::BindGroupEntry {
-                            binding: 2,
-                            resource: wgpu::BindingResource::Sampler(&resources.surface_sampler),
-                        },
-                    ],
-                });
-
-            pass.set_pipeline(&resources.pipelines.surfaces);
-            pass.set_bind_group(0, &resources.globals_bind_group, &[]);
+            let bind_group = self.make_surface_bind_group(&params, &texture_view);
+            pass.set_pipeline(&self.resources().pipelines.surfaces);
+            pass.set_bind_group(0, &self.resources().globals_bind_group, &[]);
             pass.set_bind_group(1, &bind_group, &[]);
             pass.draw(0..4, 0..1);
         }
@@ -1905,6 +1819,122 @@ impl WgpuRenderer {
     #[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
     fn draw_surfaces(&self, _surfaces: &[PaintSurface], _pass: &mut wgpu::RenderPass<'_>) -> bool {
         true
+    }
+
+    fn make_surface_bind_group(
+        &self,
+        params: &SurfaceParams,
+        texture_view: &wgpu::TextureView,
+    ) -> wgpu::BindGroup {
+        let resources = self.resources();
+        let slot = self.surface_uniform_slot.get();
+        debug_assert!(slot < self.surface_uniform_capacity);
+        self.surface_uniform_slot.set(slot + 1);
+        let offset = slot * self.surface_uniform_stride;
+        resources.queue.write_buffer(
+            &resources.surface_uniform_buffer,
+            offset,
+            bytemuck::bytes_of(params),
+        );
+        resources
+            .device
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("surface_bind_group"),
+                layout: &resources.bind_group_layouts.surfaces,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                            buffer: &resources.surface_uniform_buffer,
+                            offset,
+                            size: Some(
+                                NonZeroU64::new(std::mem::size_of::<SurfaceParams>() as u64)
+                                    .unwrap(),
+                            ),
+                        }),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::TextureView(texture_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: wgpu::BindingResource::Sampler(&resources.surface_sampler),
+                    },
+                ],
+            })
+    }
+
+    fn validate_external_surfaces(
+        &mut self,
+        scene: &Scene,
+        registry: Option<&ExternalSurfaceRegistry<WgpuExternalSurface>>,
+    ) -> anyhow::Result<()> {
+        if scene.external_surfaces.is_empty() {
+            return Ok(());
+        }
+        let registry = registry.ok_or_else(|| {
+            anyhow::anyhow!(
+                "GPUI scene contains {} external surfaces but no external-surface registry was supplied",
+                scene.external_surfaces.len()
+            )
+        })?;
+        for surface in &scene.external_surfaces {
+            anyhow::ensure!(
+                registry.get(surface.id).is_some(),
+                "missing external surface ID {}",
+                surface.id.value()
+            );
+            if self.external_surfaces_need_replacement {
+                if let Some(previous_generation) =
+                    self.external_surface_generations.get(&surface.id)
+                {
+                    let current_generation = registry
+                        .generation(surface.id)
+                        .expect("external surface was validated before reading its generation");
+                    anyhow::ensure!(
+                        current_generation > *previous_generation,
+                        "external surface ID {} must be replaced after GPU recovery",
+                        surface.id.value()
+                    );
+                }
+            }
+        }
+        self.external_surface_generations = scene
+            .external_surfaces
+            .iter()
+            .filter_map(|surface| {
+                registry
+                    .generation(surface.id)
+                    .map(|generation| (surface.id, generation))
+            })
+            .collect();
+        self.external_surfaces_need_replacement = false;
+        Ok(())
+    }
+
+    fn draw_external_surfaces(
+        &self,
+        surfaces: &[ExternalSurface],
+        registry: &ExternalSurfaceRegistry<WgpuExternalSurface>,
+        pass: &mut wgpu::RenderPass<'_>,
+    ) -> anyhow::Result<()> {
+        for surface in surfaces {
+            let resource = registry
+                .get(surface.id)
+                .expect("external surfaces were validated before encoding");
+            let params = SurfaceParams {
+                bounds: surface.bounds.into(),
+                content_mask: surface.content_mask.bounds.into(),
+            };
+            let bind_group = self.make_surface_bind_group(&params, &resource.view);
+            let resources = self.resources();
+            pass.set_pipeline(&resources.pipelines.surfaces);
+            pass.set_bind_group(0, &resources.globals_bind_group, &[]);
+            pass.set_bind_group(1, &bind_group, &[]);
+            pass.draw(0..4, 0..1);
+        }
+        Ok(())
     }
 
     /// Build a bind group for a blur pass. Writes `params` into the next slot of the shared
@@ -2014,8 +2044,8 @@ impl WgpuRenderer {
         let ideal_taps = (3.0 * sigma).ceil();
         let tap_count = ideal_taps.clamp(1.0, 32.0);
         let tap_step = (ideal_taps / tap_count).max(1.0);
-        let full_w = self.surface_config.width;
-        let full_h = self.surface_config.height;
+        let full_w = self.config.size.width.0.max(1) as u32;
+        let full_h = self.config.size.height.0.max(1) as u32;
         let blur_width = (full_w / 2).max(1) as f32;
         let blur_height = (full_h / 2).max(1) as f32;
 
@@ -2445,175 +2475,6 @@ impl WgpuRenderer {
             size: Some(size),
         })
     }
-
-    /// Mark the surface as unconfigured so rendering is skipped until a new
-    /// surface is provided via [`replace_surface`](Self::replace_surface).
-    ///
-    /// This does **not** drop the renderer — the device, queue, atlas, and
-    /// pipelines stay alive.  Use this when the native window is destroyed
-    /// (e.g. Android `TerminateWindow`) but you intend to re-create the
-    /// surface later without losing cached atlas textures.
-    pub fn unconfigure_surface(&mut self) {
-        self.surface_configured = false;
-        // Drop intermediate textures since they reference the old surface size.
-        if let Some(res) = self.resources.as_mut() {
-            res.invalidate_intermediate_textures();
-        }
-    }
-
-    /// Replace the wgpu surface with a new one (e.g. after Android destroys
-    /// and recreates the native window).  Keeps the device, queue, atlas, and
-    /// all pipelines intact so cached `AtlasTextureId`s remain valid.
-    ///
-    /// The `instance` **must** be the same [`wgpu::Instance`] that was used to
-    /// create the adapter and device (i.e. from the [`WgpuContext`]).  Using a
-    /// different instance will cause a "Device does not exist" panic because
-    /// the wgpu device is bound to its originating instance.
-    #[cfg(not(target_family = "wasm"))]
-    pub fn replace_surface<W: HasWindowHandle>(
-        &mut self,
-        window: &W,
-        config: WgpuSurfaceConfig,
-        instance: &wgpu::Instance,
-    ) -> anyhow::Result<()> {
-        let window_handle = window
-            .window_handle()
-            .map_err(|e| anyhow::anyhow!("Failed to get window handle: {e}"))?;
-
-        let surface = create_surface(instance, window_handle.as_raw())?;
-
-        let width = (config.size.width.0 as u32).max(1);
-        let height = (config.size.height.0 as u32).max(1);
-
-        let alpha_mode = if config.transparent {
-            self.transparent_alpha_mode
-        } else {
-            self.opaque_alpha_mode
-        };
-
-        self.surface_config.width = width;
-        self.surface_config.height = height;
-        self.surface_config.alpha_mode = alpha_mode;
-        if let Some(mode) = config.preferred_present_mode {
-            self.surface_config.present_mode = mode;
-        }
-
-        {
-            let res = self
-                .resources
-                .as_mut()
-                .expect("GPU resources not available");
-            surface.configure(&res.device, &self.surface_config);
-            res.surface = surface;
-
-            // Invalidate intermediate textures — they'll be recreated lazily.
-            res.invalidate_intermediate_textures();
-        }
-
-        self.surface_configured = true;
-
-        Ok(())
-    }
-
-    pub fn destroy(&mut self) {
-        // Release surface-bound GPU resources eagerly so the underlying native
-        // window can be destroyed before the renderer itself is dropped.
-        self.resources.take();
-    }
-
-    /// Returns true if the GPU device was lost and recovery is needed.
-    pub fn device_lost(&self) -> bool {
-        self.device_lost.load(std::sync::atomic::Ordering::SeqCst)
-    }
-
-    /// Returns true if a redraw is needed because GPU state was cleared.
-    /// Calling this method clears the flag.
-    pub fn needs_redraw(&mut self) -> bool {
-        std::mem::take(&mut self.needs_redraw)
-    }
-
-    /// Recovers from a lost GPU device by recreating the renderer with a new context.
-    ///
-    /// Call this after detecting `device_lost()` returns true.
-    ///
-    /// This method coordinates recovery across multiple windows:
-    /// - The first window to call this will recreate the shared context
-    /// - Subsequent windows will adopt the already-recovered context
-    #[cfg(not(target_family = "wasm"))]
-    pub fn recover<W>(&mut self, window: &W) -> anyhow::Result<()>
-    where
-        W: HasWindowHandle + HasDisplayHandle + std::fmt::Debug + Send + Sync + Clone + 'static,
-    {
-        let gpu_context = self.context.as_ref().expect("recover requires gpu_context");
-
-        // Check if another window already recovered the context
-        let needs_new_context = gpu_context
-            .borrow()
-            .as_ref()
-            .is_none_or(|ctx| ctx.device_lost());
-
-        let window_handle = window
-            .window_handle()
-            .map_err(|e| anyhow::anyhow!("Failed to get window handle: {e}"))?;
-
-        let surface = if needs_new_context {
-            log::warn!("GPU device lost, recreating context...");
-
-            // Drop old resources to release Arc<Device>/Arc<Queue> and GPU resources
-            self.resources = None;
-            *gpu_context.borrow_mut() = None;
-
-            // Wait briefly for the GPU driver to stabilize, then try to
-            // recreate the context without software renderers. If this fails
-            // the caller should request another frame and retry — the real GPU
-            // may need more time to come back (e.g. after suspend/resume).
-            std::thread::sleep(std::time::Duration::from_millis(350));
-
-            let instance = WgpuContext::instance(Box::new(window.clone()));
-            let surface = create_surface(&instance, window_handle.as_raw())?;
-            let new_context = WgpuContext::new_rejecting_software(
-                instance,
-                &surface,
-                self.compositor_gpu,
-                self.extra_requirements.as_ref(),
-            )?;
-            *gpu_context.borrow_mut() = Some(new_context);
-            surface
-        } else {
-            let ctx_ref = gpu_context.borrow();
-            let instance = &ctx_ref.as_ref().unwrap().instance;
-            create_surface(instance, window_handle.as_raw())?
-        };
-
-        let config = WgpuSurfaceConfig {
-            size: gpui::Size {
-                width: gpui::DevicePixels(self.surface_config.width as i32),
-                height: gpui::DevicePixels(self.surface_config.height as i32),
-            },
-            transparent: self.surface_config.alpha_mode != wgpu::CompositeAlphaMode::Opaque,
-            preferred_present_mode: Some(self.surface_config.present_mode),
-        };
-        let gpu_context = Rc::clone(gpu_context);
-        let ctx_ref = gpu_context.borrow();
-        let context = ctx_ref.as_ref().expect("context should exist");
-
-        self.resources = None;
-        self.atlas.handle_device_lost(context);
-
-        let extra_reqs = self.extra_requirements.clone();
-        *self = Self::new_internal(
-            Some(gpu_context.clone()),
-            context,
-            surface,
-            config,
-            self.compositor_gpu,
-            extra_reqs,
-            self.atlas.clone(),
-        )?;
-
-        log::info!("GPU recovery complete");
-        Ok(())
-    }
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -2629,6 +2490,487 @@ fn create_surface(
                 raw_window_handle,
             })
             .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+}
+
+/// Native surface wrapper around [`WgpuSceneRenderer`].
+///
+/// This type owns surface acquisition, configuration, submission, presentation, and native GPU
+/// recovery. The reusable scene renderer below it only owns GPUI GPU resources and command
+/// encoding.
+pub struct WgpuRenderer {
+    context: Option<GpuContext>,
+    compositor_gpu: Option<CompositorGpuHint>,
+    extra_requirements: Option<WgpuDeviceRequirements>,
+    scene: WgpuSceneRenderer,
+    surface: Option<wgpu::Surface<'static>>,
+    surface_config: wgpu::SurfaceConfiguration,
+    transparent_alpha_mode: wgpu::CompositeAlphaMode,
+    opaque_alpha_mode: wgpu::CompositeAlphaMode,
+    last_error: Arc<Mutex<Option<String>>>,
+    failed_frame_count: u32,
+    device_lost: Arc<std::sync::atomic::AtomicBool>,
+    surface_configured: bool,
+    needs_redraw: bool,
+}
+
+impl WgpuRenderer {
+    /// Creates a native surface-backed renderer from raw window handles.
+    #[cfg(not(target_family = "wasm"))]
+    pub fn new<W>(
+        gpu_context: GpuContext,
+        window: &W,
+        config: WgpuSurfaceConfig,
+        compositor_gpu: Option<CompositorGpuHint>,
+        extra_requirements: Option<WgpuDeviceRequirements>,
+    ) -> anyhow::Result<Self>
+    where
+        W: HasWindowHandle + HasDisplayHandle + std::fmt::Debug + Send + Sync + Clone + 'static,
+    {
+        let window_handle = window
+            .window_handle()
+            .map_err(|e| anyhow::anyhow!("Failed to get window handle: {e}"))?;
+        let target = wgpu::SurfaceTargetUnsafe::RawHandle {
+            raw_display_handle: None,
+            raw_window_handle: window_handle.as_raw(),
+        };
+        let instance = gpu_context
+            .borrow()
+            .as_ref()
+            .map(|ctx| ctx.instance.clone())
+            .unwrap_or_else(|| WgpuContext::instance(Box::new(window.clone())));
+        let surface = unsafe {
+            instance
+                .create_surface_unsafe(target)
+                .map_err(|e| anyhow::anyhow!("Failed to create surface: {e}"))?
+        };
+        let mut ctx_ref = gpu_context.borrow_mut();
+        let context = match ctx_ref.as_mut() {
+            Some(context) => {
+                context.check_compatible_with_surface(&surface)?;
+                context
+            }
+            None => ctx_ref.insert(WgpuContext::new(
+                instance,
+                &surface,
+                compositor_gpu,
+                extra_requirements.as_ref(),
+            )?),
+        };
+        let atlas = Arc::new(WgpuAtlas::from_context(context));
+        Self::new_internal(
+            Some(Rc::clone(&gpu_context)),
+            context,
+            surface,
+            config,
+            compositor_gpu,
+            extra_requirements,
+            atlas,
+        )
+    }
+
+    /// Creates a surface-backed renderer for a web canvas.
+    #[cfg(target_family = "wasm")]
+    pub fn new_from_canvas(
+        context: &WgpuContext,
+        canvas: &web_sys::HtmlCanvasElement,
+        config: WgpuSurfaceConfig,
+    ) -> anyhow::Result<Self> {
+        let surface = context
+            .instance
+            .create_surface(wgpu::SurfaceTarget::Canvas(canvas.clone()))
+            .map_err(|e| anyhow::anyhow!("Failed to create surface: {e}"))?;
+        let atlas = Arc::new(WgpuAtlas::from_context(context));
+        Self::new_internal(None, context, surface, config, None, None, atlas)
+    }
+
+    fn new_internal(
+        context_handle: Option<GpuContext>,
+        context: &WgpuContext,
+        surface: wgpu::Surface<'static>,
+        config: WgpuSurfaceConfig,
+        compositor_gpu: Option<CompositorGpuHint>,
+        extra_requirements: Option<WgpuDeviceRequirements>,
+        atlas: Arc<WgpuAtlas>,
+    ) -> anyhow::Result<Self> {
+        let surface_caps = surface.get_capabilities(&context.adapter);
+        let preferred_formats = [
+            wgpu::TextureFormat::Bgra8Unorm,
+            wgpu::TextureFormat::Rgba8Unorm,
+        ];
+        let surface_format = preferred_formats
+            .iter()
+            .find(|format| surface_caps.formats.contains(format))
+            .copied()
+            .or_else(|| {
+                surface_caps
+                    .formats
+                    .iter()
+                    .find(|format| !format.is_srgb())
+                    .copied()
+            })
+            .or_else(|| surface_caps.formats.first().copied())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Surface reports no supported texture formats for adapter {:?}",
+                    context.adapter.get_info().name
+                )
+            })?;
+        let pick_alpha_mode =
+            |preferences: &[wgpu::CompositeAlphaMode]| -> anyhow::Result<wgpu::CompositeAlphaMode> {
+                preferences
+                    .iter()
+                    .find(|mode| surface_caps.alpha_modes.contains(mode))
+                    .copied()
+                    .or_else(|| surface_caps.alpha_modes.first().copied())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Surface reports no supported alpha modes for adapter {:?}",
+                            context.adapter.get_info().name
+                        )
+                    })
+            };
+        let transparent_alpha_mode = pick_alpha_mode(&[
+            wgpu::CompositeAlphaMode::PreMultiplied,
+            wgpu::CompositeAlphaMode::Inherit,
+        ])?;
+        let opaque_alpha_mode = pick_alpha_mode(&[
+            wgpu::CompositeAlphaMode::Opaque,
+            wgpu::CompositeAlphaMode::Inherit,
+        ])?;
+        let alpha_mode = if config.transparent {
+            transparent_alpha_mode
+        } else {
+            opaque_alpha_mode
+        };
+        let max_texture_size = context.device.limits().max_texture_dimension_2d;
+        let requested_width = config.size.width.0.max(0) as u32;
+        let requested_height = config.size.height.0.max(0) as u32;
+        let width = requested_width.min(max_texture_size).max(1);
+        let height = requested_height.min(max_texture_size).max(1);
+        let surface_config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format: surface_format,
+            width,
+            height,
+            present_mode: config
+                .preferred_present_mode
+                .filter(|mode| surface_caps.present_modes.contains(mode))
+                .unwrap_or(wgpu::PresentMode::Fifo),
+            desired_maximum_frame_latency: 2,
+            alpha_mode,
+            view_formats: vec![],
+        };
+        surface.configure(&context.device, &surface_config);
+        let scene = WgpuSceneRenderer::from_parts(
+            &context.adapter,
+            context.device.clone(),
+            context.queue.clone(),
+            WgpuSceneRendererConfig {
+                size: Size {
+                    width: DevicePixels(width as i32),
+                    height: DevicePixels(height as i32),
+                },
+                format: surface_format,
+                transparent: alpha_mode == wgpu::CompositeAlphaMode::PreMultiplied,
+            },
+            atlas,
+        )?;
+        let last_error = Arc::new(Mutex::new(None));
+        scene.install_error_handler(last_error.clone());
+        Ok(Self {
+            context: context_handle,
+            compositor_gpu,
+            extra_requirements,
+            scene,
+            surface: Some(surface),
+            surface_config,
+            transparent_alpha_mode,
+            opaque_alpha_mode,
+            last_error,
+            failed_frame_count: 0,
+            device_lost: context.device_lost_flag(),
+            surface_configured: true,
+            needs_redraw: false,
+        })
+    }
+
+    /// Encodes the scene into the current surface and submits/presents it.
+    pub fn draw(&mut self, scene: &Scene) -> bool {
+        if !self.surface_configured {
+            return false;
+        }
+        if let Some(error) = self.last_error.lock().unwrap().take() {
+            self.failed_frame_count += 1;
+            log::error!(
+                "GPU error during frame (failure {} of 10): {error}",
+                self.failed_frame_count
+            );
+            if self.failed_frame_count > 10 {
+                panic!("Too many consecutive GPU errors. Last error: {error}");
+            }
+            if self.failed_frame_count > 5 {
+                self.scene.invalidate_intermediate_textures();
+                self.scene.atlas.clear();
+                self.needs_redraw = true;
+                self.failed_frame_count = 0;
+                return false;
+            }
+        } else {
+            self.failed_frame_count = 0;
+        }
+
+        let frame = match self
+            .surface
+            .as_ref()
+            .expect("GPU surface not available")
+            .get_current_texture()
+        {
+            wgpu::CurrentSurfaceTexture::Success(frame) => frame,
+            wgpu::CurrentSurfaceTexture::Suboptimal(frame) => {
+                drop(frame);
+                self.configure_surface();
+                return false;
+            }
+            wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated => {
+                self.configure_surface();
+                return false;
+            }
+            wgpu::CurrentSurfaceTexture::Timeout | wgpu::CurrentSurfaceTexture::Occluded => {
+                return false;
+            }
+            wgpu::CurrentSurfaceTexture::Validation => {
+                *self.last_error.lock().unwrap() = Some("Surface texture validation error".into());
+                return false;
+            }
+        };
+        let view = frame
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let (device, queue) = self.scene.gpu_context();
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("main_encoder"),
+        });
+        let target = WgpuRenderTarget {
+            view: &view,
+            size: Size {
+                width: DevicePixels(self.surface_config.width as i32),
+                height: DevicePixels(self.surface_config.height as i32),
+            },
+            format: self.surface_config.format,
+            load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+        };
+        let result = self.scene.encode_native(scene, &mut encoder, target);
+        match result {
+            Ok(_) => {
+                queue.submit(Some(encoder.finish()));
+                frame.present();
+                true
+            }
+            Err(error) => {
+                log::error!("failed to encode GPUI scene: {error:#}");
+                frame.present();
+                false
+            }
+        }
+    }
+
+    fn configure_surface(&self) {
+        if let (Some(surface), Some(resources)) = (&self.surface, &self.scene.resources) {
+            surface.configure(&resources.device, &self.surface_config);
+        }
+    }
+
+    /// Updates the surface and scene target dimensions.
+    pub fn update_drawable_size(&mut self, size: Size<DevicePixels>) {
+        let width = size.width.0.max(0) as u32;
+        let height = size.height.0.max(0) as u32;
+        let width = width.min(self.scene.max_texture_size()).max(1);
+        let height = height.min(self.scene.max_texture_size()).max(1);
+        if self.surface_config.width == width && self.surface_config.height == height {
+            return;
+        }
+        self.surface_config.width = width;
+        self.surface_config.height = height;
+        self.scene.update_drawable_size(Size {
+            width: DevicePixels(width as i32),
+            height: DevicePixels(height as i32),
+        });
+        self.configure_surface();
+    }
+
+    /// Updates surface alpha mode and rebuilds the scene pipelines.
+    pub fn update_transparency(&mut self, transparent: bool) {
+        let alpha_mode = if transparent {
+            self.transparent_alpha_mode
+        } else {
+            self.opaque_alpha_mode
+        };
+        if self.surface_config.alpha_mode == alpha_mode {
+            return;
+        }
+        self.surface_config.alpha_mode = alpha_mode;
+        self.scene
+            .update_transparency(alpha_mode == wgpu::CompositeAlphaMode::PreMultiplied);
+        self.configure_surface();
+    }
+
+    /// Returns the GPUI atlas shared with the platform window.
+    pub fn sprite_atlas(&self) -> &Arc<WgpuAtlas> {
+        self.scene.sprite_atlas()
+    }
+
+    /// Returns GPU information for the platform layer.
+    pub fn gpu_specs(&self) -> GpuSpecs {
+        self.scene.gpu_specs()
+    }
+
+    /// Returns the device and queue used by the native renderer.
+    pub fn gpu_context(&self) -> (Arc<wgpu::Device>, Arc<wgpu::Queue>) {
+        self.scene.gpu_context()
+    }
+
+    /// Returns the largest supported 2D texture dimension.
+    pub fn max_texture_size(&self) -> u32 {
+        self.scene.max_texture_size()
+    }
+
+    /// Selects the subpixel text channel layout used by the native target.
+    pub fn set_subpixel_layout(&mut self, is_bgr: bool) {
+        self.scene.set_subpixel_layout(is_bgr);
+    }
+
+    /// Returns whether dual-source text blending is enabled.
+    pub fn supports_dual_source_blending(&self) -> bool {
+        self.scene.supports_dual_source_blending()
+    }
+
+    /// Marks the native surface unavailable until it is replaced.
+    pub fn unconfigure_surface(&mut self) {
+        self.surface_configured = false;
+        self.scene.invalidate_intermediate_textures();
+    }
+
+    /// Replaces the native surface while preserving the scene renderer and atlas.
+    #[cfg(not(target_family = "wasm"))]
+    pub fn replace_surface<W: HasWindowHandle>(
+        &mut self,
+        window: &W,
+        config: WgpuSurfaceConfig,
+        instance: &wgpu::Instance,
+    ) -> anyhow::Result<()> {
+        let handle = window
+            .window_handle()
+            .map_err(|e| anyhow::anyhow!("Failed to get window handle: {e}"))?;
+        let surface = create_surface(instance, handle.as_raw())?;
+        let alpha_mode = if config.transparent {
+            self.transparent_alpha_mode
+        } else {
+            self.opaque_alpha_mode
+        };
+        let width = config.size.width.0.max(0) as u32;
+        let height = config.size.height.0.max(0) as u32;
+        self.surface_config.width = width.min(self.scene.max_texture_size()).max(1);
+        self.surface_config.height = height.min(self.scene.max_texture_size()).max(1);
+        self.surface_config.alpha_mode = alpha_mode;
+        if let Some(mode) = config.preferred_present_mode {
+            self.surface_config.present_mode = mode;
+        }
+        self.surface = Some(surface);
+        self.scene
+            .update_transparency(alpha_mode == wgpu::CompositeAlphaMode::PreMultiplied);
+        self.scene.update_drawable_size(Size {
+            width: DevicePixels(self.surface_config.width as i32),
+            height: DevicePixels(self.surface_config.height as i32),
+        });
+        self.configure_surface();
+        self.surface_configured = true;
+        Ok(())
+    }
+
+    /// Releases GPU resources before destroying the native window.
+    pub fn destroy(&mut self) {
+        self.scene.resources = None;
+        self.surface = None;
+    }
+
+    /// Returns whether the native renderer requested another frame after an error.
+    pub fn needs_redraw(&mut self) -> bool {
+        std::mem::take(&mut self.needs_redraw)
+    }
+
+    /// Returns whether the shared native GPU context reported device loss.
+    pub fn device_lost(&self) -> bool {
+        self.device_lost.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Recovers the native device and surface after device loss.
+    #[cfg(not(target_family = "wasm"))]
+    pub fn recover<W>(&mut self, window: &W) -> anyhow::Result<()>
+    where
+        W: HasWindowHandle + HasDisplayHandle + std::fmt::Debug + Send + Sync + Clone + 'static,
+    {
+        let gpu_context = self.context.as_ref().expect("recover requires gpu_context");
+        let needs_new_context = gpu_context
+            .borrow()
+            .as_ref()
+            .is_none_or(|context| context.device_lost());
+        let window_handle = window
+            .window_handle()
+            .map_err(|e| anyhow::anyhow!("Failed to get window handle: {e}"))?;
+        let surface = if needs_new_context {
+            log::warn!("GPU device lost, recreating context...");
+            self.scene.resources = None;
+            *gpu_context.borrow_mut() = None;
+            std::thread::sleep(std::time::Duration::from_millis(350));
+            let instance = WgpuContext::instance(Box::new(window.clone()));
+            let surface = create_surface(&instance, window_handle.as_raw())?;
+            let new_context = WgpuContext::new_rejecting_software(
+                instance,
+                &surface,
+                self.compositor_gpu,
+                self.extra_requirements.as_ref(),
+            )?;
+            *gpu_context.borrow_mut() = Some(new_context);
+            surface
+        } else {
+            let context_ref = gpu_context.borrow();
+            let instance = &context_ref.as_ref().unwrap().instance;
+            create_surface(instance, window_handle.as_raw())?
+        };
+        let surface_config = WgpuSurfaceConfig {
+            size: Size {
+                width: DevicePixels(self.surface_config.width as i32),
+                height: DevicePixels(self.surface_config.height as i32),
+            },
+            transparent: self.surface_config.alpha_mode != wgpu::CompositeAlphaMode::Opaque,
+            preferred_present_mode: Some(self.surface_config.present_mode),
+        };
+        let context_ref = gpu_context.borrow();
+        let context = context_ref.as_ref().expect("context should exist");
+        let atlas = self.scene.atlas.clone();
+        let scene = WgpuSceneRenderer::from_parts(
+            &context.adapter,
+            context.device.clone(),
+            context.queue.clone(),
+            WgpuSceneRendererConfig {
+                size: surface_config.size,
+                format: self.surface_config.format,
+                transparent: surface_config.transparent,
+            },
+            atlas.clone(),
+        )?;
+        atlas.replace_gpu_context(
+            context.device.clone(),
+            context.queue.clone(),
+            self.surface_config.format,
+        );
+        scene.install_error_handler(self.last_error.clone());
+        self.scene = scene;
+        self.surface = Some(surface);
+        self.configure_surface();
+        self.device_lost = context.device_lost_flag();
+        Ok(())
     }
 }
 
@@ -2674,5 +3016,64 @@ impl RenderingParameters {
             grayscale_enhanced_contrast,
             subpixel_enhanced_contrast,
         }
+    }
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use super::*;
+    use gpui::block_on;
+
+    #[test]
+    fn replacement_preserves_atlas_identity_and_renderer_format() -> anyhow::Result<()> {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            flags: wgpu::InstanceFlags::default(),
+            backend_options: wgpu::BackendOptions::default(),
+            memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
+            display: None,
+        });
+        let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            compatible_surface: None,
+            force_fallback_adapter: false,
+        }))
+        .map_err(|error| anyhow::anyhow!("failed to request adapter: {error}"))?;
+        let requirements = WgpuSceneRenderer::requirements(&adapter);
+        let (device, queue) = block_on(
+            adapter.request_device(&wgpu::DeviceDescriptor {
+                label: Some("wgpu_renderer_recovery_test"),
+                required_features: requirements.features,
+                required_limits: wgpu::Limits::downlevel_defaults()
+                    .using_resolution(adapter.limits())
+                    .using_alignment(adapter.limits()),
+                memory_hints: wgpu::MemoryHints::MemoryUsage,
+                trace: wgpu::Trace::Off,
+                experimental_features: wgpu::ExperimentalFeatures::disabled(),
+            }),
+        )
+        .map_err(|error| anyhow::anyhow!("failed to request device: {error}"))?;
+        let device = Arc::new(device);
+        let queue = Arc::new(queue);
+        let format = wgpu::TextureFormat::Rgba8UnormSrgb;
+        let mut renderer = WgpuSceneRenderer::from_host(
+            &adapter,
+            device.clone(),
+            queue.clone(),
+            WgpuSceneRendererConfig {
+                size: Size {
+                    width: DevicePixels(64),
+                    height: DevicePixels(64),
+                },
+                format,
+                transparent: false,
+            },
+        )?;
+        let atlas = renderer.sprite_atlas().clone();
+        renderer.replace_gpu_context(&adapter, device, queue)?;
+
+        assert!(Arc::ptr_eq(&atlas, renderer.sprite_atlas()));
+        assert_eq!(renderer.target_format(), format);
+        Ok(())
     }
 }

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -294,8 +294,7 @@ pub struct WgpuSceneRenderer {
     surface_uniform_stride: u64,
     surface_uniform_capacity: u64,
     surface_uniform_slot: std::cell::Cell<u64>,
-    external_surface_generations: HashMap<ExternalSurfaceId, u64>,
-    external_surfaces_need_replacement: bool,
+    pending_external_surface_replacements: HashMap<ExternalSurfaceId, u64>,
 }
 
 impl WgpuSceneRenderer {
@@ -541,8 +540,7 @@ impl WgpuSceneRenderer {
             surface_uniform_stride,
             surface_uniform_capacity: INITIAL_SURFACE_UNIFORM_SLOTS,
             surface_uniform_slot: std::cell::Cell::new(0),
-            external_surface_generations: HashMap::new(),
-            external_surfaces_need_replacement: false,
+            pending_external_surface_replacements: HashMap::new(),
         })
     }
 
@@ -1215,24 +1213,27 @@ impl WgpuSceneRenderer {
     /// Construction is transactional: the live renderer and its shared atlas remain untouched
     /// until replacement resources have been built successfully. The atlas [`Arc`] itself is
     /// preserved so the GPUI window keeps the same platform-atlas identity. The renderer format
-    /// is fixed for its lifetime; the host must recreate its render targets and replace every
-    /// registered external-surface view after device loss before encoding again.
+    /// is fixed for its lifetime. When an external-surface registry is supplied, its current
+    /// generations are snapshotted and each registered view must be replaced before that ID is
+    /// encoded again. Hosts without external surfaces may pass `None`.
     pub fn replace_gpu_context(
         &mut self,
         adapter: &wgpu::Adapter,
         device: Arc<wgpu::Device>,
         queue: Arc<wgpu::Queue>,
+        external_surfaces: Option<&ExternalSurfaceRegistry<WgpuExternalSurface>>,
     ) -> anyhow::Result<()> {
         let config = self.config;
         Self::validate_host_target_format(adapter, config.format)?;
         let atlas = self.atlas.clone();
-        let previous_external_surface_generations = self.external_surface_generations.clone();
+        let pending_external_surface_replacements = external_surfaces
+            .map(|registry| registry.generations().collect())
+            .unwrap_or_default();
         let replacement_device = device.clone();
         let replacement_queue = queue.clone();
         let mut replacement = Self::from_parts(adapter, device, queue, config, atlas.clone())?;
+        replacement.pending_external_surface_replacements = pending_external_surface_replacements;
         atlas.replace_gpu_context(replacement_device, replacement_queue, config.format);
-        replacement.external_surface_generations = previous_external_surface_generations;
-        replacement.external_surfaces_need_replacement = true;
         *self = replacement;
         Ok(())
     }
@@ -1879,37 +1880,30 @@ impl WgpuSceneRenderer {
                 scene.external_surfaces.len()
             )
         })?;
+        let mut validated_ids = Vec::with_capacity(scene.external_surfaces.len());
         for surface in &scene.external_surfaces {
             anyhow::ensure!(
                 registry.get(surface.id).is_some(),
                 "missing external surface ID {}",
                 surface.id.value()
             );
-            if self.external_surfaces_need_replacement {
-                if let Some(previous_generation) =
-                    self.external_surface_generations.get(&surface.id)
-                {
-                    let current_generation = registry
-                        .generation(surface.id)
-                        .expect("external surface was validated before reading its generation");
-                    anyhow::ensure!(
-                        current_generation > *previous_generation,
-                        "external surface ID {} must be replaced after GPU recovery",
-                        surface.id.value()
-                    );
-                }
+            let current_generation = registry
+                .generation(surface.id)
+                .expect("external surface was validated before reading its generation");
+            if let Some(recovery_generation) =
+                self.pending_external_surface_replacements.get(&surface.id)
+            {
+                anyhow::ensure!(
+                    current_generation > *recovery_generation,
+                    "external surface ID {} must be replaced after GPU recovery",
+                    surface.id.value()
+                );
             }
+            validated_ids.push(surface.id);
         }
-        self.external_surface_generations = scene
-            .external_surfaces
-            .iter()
-            .filter_map(|surface| {
-                registry
-                    .generation(surface.id)
-                    .map(|generation| (surface.id, generation))
-            })
-            .collect();
-        self.external_surfaces_need_replacement = false;
+        for id in validated_ids {
+            self.pending_external_surface_replacements.remove(&id);
+        }
         Ok(())
     }
 
@@ -3024,6 +3018,91 @@ mod tests {
     use super::*;
     use gpui::block_on;
 
+    fn test_external_scene(ids: &[ExternalSurfaceId]) -> Scene {
+        let bounds = Bounds {
+            origin: Point {
+                x: ScaledPixels(0.0),
+                y: ScaledPixels(0.0),
+            },
+            size: Size {
+                width: ScaledPixels(16.0),
+                height: ScaledPixels(16.0),
+            },
+        };
+        let mut scene = Scene::default();
+        for &id in ids {
+            scene.insert_primitive(ExternalSurface {
+                order: 0,
+                bounds,
+                content_mask: gpui::ContentMask { bounds },
+                id,
+            });
+        }
+        scene.finish();
+        scene
+    }
+
+    fn test_external_view(device: &wgpu::Device) -> Arc<wgpu::TextureView> {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("external_surface_recovery_test_view"),
+            size: wgpu::Extent3d {
+                width: 16,
+                height: 16,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8UnormSrgb,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        Arc::new(texture.create_view(&wgpu::TextureViewDescriptor::default()))
+    }
+
+    fn encode_external_scene(
+        renderer: &mut WgpuSceneRenderer,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        scene: &Scene,
+        registry: &ExternalSurfaceRegistry<WgpuExternalSurface>,
+    ) -> anyhow::Result<()> {
+        let target_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("external_surface_recovery_test_target"),
+            size: wgpu::Extent3d {
+                width: 16,
+                height: 16,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8UnormSrgb,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let target_view = target_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("external_surface_recovery_test_encoder"),
+        });
+        renderer.encode_with_external_surfaces(
+            scene,
+            &mut encoder,
+            WgpuRenderTarget {
+                view: &target_view,
+                size: Size {
+                    width: DevicePixels(16),
+                    height: DevicePixels(16),
+                },
+                format: wgpu::TextureFormat::Rgba8UnormSrgb,
+                load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+            },
+            registry,
+        )?;
+        queue.submit(Some(encoder.finish()));
+        Ok(())
+    }
+
     #[test]
     fn replacement_preserves_atlas_identity_and_renderer_format() -> anyhow::Result<()> {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
@@ -3070,10 +3149,135 @@ mod tests {
             },
         )?;
         let atlas = renderer.sprite_atlas().clone();
-        renderer.replace_gpu_context(&adapter, device, queue)?;
+        renderer.replace_gpu_context(&adapter, device, queue, None)?;
 
         assert!(Arc::ptr_eq(&atlas, renderer.sprite_atlas()));
         assert_eq!(renderer.target_format(), format);
+        Ok(())
+    }
+
+    #[test]
+    fn external_surface_recovery_tracks_each_id_until_replaced() -> anyhow::Result<()> {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            flags: wgpu::InstanceFlags::default(),
+            backend_options: wgpu::BackendOptions::default(),
+            memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
+            display: None,
+        });
+        let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            compatible_surface: None,
+            force_fallback_adapter: false,
+        }))
+        .map_err(|error| anyhow::anyhow!("failed to request adapter: {error}"))?;
+        let requirements = WgpuSceneRenderer::requirements(&adapter);
+        let (device, queue) = block_on(
+            adapter.request_device(&wgpu::DeviceDescriptor {
+                label: Some("wgpu_external_surface_recovery_test"),
+                required_features: requirements.features,
+                required_limits: wgpu::Limits::downlevel_defaults()
+                    .using_resolution(adapter.limits())
+                    .using_alignment(adapter.limits()),
+                memory_hints: wgpu::MemoryHints::MemoryUsage,
+                trace: wgpu::Trace::Off,
+                experimental_features: wgpu::ExperimentalFeatures::disabled(),
+            }),
+        )
+        .map_err(|error| anyhow::anyhow!("failed to request device: {error}"))?;
+        let device = Arc::new(device);
+        let queue = Arc::new(queue);
+        let format = wgpu::TextureFormat::Rgba8UnormSrgb;
+        let mut renderer = WgpuSceneRenderer::from_host(
+            &adapter,
+            device.clone(),
+            queue.clone(),
+            WgpuSceneRendererConfig {
+                size: Size {
+                    width: DevicePixels(16),
+                    height: DevicePixels(16),
+                },
+                format,
+                transparent: false,
+            },
+        )?;
+
+        let mut registry = ExternalSurfaceRegistry::default();
+        let id_a = registry.register(WgpuExternalSurface {
+            view: test_external_view(&device),
+        });
+        let id_b = registry.register(WgpuExternalSurface {
+            view: test_external_view(&device),
+        });
+        let scene_ab = test_external_scene(&[id_a, id_b]);
+        let scene_a = test_external_scene(&[id_a]);
+        let scene_b = test_external_scene(&[id_b]);
+
+        // Both registered surfaces are valid before recovery.
+        encode_external_scene(&mut renderer, &device, &queue, &scene_ab, &registry)?;
+
+        // Recovery snapshots both generations. Replacing A must not release B's requirement.
+        renderer.replace_gpu_context(&adapter, device.clone(), queue.clone(), Some(&registry))?;
+        assert!(registry.replace(
+            id_a,
+            WgpuExternalSurface {
+                view: test_external_view(&device),
+            },
+        ));
+        encode_external_scene(&mut renderer, &device, &queue, &scene_a, &registry)?;
+
+        let empty_scene = Scene::default();
+        encode_external_scene(&mut renderer, &device, &queue, &empty_scene, &registry)?;
+
+        // The stale B view is rejected during validation, before any command submission or GPU
+        // work. The failed scene must not clear A or B state prematurely.
+        let target_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("external_surface_recovery_test_stale_target"),
+            size: wgpu::Extent3d {
+                width: 16,
+                height: 16,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let target_view = target_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let mut stale_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("external_surface_recovery_test_stale_encoder"),
+        });
+        let error = renderer
+            .encode_with_external_surfaces(
+                &scene_b,
+                &mut stale_encoder,
+                WgpuRenderTarget {
+                    view: &target_view,
+                    size: Size {
+                        width: DevicePixels(16),
+                        height: DevicePixels(16),
+                    },
+                    format,
+                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                },
+                &registry,
+            )
+            .expect_err("stale external surface B should be rejected after recovery");
+        assert!(
+            error
+                .to_string()
+                .contains("external surface ID 2 must be replaced after GPU recovery")
+        );
+
+        assert!(registry.replace(
+            id_b,
+            WgpuExternalSurface {
+                view: test_external_view(&device),
+            },
+        ));
+        encode_external_scene(&mut renderer, &device, &queue, &scene_b, &registry)?;
         Ok(())
     }
 }

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -513,6 +513,10 @@ impl DirectXRenderer {
                     self.draw_polychrome_sprites(texture_id, range.start, range.len())
                 }
                 PrimitiveBatch::Surfaces(range) => self.draw_surfaces(&scene.surfaces[range]),
+                // External surfaces are resolved by the WGPU embedding host. Keep native
+                // backends tolerant of the backend-neutral primitive until they provide their
+                // own resource registry.
+                PrimitiveBatch::ExternalSurfaces(_) => Ok(()),
                 PrimitiveBatch::BackdropFilters(range) => {
                     let result = (|| {
                         for filter in &scene.backdrop_filters[range] {

--- a/crates/gpui_windows/src/platform.rs
+++ b/crates/gpui_windows/src/platform.rs
@@ -554,7 +554,9 @@ impl Platform for WindowsPlatform {
         options: WindowParams,
     ) -> Result<Box<dyn PlatformWindow>> {
         let window = WindowsWindow::new(handle, options, self.generate_creation_info())?;
-        let handle = window.get_raw_handle();
+        let handle = window
+            .get_raw_handle()
+            .ok_or_else(|| anyhow!("native WindowsWindow did not provide an HWND"))?;
         self.raw_window_handles.write().push(handle.into());
 
         Ok(Box::new(window))

--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -1131,8 +1131,8 @@ impl PlatformWindow for WindowsWindow {
         self.state.renderer.borrow().sprite_atlas().clone()
     }
 
-    fn get_raw_handle(&self) -> HWND {
-        self.0.hwnd
+    fn get_raw_handle(&self) -> Option<HWND> {
+        Some(self.0.hwnd)
     }
 
     fn gpu_specs(&self) -> Option<GpuSpecs> {


### PR DESCRIPTION
## Summary\n\n- hard-cut the workspace to WGPU 30.0.1\n- migrate surface color-space, adapter, mapping, and queue presentation APIs\n- make the Windows native handle contract optional for non-native windows\n- add explicit gpui_embed checks to the existing Windows CI job\n\nLocal verification and the WGPU mock proof pass on commit fdb263a5af2a034cbb064eb938bbb944aef9cf1d. The fork is at https://github.com/andrewtdiz/gpui-ce/tree/main.