### PR TITLE
Better padding snapping for automatically sized axis.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
+checksum = "515a1f282e33d55983c499d7e9e87082e81cbc32974825bf9032f928392d5844"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -1128,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+checksum = "2fe67f2944eef52fc7b106b8c9450d243a88701a0c065f7f57235e76abaed7df"
 dependencies = [
  "compression-core",
  "deflate64",
@@ -1139,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+checksum = "6e8ccc4ea9f6acc32d102c0f6d471d11d913ad15f20c04de743374861fa1d414"
 
 [[package]]
 name = "concurrent-queue"

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -437,6 +437,90 @@ fn border_widths_to_taffy(
     }
 }
 
+// Converts padding, snapping each auto-sized axis as a proportional pair.
+fn padding_to_taffy(
+    padding: &Edges<DefiniteLength>,
+    rem_size: Pixels,
+    scale_factor: f32,
+    proportional_horizontal: bool,
+    proportional_vertical: bool,
+) -> TaffyRect<taffy::style::LengthPercentage> {
+    // Snaps the combined length, then divides it by the authored ratio.
+    fn snap_absolute_pair(
+        first: AbsoluteLength,
+        second: AbsoluteLength,
+        rem_size: Pixels,
+        scale_factor: f32,
+    ) -> (f32, f32) {
+        let first = first.to_pixels(rem_size).0;
+        let second = second.to_pixels(rem_size).0;
+        let total = first + second;
+
+        if first < 0.0 || second < 0.0 || total == 0.0 {
+            return (
+                round_to_device_pixel(first, scale_factor),
+                round_to_device_pixel(second, scale_factor),
+            );
+        }
+
+        let snapped_total = round_to_device_pixel(total, scale_factor);
+        let snapped_first = snapped_total * (first / total);
+
+        (snapped_first, snapped_total - snapped_first)
+    }
+
+    // Keeps normal per-edge conversion for explicit axes and percentage padding.
+    fn convert_pair(
+        first: &DefiniteLength,
+        second: &DefiniteLength,
+        rem_size: Pixels,
+        scale_factor: f32,
+        proportional: bool,
+    ) -> (
+        taffy::style::LengthPercentage,
+        taffy::style::LengthPercentage,
+    ) {
+        if proportional
+            && let (DefiniteLength::Absolute(first), DefiniteLength::Absolute(second)) =
+                (*first, *second)
+        {
+            let (first, second) = snap_absolute_pair(first, second, rem_size, scale_factor);
+
+            (
+                taffy::style::LengthPercentage::length(first),
+                taffy::style::LengthPercentage::length(second),
+            )
+        } else {
+            (
+                first.to_taffy(rem_size, scale_factor),
+                second.to_taffy(rem_size, scale_factor),
+            )
+        }
+    }
+
+    let (left, right) = convert_pair(
+        &padding.left,
+        &padding.right,
+        rem_size,
+        scale_factor,
+        proportional_horizontal,
+    );
+    let (top, bottom) = convert_pair(
+        &padding.top,
+        &padding.bottom,
+        rem_size,
+        scale_factor,
+        proportional_vertical,
+    );
+
+    TaffyRect {
+        top,
+        right,
+        bottom,
+        left,
+    }
+}
+
 trait ToTaffy<Output> {
     fn to_taffy(&self, rem_size: Pixels, scale_factor: f32) -> Output;
 }
@@ -496,7 +580,13 @@ impl ToTaffy<taffy::style::Style> for Style {
             max_size: self.max_size.to_taffy(rem_size, scale_factor),
             aspect_ratio: self.aspect_ratio,
             margin: self.margin.to_taffy(rem_size, scale_factor),
-            padding: self.padding.to_taffy(rem_size, scale_factor),
+            padding: padding_to_taffy(
+                &self.padding,
+                rem_size,
+                scale_factor,
+                self.size.width == Length::Auto,
+                self.size.height == Length::Auto,
+            ),
             border: border_widths_to_taffy(&self.border_widths, rem_size, scale_factor),
             align_items: self.align_items.map(|x| x.into()),
             align_self: self.align_self.map(|x| x.into()),
@@ -750,6 +840,42 @@ impl From<Size<Pixels>> for Size<AvailableSpace> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn auto_sized_axes_snap_padding_proportionally() {
+        use taffy::style::LengthPercentage;
+
+        let mut style = Style {
+            padding: Edges {
+                top: Pixels(6.5).into(),
+                right: Pixels(5.0).into(),
+                bottom: Pixels(6.5).into(),
+                left: Pixels(2.5).into(),
+            },
+            ..Default::default()
+        };
+
+        let padding = style.to_taffy(Pixels(16.0), 1.0).padding;
+        let expected_left = 7.0 * (2.5 / 7.5);
+        assert_eq!(padding.left, LengthPercentage::length(expected_left));
+        assert_eq!(padding.right, LengthPercentage::length(7.0 - expected_left));
+        assert_eq!(padding.top, LengthPercentage::length(6.5));
+        assert_eq!(padding.bottom, LengthPercentage::length(6.5));
+
+        style.size.width = Length::Definite(Pixels(100.0).into());
+        let padding = style.to_taffy(Pixels(16.0), 1.0).padding;
+        assert_eq!(padding.left, LengthPercentage::length(2.0));
+        assert_eq!(padding.right, LengthPercentage::length(5.0));
+        assert_eq!(padding.top, LengthPercentage::length(6.5));
+        assert_eq!(padding.bottom, LengthPercentage::length(6.5));
+
+        style.size.width = Length::Auto;
+        style.padding.top = Pixels(6.75).into();
+        style.padding.bottom = Pixels(6.75).into();
+        let padding = style.to_taffy(Pixels(16.0), 2.0).padding;
+        assert_eq!(padding.top, LengthPercentage::length(13.5));
+        assert_eq!(padding.bottom, LengthPercentage::length(13.5));
+    }
 
     #[test]
     fn border_widths_to_taffy_use_stroke_snapping() {


### PR DESCRIPTION
# Summary
Currently all padding is snapped to the window pixel size independently from each other.

This change makes it so that when the width or height has an automatic size, then the left-and-right, or the top-and-bottom, padding are snapped to the window pixel size more proportionately to each other.

This change should have no effect for padding pairs that are integers.

# AI Disclosure
GPT 5.6-Sol helped me with this PR. All code has been read and reviewed by me.