### PR TITLE
add Interactivity::on_prepaint

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -750,6 +750,22 @@ impl Interactivity {
     fn has_pinch_listeners(&self) -> bool {
         !self.pinch_listeners.is_empty()
     }
+
+    /// Bind the given callback to be called during prepaint of the element.
+    /// The imperative API equivalent to [`StatefulInteractiveElement::on_prepaint`].
+    ///
+    /// See [`Context::listener`](crate::Context::listener) to get access to a view's state from this callback.
+    pub fn on_prepaint(
+        &mut self,
+        listener: impl Fn(&InteractivityPrepaint, &mut Window, &mut App) + 'static,
+    ) where
+        Self: Sized,
+    {
+        self.prepaint_listeners
+            .push(Box::new(move |payload, window, cx| {
+                listener(payload, window, cx)
+            }));
+    }
 }
 
 /// A trait for elements that want to use the standard GPUI event handlers that don't
@@ -1673,7 +1689,33 @@ pub trait StatefulInteractiveElement: InteractiveElement {
         self.interactivity().tooltip_show_delay(delay);
         self
     }
+
+    /// Bind the given callback to execute before the element's prepaint.
+    /// The fluent API equivalent to [`Interactivity::on_prepaint`].
+    ///
+    /// See [`Context::listener`](crate::Context::listener) to get access to a view's state from this callback.
+    fn on_prepaint(
+        mut self,
+        listener: impl Fn(&InteractivityPrepaint, &mut Window, &mut App) + 'static,
+    ) -> Self
+    where
+        Self: Sized,
+    {
+        self.interactivity().on_prepaint(listener);
+        self
+    }
 }
+
+/// Describes the known state of an Interactivity element before prepaint begins.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct InteractivityPrepaint {
+    /// The bounds of the element
+    pub bounds: Bounds<Pixels>,
+    /// The size of the contents of the element
+    pub content_size: Size<Pixels>,
+}
+pub(crate) type PrepaintListener =
+    Box<dyn Fn(&InteractivityPrepaint, &mut Window, &mut App) + 'static>;
 
 pub(crate) type MouseDownListener =
     Box<dyn Fn(&MouseDownEvent, DispatchPhase, &Hitbox, &mut Window, &mut App) + 'static>;
@@ -2094,6 +2136,7 @@ pub struct Interactivity {
         Box<dyn Fn(&dyn Any, &mut Window, &mut App) -> StyleRefinement>,
     )>,
     pub(crate) group_drag_over_styles: Vec<(TypeId, GroupStyle)>,
+    pub(crate) prepaint_listeners: Vec<PrepaintListener>,
     pub(crate) mouse_down_listeners: Vec<MouseDownListener>,
     pub(crate) mouse_up_listeners: Vec<MouseUpListener>,
     pub(crate) mouse_pressure_listeners: Vec<MousePressureListener>,
@@ -2268,6 +2311,16 @@ impl Interactivity {
         f: impl FnOnce(&Style, Point<Pixels>, Option<Hitbox>, &mut Window, &mut App) -> R,
     ) -> R {
         self.content_size = content_size;
+
+        if !self.prepaint_listeners.is_empty() {
+            let payload = InteractivityPrepaint {
+                bounds,
+                content_size,
+            };
+            for listener in self.prepaint_listeners.drain(..) {
+                listener(&payload, window, cx);
+            }
+        }
 
         #[cfg(any(feature = "inspector", debug_assertions))]
         window.with_inspector_state(


### PR DESCRIPTION
Example use-cases:
- [Resize-able panel parent which knows its total size](https://codeberg.org/temportalflux/jjui/src/commit/f8d6d9e6a9d97f4b1f65e3e4167d1e672d9acf36/src/elements/resize_group.rs#L260)
- [Window decoration bar has known height for using in dialog occlusion](https://codeberg.org/temportalflux/jjui/src/commit/f8d6d9e6a9d97f4b1f65e3e4167d1e672d9acf36/src/entity/window/view.rs#L311-L313)
- [Popovers need to know the bounds of the item they are anchored to](https://codeberg.org/temportalflux/jjui/src/commit/f8d6d9e6a9d97f4b1f65e3e4167d1e672d9acf36/src/entity/mod.rs#L10-L35)
- [Acquire height of virtualized scroll box](https://codeberg.org/temportalflux/jjui/src/commit/f8d6d9e6a9d97f4b1f65e3e4167d1e672d9acf36/src/view/commit_log.rs#L28)

Some of those use-cases may be able to be covered by other optimizations in the future (e.g. virtualizing not being critical if the underlying rendering changes), but for now I've not found any better way to access the bounding box of an element for usage in auxiliary functionality.