### PR TITLE
Added icon support on Wayland

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2550,6 +2550,7 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "log",
+ "memfd",
  "notify-rust",
  "oo7",
  "open",
@@ -3715,6 +3716,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "memmap2"

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1983,7 +1983,8 @@ pub struct WindowParams {
     #[cfg_attr(any(target_os = "linux", target_os = "freebsd"), allow(dead_code))]
     pub show: bool,
 
-    /// An image to set as the window icon (x11 only)
+    /// An image to set as the window icon (X11 and Wayland only)
+    /// Wayland requires the xdg-toplevel-icon protocol to be available
     #[cfg_attr(feature = "wayland", allow(dead_code))]
     pub icon: Option<Arc<image::RgbaImage>>,
 

--- a/crates/gpui_linux/Cargo.toml
+++ b/crates/gpui_linux/Cargo.toml
@@ -21,6 +21,7 @@ wayland = [
   "ashpd/wayland",
 
   "calloop-wayland-source",
+  "memfd",
   "wayland-backend",
   "wayland-client",
   "wayland-cursor",
@@ -94,6 +95,7 @@ scap = { workspace = true, optional = true }
 
 # Wayland
 calloop-wayland-source = { version = "0.4.1", optional = true }
+memfd = { version = "0.6.5", optional = true }
 wayland-backend = { version = "0.3.15", features = [
   "client_system",
   "dlopen",

--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -1,5 +1,6 @@
 use std::{
     cell::{RefCell, RefMut},
+    collections::BTreeSet,
     hash::Hash,
     os::fd::{AsRawFd, BorrowedFd},
     path::PathBuf,
@@ -36,12 +37,6 @@ use wayland_client::{
         wl_shm_pool, wl_surface,
     },
 };
-use wayland_protocols::wp::pointer_gestures::zv1::client::{
-    zwp_pointer_gesture_hold_v1, zwp_pointer_gesture_pinch_v1, zwp_pointer_gestures_v1,
-};
-use wayland_protocols::wp::primary_selection::zv1::client::zwp_primary_selection_offer_v1::{
-    self, ZwpPrimarySelectionOfferV1,
-};
 use wayland_protocols::wp::primary_selection::zv1::client::{
     zwp_primary_selection_device_manager_v1, zwp_primary_selection_device_v1,
     zwp_primary_selection_source_v1,
@@ -68,6 +63,19 @@ use wayland_protocols::{
 use wayland_protocols::{
     wp::fractional_scale::v1::client::{wp_fractional_scale_manager_v1, wp_fractional_scale_v1},
     xdg::dialog::v1::client::xdg_dialog_v1::XdgDialogV1,
+};
+use wayland_protocols::{
+    wp::pointer_gestures::zv1::client::{
+        zwp_pointer_gesture_hold_v1, zwp_pointer_gesture_pinch_v1, zwp_pointer_gestures_v1,
+    },
+    xdg::toplevel_icon::v1::client::xdg_toplevel_icon_manager_v1,
+};
+use wayland_protocols::{
+    wp::primary_selection::zv1::client::zwp_primary_selection_offer_v1::{
+        self, ZwpPrimarySelectionOfferV1,
+    },
+    xdg::toplevel_icon::v1::client::xdg_toplevel_icon_manager_v1::XdgToplevelIconManagerV1,
+    xdg::toplevel_icon::v1::client::xdg_toplevel_icon_v1::XdgToplevelIconV1,
 };
 use wayland_protocols_plasma::blur::client::{org_kde_kwin_blur, org_kde_kwin_blur_manager};
 use wayland_protocols_wlr::layer_shell::v1::client::{zwlr_layer_shell_v1, zwlr_layer_surface_v1};
@@ -221,6 +229,7 @@ pub struct Globals {
     pub gesture_manager: Option<zwp_pointer_gestures_v1::ZwpPointerGesturesV1>,
     pub dialog: Option<xdg_wm_dialog_v1::XdgWmDialogV1>,
     pub system_bell: Option<xdg_system_bell_v1::XdgSystemBellV1>,
+    pub icon_manager: Option<xdg_toplevel_icon_manager_v1::XdgToplevelIconManagerV1>,
     pub executor: ForegroundExecutor,
 }
 
@@ -263,6 +272,7 @@ impl Globals {
             gesture_manager: globals.bind(&qh, 1..=3, ()).ok(),
             dialog: globals.bind(&qh, dialog_v..=dialog_v, ()).ok(),
             system_bell: globals.bind(&qh, 1..=1, ()).ok(),
+            icon_manager: globals.bind(&qh, 1..=1, ()).ok(),
             executor,
             qh,
         }
@@ -360,6 +370,7 @@ pub(crate) struct WaylandClientState {
     event_loop: Option<EventLoop<'static, WaylandClientStatePtr>>,
     pub common: LinuxCommon,
     ime_enabled: Option<bool>,
+    pub(crate) icon_sizes: BTreeSet<i32>,
 }
 
 pub struct DragState {
@@ -851,6 +862,7 @@ impl WaylandClient {
             startup_activation_token,
             event_loop: Some(event_loop),
             ime_enabled: None,
+            icon_sizes: BTreeSet::default(),
         }));
 
         WaylandSource::new(conn, event_queue)
@@ -988,6 +1000,7 @@ impl LinuxClient for WaylandClient {
 
         if window.0.toplevel().is_some() {
             state.consume_startup_activation_token(&window.0.surface());
+            window.0.regenerate_icons(&state.icon_sizes);
         }
         state.windows.insert(surface_id, window.0.clone());
 
@@ -2844,6 +2857,44 @@ impl Dispatch<XdgDialogV1, ()> for WaylandClientStatePtr {
         _state: &mut Self,
         _proxy: &XdgDialogV1,
         _event: <XdgDialogV1 as Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qhandle: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<XdgToplevelIconManagerV1, ()> for WaylandClientStatePtr {
+    fn event(
+        this: &mut Self,
+        _proxy: &XdgToplevelIconManagerV1,
+        event: <XdgToplevelIconManagerV1 as Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qhandle: &QueueHandle<Self>,
+    ) {
+        let client = this.get_client();
+        let mut state = client.borrow_mut();
+
+        match event {
+            xdg_toplevel_icon_manager_v1::Event::IconSize { size } => {
+                state.icon_sizes.insert(size);
+            }
+            xdg_toplevel_icon_manager_v1::Event::Done => {
+                for window in state.windows.values() {
+                    window.regenerate_icons(&state.icon_sizes);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Dispatch<XdgToplevelIconV1, ()> for WaylandClientStatePtr {
+    fn event(
+        _state: &mut Self,
+        _proxy: &XdgToplevelIconV1,
+        _event: <XdgToplevelIconV1 as Proxy>::Event,
         _data: &(),
         _conn: &Connection,
         _qhandle: &QueueHandle<Self>,

--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -1,20 +1,26 @@
+use core::mem;
 use std::{
     cell::{Cell, Ref, RefCell, RefMut},
+    collections::BTreeSet,
     ffi::c_void,
+    io::Write,
+    os::fd::AsFd,
     ptr::NonNull,
     rc::Rc,
     sync::Arc,
 };
 
 use collections::{FxHashMap, HashMap};
+use filedescriptor::FileDescriptor;
 use futures::channel::oneshot::Receiver;
 
+use image::{ImageBuffer, Rgba, imageops::FilterType};
 use raw_window_handle as rwh;
 use wayland_backend::client::ObjectId;
 use wayland_client::WEnum;
 use wayland_client::{
     Proxy,
-    protocol::{wl_output, wl_seat, wl_surface},
+    protocol::{wl_output, wl_seat, wl_shm, wl_surface},
 };
 use wayland_protocols::wp::viewporter::client::wp_viewport;
 use wayland_protocols::xdg::decoration::zv1::client::zxdg_toplevel_decoration_v1;
@@ -130,6 +136,8 @@ pub struct WaylandWindowState {
     window_controls: WindowControls,
     client_inset: Option<Pixels>,
     accesskit_adapter: Option<accesskit_unix::Adapter>,
+    icon: Option<Arc<ImageBuffer<Rgba<u8>, Vec<u8>>>>,
+    generated_icons: Vec<FileDescriptor>,
 }
 
 pub enum WaylandSurfaceState {
@@ -605,6 +613,8 @@ impl WaylandWindowState {
             children: FxHashMap::default(),
             surface,
             app_id: options.app_id,
+            icon: options.icon,
+            generated_icons: Vec::default(),
             blur: None,
             viewport,
             globals,
@@ -1395,6 +1405,87 @@ impl WaylandWindowStatePtr {
 
     pub fn primary_output_scale(&self) -> i32 {
         self.state.borrow_mut().primary_output_scale()
+    }
+
+    pub fn regenerate_icons(&self, icon_sizes: &BTreeSet<i32>) {
+        let mut state = self.state.borrow_mut();
+        let state = &mut *state;
+
+        let Some(icon) = &state.icon else { return };
+        let Some(icon_manager) = &state.globals.icon_manager else {
+            return;
+        };
+
+        let squared = {
+            let (width, height) = icon.dimensions();
+            let size = width.max(height);
+
+            let mut image = ImageBuffer::from_pixel(size, size, Rgba([0u8, 0, 0, 0]));
+
+            image::imageops::overlay(
+                &mut image,
+                icon.as_ref(),
+                (size - width) as i64 / 2,
+                (size - height) as i64 / 2,
+            );
+
+            image
+        };
+
+        let icons: Vec<_> = icon_sizes
+            .iter()
+            .copied()
+            .filter_map(|size| {
+                let mem = memfd::MemfdOptions::new()
+                    .allow_sealing(true)
+                    .create(format!("icon-{size}x{size}"))
+                    .ok()?;
+
+                let buffer_len = size * size * mem::size_of::<Rgba<u8>>() as i32;
+                mem.as_file()
+                    .set_len(u64::try_from(buffer_len).ok()?)
+                    .ok()?;
+
+                let mut fd = FileDescriptor::new(mem);
+
+                let pool =
+                    state
+                        .globals
+                        .shm
+                        .create_pool(fd.as_fd(), buffer_len, &state.globals.qh, ());
+
+                let buffer = pool.create_buffer(
+                    0,
+                    size,
+                    size,
+                    size * 4,
+                    wl_shm::Format::Argb8888,
+                    &state.globals.qh,
+                    (),
+                );
+
+                let image = image::imageops::resize(
+                    &squared,
+                    size as u32,
+                    size as u32,
+                    FilterType::CatmullRom,
+                )
+                .into_raw_bgra();
+
+                fd.write_all(&image).unwrap();
+
+                Some((buffer, fd))
+            })
+            .collect();
+
+        let icon = icon_manager.create_icon(&state.globals.qh, ());
+        icon.set_name(state.app_id.clone().unwrap_or_default());
+        state.generated_icons = Vec::new();
+        for (ref buffer, fd) in icons {
+            icon.add_buffer(buffer, 1);
+            state.generated_icons.push(fd)
+        }
+        icon_manager.set_icon(state.surface_state.toplevel().unwrap(), Some(&icon));
     }
 }
 


### PR DESCRIPTION
Uses the xdg-toplevel-icon protocols to set the icon from a provided image when a window is created.

Currently, I think this only works on KDE, which is a bit sad. However, this is the only way to be able to dynamically set icons, and the only way without creating a corresponding `.desktop` file and placing the icon in the filesystem, so it's useful to have for free-standing programs to be able to not have the default Wayland icon