### PR TITLE
expand on_hover to support multiple listeners on the same element

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -677,11 +677,7 @@ impl Interactivity {
     where
         Self: Sized,
     {
-        debug_assert!(
-            self.hover_listener.is_none(),
-            "calling on_hover more than once on the same element is not supported"
-        );
-        self.hover_listener = Some(Box::new(listener));
+        self.hover_listeners.push(Rc::new(listener));
     }
 
     /// Use the given callback to construct a new tooltip view when the mouse hovers over this element.
@@ -1693,6 +1689,7 @@ pub(crate) type PinchListener =
     Box<dyn Fn(&PinchEvent, DispatchPhase, &Hitbox, &mut Window, &mut App) + 'static>;
 
 pub(crate) type ClickListener = Rc<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>;
+pub(crate) type HoverListener = Rc<dyn Fn(&bool, &mut Window, &mut App) + 'static>;
 
 pub(crate) struct DragListener {
     value: Arc<dyn Any>,
@@ -2110,7 +2107,7 @@ pub struct Interactivity {
     pub(crate) click_listeners: Vec<ClickListener>,
     pub(crate) aux_click_listeners: Vec<ClickListener>,
     pub(crate) drag_listener: Option<DragListener>,
-    pub(crate) hover_listener: Option<Box<dyn Fn(&bool, &mut Window, &mut App)>>,
+    pub(crate) hover_listeners: Vec<HoverListener>,
     pub(crate) tooltip_builder: Option<TooltipBuilder>,
     pub(crate) tooltip_show_delay: Option<Duration>,
     pub(crate) window_control: Option<WindowControlArea>,
@@ -2366,7 +2363,7 @@ impl Interactivity {
             || self.tracked_focus_handle.is_some()
             || self.hover_style.is_some()
             || self.group_hover_style.is_some()
-            || self.hover_listener.is_some()
+            || !self.hover_listeners.is_empty()
             || !self.mouse_up_listeners.is_empty()
             || !self.mouse_pressure_listeners.is_empty()
             || !self.mouse_down_listeners.is_empty()
@@ -3069,7 +3066,7 @@ impl Interactivity {
                 });
             }
 
-            if let Some(hover_listener) = self.hover_listener.take() {
+            if !self.hover_listeners.is_empty() {
                 let was_hovered = element_state
                     .hover_listener_state
                     .get_or_insert_with(Default::default)
@@ -3078,13 +3075,15 @@ impl Interactivity {
                     .pending_mouse_down
                     .get_or_insert_with(Default::default)
                     .clone();
-                let hover_listener = Rc::new(hover_listener);
+                let hover_listeners = self.hover_listeners.clone();
                 let update_hover = move |is_hovered: bool, window: &mut Window, cx: &mut App| {
                     let mut was_hovered = was_hovered.borrow_mut();
                     if is_hovered != *was_hovered {
                         *was_hovered = is_hovered;
                         drop(was_hovered);
-                        hover_listener(&is_hovered, window, cx);
+                        for listener in &hover_listeners {
+                            listener(&is_hovered, window, cx);
+                        }
                     }
                 };
 


### PR DESCRIPTION
I have a couple cases where a function returns a Div with on_hover applied, and then callers can also append additional on_hover logic, but the existing code only supports a single callback per interactive element. This expands that to allow multiple listeners.