### PR TITLE
Gate the Windows surface draw on the wgpu-surfaces feature

### DIFF
--- a/crates/gpui_wgpu/Cargo.toml
+++ b/crates/gpui_wgpu/Cargo.toml
@@ -15,6 +15,9 @@ path = "src/gpui_wgpu.rs"
 [features]
 default = []
 font-kit = ["dep:font-kit"]
+# Windows-only: `PaintSurface::texture` exists there only when `gpui` has
+# `wgpu-surfaces` on, so `draw_surfaces` has to follow the same switch.
+wgpu-surfaces = ["gpui/wgpu-surfaces"]
 
 [dependencies]
 gpui.workspace = true

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -1852,7 +1852,11 @@ impl WgpuRenderer {
         )
     }
 
-    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "windows"))]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        all(target_os = "windows", feature = "wgpu-surfaces")
+    ))]
     fn draw_surfaces(&self, surfaces: &[PaintSurface], pass: &mut wgpu::RenderPass<'_>) -> bool {
         let resources = self.resources();
         for surface in surfaces {
@@ -1902,7 +1906,11 @@ impl WgpuRenderer {
         true
     }
 
-    #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "windows")))]
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        all(target_os = "windows", feature = "wgpu-surfaces")
+    )))]
     fn draw_surfaces(&self, _surfaces: &[PaintSurface], _pass: &mut wgpu::RenderPass<'_>) -> bool {
         true
     }

--- a/crates/gpui_windows/Cargo.toml
+++ b/crates/gpui_windows/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/gpui_windows.rs"
 default = ["gpui/default"]
 test-support = ["gpui/test-support"]
 screen-capture = ["gpui/screen-capture", "scap"]
-wgpu = ["dep:gpui_wgpu", "gpui/wgpu-surfaces"]
+wgpu = ["dep:gpui_wgpu", "gpui/wgpu-surfaces", "gpui_wgpu/wgpu-surfaces"]
 
 [dependencies]
 gpui.workspace = true


### PR DESCRIPTION
#121 (mine) broke the Windows build on main. `draw_surfaces` is gated on `target_os = "windows"`, but the `PaintSurface::texture` it reads also needs `feature = "wgpu-surfaces"`. A plain `cargo build --workspace` enables neither, so the field is absent:

```
error[E0609]: no field `texture` on type `&PaintSurface`
   --> crates\gpui_wgpu\src\wgpu_renderer.rs:1859:46
    = note: available fields are: `order`, `bounds`, `content_mask`
```

`gpui_wgpu` gets its own `wgpu-surfaces` feature forwarding to `gpui/wgpu-surfaces`; both `draw_surfaces` arms gate on it; `gpui_windows/wgpu` enables it alongside the gpui one. Renderer and struct now follow one switch. No change on any other platform — off Windows the cfgs evaluate exactly as before.

Verified on Windows 11: `cargo build --workspace --all-targets` and `cargo test --workspace` (568 passed, 0 failed) — the two commands `test-windows` runs — plus `cargo check -p gpui_ce_windows --features wgpu`.

Two things worth flagging rather than burying:

- Enabling `gpui/wgpu-surfaces` **directly**, instead of through `gpui_windows/wgpu`, now gets you the API with `draw_surfaces` stubbed out — surfaces silently don't draw. `gpui_windows/wgpu` sets both, which is the intended path, but if you'd rather the field were simply unconditional on Windows and the feature dropped, I'm happy to redo it that way.
- CI never builds the `--features wgpu` configuration at all, which is why #121 went in green on Linux/macOS. Happy to add that job in a separate PR if you want it.

The `lockfile` and `typos` failures on main are unrelated dependency drift.

Sorry for the breakage.
