### PR TITLE
reduce constraints on Stateful element trait impls

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -3930,12 +3930,7 @@ where
     }
 }
 
-impl<E> StatefulInteractiveElement for Stateful<E>
-where
-    E: Element,
-    Self: InteractiveElement,
-{
-}
+impl<E> StatefulInteractiveElement for Stateful<E> where Self: InteractiveElement {}
 
 impl<E> InteractiveElement for Stateful<E>
 where
@@ -4022,14 +4017,11 @@ where
     }
 }
 
-impl<E> IntoElement for Stateful<E>
-where
-    E: Element,
-{
-    type Element = Self;
+impl<E: IntoElement> IntoElement for Stateful<E> {
+    type Element = E::Element;
 
     fn into_element(self) -> Self::Element {
-        self
+        self.element.into_element()
     }
 }
 


### PR DESCRIPTION
These trait constraints are not actually used by internal implementation, and prevent the `StatefulInteractiveElement` trait from being used to identify `RenderOnce` types which resolve to a `Stateful<T>`