### PR TITLE
Add gpui_ce_webview: native OS webview support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "atk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b"
+dependencies = [
+ "atk-sys",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "atk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "atomic"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +869,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cairo-rs"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
+dependencies = [
+ "bitflags 2.13.1",
+ "cairo-sys-rs",
+ "glib",
+ "libc",
+ "once_cell",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cairo-sys-rs"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "calloop"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,12 +964,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom 7.1.3",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -1087,6 +1151,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "command-fds"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,6 +1248,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
+dependencies = [
+ "time",
+ "version_check",
 ]
 
 [[package]]
@@ -1467,6 +1551,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "ctor"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1666,10 +1773,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "dom_query"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
+dependencies = [
+ "bit-set 0.8.0",
+ "cssparser",
+ "foldhash 0.2.0",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dpi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
 
 [[package]]
 name = "dunce"
@@ -1907,6 +2050,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "field-offset"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
+dependencies = [
+ "memoffset",
+ "rustc_version",
 ]
 
 [[package]]
@@ -2207,6 +2360,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f245958c627ac99d8e529166f9823fb3b838d1d41fd2b297af3075093c2691"
+dependencies = [
+ "cairo-rs",
+ "gdk-pixbuf",
+ "gdk-sys",
+ "gio",
+ "glib",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gdk-pixbuf"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec"
+dependencies = [
+ "gdk-pixbuf-sys",
+ "gio",
+ "glib",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
+name = "gdk-pixbuf-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gdk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
+name = "gdkx11"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3caa00e14351bebbc8183b3c36690327eb77c49abc2268dd4bd36b856db3fbfe"
+dependencies = [
+ "gdk",
+ "gdkx11-sys",
+ "gio",
+ "glib",
+ "libc",
+ "x11",
+]
+
+[[package]]
+name = "gdkx11-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e7445fe01ac26f11601db260dd8608fe172514eb63b3b5e261ea6b0f4428d"
+dependencies = [
+ "gdk-sys",
+ "glib-sys",
+ "libc",
+ "system-deps",
+ "x11",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2281,6 +2519,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "gio"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "gio-sys",
+ "glib",
+ "libc",
+ "once_cell",
+ "pin-project-lite",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "gio-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "winapi",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2289,6 +2559,53 @@ dependencies = [
  "khronos_api",
  "log",
  "xml-rs",
+]
+
+[[package]]
+name = "glib"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
+dependencies = [
+ "bitflags 2.13.1",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "memchr",
+ "once_cell",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-crate 2.0.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
+dependencies = [
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -2329,6 +2646,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
 dependencies = [
  "gl_generator",
+]
+
+[[package]]
+name = "gobject-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -2724,6 +3052,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpui_ce_webview"
+version = "0.1.0"
+dependencies = [
+ "gpui-ce",
+ "gpui_ce_elements",
+ "gpui_ce_platform",
+ "raw-window-handle",
+ "wry",
+]
+
+[[package]]
 name = "gpui_ce_wgpu"
 version = "0.1.0"
 dependencies = [
@@ -2819,6 +3158,58 @@ dependencies = [
  "walkdir",
  "which",
  "windows 0.62.2",
+]
+
+[[package]]
+name = "gtk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd56fb197bfc42bd5d2751f4f017d44ff59fbb58140c6b49f9b3b2bdab08506a"
+dependencies = [
+ "atk",
+ "cairo-rs",
+ "field-offset",
+ "futures-channel",
+ "gdk",
+ "gdk-pixbuf",
+ "gio",
+ "glib",
+ "gtk-sys",
+ "gtk3-macros",
+ "libc",
+ "pango",
+ "pkg-config",
+]
+
+[[package]]
+name = "gtk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f29a1c21c59553eb7dd40e918be54dccd60c52b049b75119d5d96ce6b624414"
+dependencies = [
+ "atk-sys",
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
+
+[[package]]
+name = "gtk3-macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff3c5b21f14f0736fed6dcfc0bfb4225ebf5725f3c0209edeec181e4d73e9d"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2978,6 +3369,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
+dependencies = [
+ "log",
+ "markup5ever",
 ]
 
 [[package]]
@@ -3297,6 +3698,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "javascriptcore-rs"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca5671e9ffce8ffba57afc24070e906da7fc4b1ba66f2cabebf61bf2ea257fcc"
+dependencies = [
+ "bitflags 1.3.2",
+ "glib",
+ "javascriptcore-rs-sys",
+]
+
+[[package]]
+name = "javascriptcore-rs-sys"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1be78d14ffa4b75b66df31840478fef72b51f8c2465d4ca7c194da9f7a5124"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "jiff"
 version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3330,6 +3754,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3644,6 +4084,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3796,6 +4247,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.13.1",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "raw-window-handle",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4013,6 +4479,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4056,6 +4544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
+ "objc2-exception-helper",
 ]
 
 [[package]]
@@ -4083,6 +4572,7 @@ dependencies = [
  "bitflags 2.13.1",
  "block2 0.6.2",
  "objc2 0.6.4",
+ "objc2-core-foundation",
  "objc2-foundation 0.3.2",
 ]
 
@@ -4136,6 +4626,15 @@ name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-exception-helper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a1c5fbb72d7735b076bb47b578523aedc40f3c439bea6dfd595c089d79d98a"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "objc2-foundation"
@@ -4215,6 +4714,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-user-notifications"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4224,6 +4735,20 @@ dependencies = [
  "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-location",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-web-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
  "objc2-foundation 0.3.2",
 ]
 
@@ -4383,6 +4908,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
 
 [[package]]
+name = "pango"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4"
+dependencies = [
+ "gio",
+ "glib",
+ "libc",
+ "once_cell",
+ "pango-sys",
+]
+
+[[package]]
+name = "pango-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4476,6 +5026,16 @@ dependencies = [
  "phf_macros",
  "phf_shared",
  "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
@@ -4692,6 +5252,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4719,11 +5285,54 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+dependencies = [
+ "toml_edit 0.20.7",
+]
+
+[[package]]
+name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit 0.25.13+spec-1.1.0",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -5410,6 +6019,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "selectors"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
+dependencies = [
+ "bitflags 2.13.1",
+ "cssparser",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash 2.1.3",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
 name = "self_cell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5539,6 +6167,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -5700,6 +6337,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "soup3"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "471f924a40f31251afc77450e781cb26d55c0b650842efafc9c6cbd2f7cc4f9f"
+dependencies = [
+ "futures-channel",
+ "gio",
+ "glib",
+ "libc",
+ "soup3-sys",
+]
+
+[[package]]
+name = "soup3-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebe8950a680a12f24f15ebe1bf70db7af98ad242d9db43596ad3108aab86c27"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5779,6 +6442,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 dependencies = [
  "float-cmp",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -5916,6 +6603,16 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
@@ -5971,6 +6668,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+dependencies = [
+ "cfg-expr",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 0.8.23",
+ "version-compare",
+]
+
+[[package]]
 name = "taffy"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5999,6 +6709,23 @@ dependencies = [
  "libc",
  "objc",
 ]
+
+[[package]]
+name = "tao-macros"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7eeb6d99155545da6150a1795945f16ac9c178deb2a5f2e74d776107bd5849"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri-winrt-notification"
@@ -6107,6 +6834,7 @@ dependencies = [
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -6114,6 +6842,16 @@ name = "time-core"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tiny-keccak"
@@ -6237,6 +6975,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -6522,6 +7282,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6782,6 +7548,98 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba8b815c1b593dc0baf78dd0f4fc8fdb2de53198fb1163738093e9a311c33fb3"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+]
+
+[[package]]
+name = "webkit2gtk"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1027150013530fb2eaf806408df88461ae4815a45c541c8975e61d6f2fc4793"
+dependencies = [
+ "bitflags 1.3.2",
+ "cairo-rs",
+ "gdk",
+ "gdk-sys",
+ "gio",
+ "gio-sys",
+ "glib",
+ "glib-sys",
+ "gobject-sys",
+ "gtk",
+ "gtk-sys",
+ "javascriptcore-rs",
+ "libc",
+ "once_cell",
+ "soup3",
+ "webkit2gtk-sys",
+]
+
+[[package]]
+name = "webkit2gtk-sys"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916a5f65c2ef0dfe12fff695960a2ec3d4565359fdbb2e9943c974e06c734ea5"
+dependencies = [
+ "bitflags 1.3.2",
+ "cairo-sys-rs",
+ "gdk-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "javascriptcore-rs-sys",
+ "libc",
+ "pkg-config",
+ "soup3-sys",
+ "system-deps",
+]
+
+[[package]]
+name = "webview2-com"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
+dependencies = [
+ "webview2-com-macros",
+ "webview2-com-sys",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+]
+
+[[package]]
+name = "webview2-com-macros"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "webview2-com-sys"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
+dependencies = [
+ "thiserror 2.0.20",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -7271,6 +8129,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -7294,6 +8161,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7356,6 +8238,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -7368,6 +8256,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -7377,6 +8271,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7398,6 +8298,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -7407,6 +8313,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7422,6 +8334,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -7434,6 +8352,12 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
@@ -7443,6 +8367,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"
@@ -7500,6 +8433,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
+name = "wry"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
+dependencies = [
+ "base64 0.22.1",
+ "block2 0.6.2",
+ "cookie",
+ "crossbeam-channel",
+ "dirs 6.0.0",
+ "dom_query",
+ "dpi",
+ "dunce",
+ "gdkx11",
+ "gtk",
+ "http",
+ "javascriptcore-rs",
+ "jni",
+ "libc",
+ "ndk",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit",
+ "objc2-web-kit",
+ "once_cell",
+ "percent-encoding",
+ "raw-window-handle",
+ "sha2 0.10.9",
+ "soup3",
+ "tao-macros",
+ "thiserror 2.0.20",
+ "url",
+ "webkit2gtk",
+ "webkit2gtk-sys",
+ "webview2-com",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
+ "windows-version",
+ "x11-dl",
+]
+
+[[package]]
 name = "x11"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7517,6 +8494,17 @@ checksum = "662d74b3d77e396b8e5beb00b9cad6a9eccf40b2ef68cc858784b14c41d535a3"
 dependencies = [
  "libc",
  "x11rb",
+]
+
+[[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
 ]
 
 [[package]]
@@ -7722,7 +8710,7 @@ version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 3.0.4",
@@ -7982,7 +8970,7 @@ version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 3.0.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "./crates/gpui_zed_util/",
   "./crates/gpui_ce_util/",
   "./crates/gpui_path/",
+  "./crates/gpui_webview/",
   "./tooling/perf/",
 ]
 default-members = ["./crates/gpui/"]
@@ -199,6 +200,9 @@ gpui_wgpu = { path = "./crates/gpui_wgpu/", version = "0.1.0", package = "gpui_c
 gpui_macros = { path = "./crates/gpui_macros/", version = "0.1.0", package = "gpui_ce_macros" }
 gpui_shared_string = { path = "./crates/gpui_shared_string/", version = "0.1.0", package = "gpui_ce_shared_string" }
 gpui_tokio = { path = "./crates/gpui_tokio/", version = "0.1.0", package = "gpui_ce_tokio" }
+gpui_webview = { path = "./crates/gpui_webview/", version = "0.1.0", package = "gpui_ce_webview" }
+
+wry = "0.55"
 
 [workspace.dependencies.windows]
 version = "0.62.2"

--- a/crates/gpui_webview/Cargo.toml
+++ b/crates/gpui_webview/Cargo.toml
@@ -22,7 +22,7 @@ raw-window-handle = "0.6"
 wry = { workspace = true, optional = true }
 
 [dev-dependencies]
-gpui_platform = { workspace = true, features = ["wgpu"] }
+gpui_platform = { workspace = true, features = ["wgpu", "font-kit"] }
 gpui_elements = { path = "../gpui_elements/", package = "gpui_ce_elements" }
 
 [[example]]

--- a/crates/gpui_webview/Cargo.toml
+++ b/crates/gpui_webview/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "gpui_ce_webview"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "Apache-2.0"
+description = "Native OS webview element for gpui-ce, backed by wry."
+
+[lib]
+name = "gpui_webview"
+
+[lints]
+workspace = true
+
+[features]
+default = ["webview"]
+webview = ["dep:wry"]
+
+[dependencies]
+gpui.workspace = true
+raw-window-handle = "0.6"
+wry = { workspace = true, optional = true }
+
+[dev-dependencies]
+gpui_platform = { workspace = true, features = ["wgpu"] }
+gpui_elements = { path = "../gpui_elements/", package = "gpui_ce_elements" }
+
+[[example]]
+name = "browser"
+path = "examples/browser.rs"

--- a/crates/gpui_webview/examples/browser.rs
+++ b/crates/gpui_webview/examples/browser.rs
@@ -1,0 +1,171 @@
+use std::{cell::RefCell, rc::Rc};
+
+use gpui::{
+    App, Bounds, ClickEvent, Context, Entity, Render, Window, WindowBounds, WindowOptions, div,
+    prelude::*, px, rgb, size,
+};
+use gpui_elements::editable_text::{
+    EditableTextState, StringStorage,
+    actions::{DEFAULT_INPUT_CONTEXT, Enter, default_bindings},
+    text_input,
+};
+use gpui_webview::{WebViewHandle, webview};
+
+const HOME_URL: &str = "https://example.com";
+
+struct Browser {
+    url_state: Option<Entity<EditableTextState>>,
+    webview_handle: Rc<RefCell<Option<WebViewHandle>>>,
+}
+
+impl Browser {
+    fn new() -> Self {
+        Self {
+            url_state: None,
+            webview_handle: Rc::new(RefCell::new(None)),
+        }
+    }
+
+    /// Navigate the webview to whatever is currently in the URL bar.
+    fn go(&self, cx: &mut App) {
+        let Some(state) = &self.url_state else {
+            return;
+        };
+        let text = state.read(cx).as_str().trim().to_string();
+        if text.is_empty() {
+            return;
+        }
+        let has_scheme = text.split_once(':').is_some_and(|(scheme, _)| {
+            scheme
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_ascii_alphabetic())
+                && scheme
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
+        });
+        let url = if has_scheme {
+            text
+        } else {
+            format!("https://{text}")
+        };
+        if let Some(handle) = self.webview_handle.borrow().as_ref() {
+            handle.load_url(&url);
+        }
+    }
+}
+
+impl Render for Browser {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        // Find or lazily create the state entity backing the URL bar.
+        let url_state = EditableTextState::use_keyed_init("url-bar", window, cx, |_window, _cx| {
+            StringStorage::from(HOME_URL)
+        });
+        self.url_state = Some(url_state.clone());
+        if std::env::var_os("GPUI_TRACE").is_some() {
+            let ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis())
+                .unwrap_or_default();
+            eprintln!(
+                "TRACE {ms}ms render url_state: {:?}",
+                self.url_state.as_ref().unwrap().read(cx).as_str()
+            );
+        }
+
+        // Keep the webview handle in a shared cell so the `on_create_handle`
+        // callback can hand it to us once the native webview exists.
+        let handle_cell = self.webview_handle.clone();
+
+        // Weak reference to the URL bar state so the webview can push URL
+        // changes back into the text box once it detects internal navigation.
+        let url_state_for_webview = url_state.downgrade();
+
+        div()
+            .flex()
+            .flex_col()
+            .size_full()
+            .bg(rgb(0x1e1e2e))
+            .child(
+                // URL bar row: textbox + go button
+                div()
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap_2()
+                    .h(px(48.0))
+                    .px_3()
+                    .bg(rgb(0x313244))
+                    .child(
+                        text_input("url-bar")
+                            .state(url_state.downgrade())
+                            .caret_blink_interval_500ms()
+                            .placeholder("Enter a URL")
+                            .flex_1()
+                            .px_2()
+                            .py_1()
+                            .rounded_md()
+                            .border_1()
+                            .border_color(rgb(0x45475a))
+                            .text_color(rgb(0xcdd6f4))
+                            .whitespace_nowrap()
+                            .overflow_x_scroll()
+                            .on_action(cx.listener(|this, _: &Enter, _window, cx| {
+                                this.go(cx);
+                            })),
+                    )
+                    .child(
+                        div()
+                            .id("go")
+                            .px_4()
+                            .py_1()
+                            .rounded_md()
+                            .bg(rgb(0xa6e3a1))
+                            .text_color(rgb(0x1e1e2e))
+                            .font_weight(gpui::FontWeight::BOLD)
+                            .cursor_pointer()
+                            .hover(|style| style.bg(rgb(0x94e2d5)))
+                            .child("Go")
+                            .on_click(cx.listener(|this, _event: &ClickEvent, _window, cx| {
+                                this.go(cx);
+                            })),
+                    ),
+            )
+            .child(
+                // Web content (native webview)
+                webview("browser-content")
+                    .url(HOME_URL)
+                    .on_url_changed(move |url, _window, cx| {
+                        let Some(state) = url_state_for_webview.upgrade() else {
+                            return;
+                        };
+                        state.update(cx, |state, cx| {
+                            if state.as_str() != url {
+                                state.emplace(url, cx);
+                            }
+                        });
+                    })
+                    .on_create_handle(move |handle, _window, _cx| {
+                        *handle_cell.borrow_mut() = Some(handle);
+                    })
+                    .flex_1(),
+            )
+    }
+}
+
+fn main() {
+    gpui_platform::application().run(|cx: &mut App| {
+        cx.bind_keys(default_bindings().as_keybindings(Some(DEFAULT_INPUT_CONTEXT)));
+
+        let bounds = Bounds::centered(None, size(px(1000.), px(700.)), cx);
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
+                ..Default::default()
+            },
+            |_, cx| cx.new(|_| Browser::new()),
+        )
+        .unwrap();
+        cx.activate(true);
+    });
+}

--- a/crates/gpui_webview/examples/browser.rs
+++ b/crates/gpui_webview/examples/browser.rs
@@ -35,7 +35,7 @@ impl Browser {
         if text.is_empty() {
             return;
         }
-        let has_scheme = text.split_once(':').is_some_and(|(scheme, _)| {
+        let has_scheme = text.split_once("://").is_some_and(|(scheme, _)| {
             scheme
                 .chars()
                 .next()

--- a/crates/gpui_webview/src/lib.rs
+++ b/crates/gpui_webview/src/lib.rs
@@ -1,0 +1,6 @@
+mod platform;
+mod webview;
+mod webview_handle;
+
+pub use webview::{WebView, webview};
+pub use webview_handle::WebViewHandle;

--- a/crates/gpui_webview/src/platform/mod.rs
+++ b/crates/gpui_webview/src/platform/mod.rs
@@ -1,0 +1,34 @@
+use gpui::{Bounds, Pixels, SharedString};
+
+#[allow(dead_code)]
+pub(crate) trait PlatformWebView {
+    fn set_bounds(&self, bounds: Bounds<Pixels>);
+    fn set_visible(&self, visible: bool);
+    fn load_url(&self, url: &str);
+    fn load_html(&self, html: &str);
+    fn go_back(&self);
+    fn go_forward(&self);
+    fn reload(&self);
+    fn stop_loading(&self);
+    fn evaluate_javascript(
+        &self,
+        script: &str,
+        callback: Option<Box<dyn FnOnce(Result<String, String>) + Send>>,
+    );
+    fn title(&self) -> SharedString;
+    fn url(&self) -> SharedString;
+    fn set_devtools_enabled(&self, enabled: bool);
+    fn focus(&self);
+}
+
+#[cfg(feature = "webview")]
+mod wry_backend;
+
+#[cfg(feature = "webview")]
+pub(crate) use wry_backend::*;
+
+#[cfg(not(feature = "webview"))]
+mod stub;
+
+#[cfg(not(feature = "webview"))]
+pub(crate) use stub::*;

--- a/crates/gpui_webview/src/platform/stub.rs
+++ b/crates/gpui_webview/src/platform/stub.rs
@@ -1,0 +1,44 @@
+use super::PlatformWebView;
+use crate::webview::WebViewConfig;
+use gpui::{App, Bounds, Pixels, SharedString, Window};
+
+pub(crate) struct StubWebView;
+
+impl StubWebView {
+    pub fn new(_window: &Window, _config: &WebViewConfig) -> Self {
+        panic!("gpui_webview: WebView requires the 'webview' feature to be enabled")
+    }
+}
+
+impl PlatformWebView for StubWebView {
+    fn set_bounds(&self, _: Bounds<Pixels>) {}
+    fn set_visible(&self, _: bool) {}
+    fn load_url(&self, _: &str) {}
+    fn load_html(&self, _: &str) {}
+    fn go_back(&self) {}
+    fn go_forward(&self) {}
+    fn reload(&self) {}
+    fn stop_loading(&self) {}
+    fn evaluate_javascript(
+        &self,
+        _: &str,
+        _: Option<Box<dyn FnOnce(Result<String, String>) + Send>>,
+    ) {
+    }
+    fn title(&self) -> SharedString {
+        SharedString::default()
+    }
+    fn url(&self) -> SharedString {
+        SharedString::default()
+    }
+    fn set_devtools_enabled(&self, _: bool) {}
+    fn focus(&self) {}
+}
+
+pub(crate) fn create_platform_webview(
+    window: &Window,
+    config: &WebViewConfig,
+    _cx: &mut App,
+) -> Box<dyn PlatformWebView> {
+    Box::new(StubWebView::new(window, config))
+}

--- a/crates/gpui_webview/src/platform/wry_backend.rs
+++ b/crates/gpui_webview/src/platform/wry_backend.rs
@@ -24,12 +24,12 @@ impl WryWebView {
         let mut builder = wry::WebViewBuilder::new();
 
         let bounds = wry::Rect {
-            position: wry::dpi::PhysicalPosition::new(
+            position: wry::dpi::LogicalPosition::new(
                 config.bounds.origin.x.as_f32(),
                 config.bounds.origin.y.as_f32(),
             )
             .into(),
-            size: wry::dpi::PhysicalSize::new(
+            size: wry::dpi::LogicalSize::new(
                 config.bounds.size.width.as_f32(),
                 config.bounds.size.height.as_f32(),
             )
@@ -101,12 +101,12 @@ impl WryWebView {
 impl PlatformWebView for WryWebView {
     fn set_bounds(&self, bounds: Bounds<Pixels>) {
         let _ = self.webview.set_bounds(wry::Rect {
-            position: wry::dpi::PhysicalPosition::new(
+            position: wry::dpi::LogicalPosition::new(
                 bounds.origin.x.as_f32(),
                 bounds.origin.y.as_f32(),
             )
             .into(),
-            size: wry::dpi::PhysicalSize::new(
+            size: wry::dpi::LogicalSize::new(
                 bounds.size.width.as_f32(),
                 bounds.size.height.as_f32(),
             )

--- a/crates/gpui_webview/src/platform/wry_backend.rs
+++ b/crates/gpui_webview/src/platform/wry_backend.rs
@@ -1,0 +1,194 @@
+use gpui::{App, Bounds, Pixels, SharedString, Window};
+use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+use std::sync::{Arc, Mutex};
+
+use super::PlatformWebView;
+use crate::webview::WebViewConfig;
+
+struct RawWindowHandleWrapper(RawWindowHandle);
+
+impl HasWindowHandle for RawWindowHandleWrapper {
+    fn window_handle(
+        &self,
+    ) -> Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError> {
+        Ok(unsafe { raw_window_handle::WindowHandle::borrow_raw(self.0) })
+    }
+}
+
+pub(crate) struct WryWebView {
+    webview: wry::WebView,
+}
+
+impl WryWebView {
+    pub fn new(window: &Window, config: &WebViewConfig, cx: &mut App) -> Self {
+        let mut builder = wry::WebViewBuilder::new();
+
+        let bounds = wry::Rect {
+            position: wry::dpi::PhysicalPosition::new(
+                config.bounds.origin.x.as_f32(),
+                config.bounds.origin.y.as_f32(),
+            )
+            .into(),
+            size: wry::dpi::PhysicalSize::new(
+                config.bounds.size.width.as_f32(),
+                config.bounds.size.height.as_f32(),
+            )
+            .into(),
+        };
+        builder = builder.with_bounds(bounds);
+
+        if let Some(url) = &config.url {
+            builder = builder.with_url(url.as_str());
+        } else if let Some(html) = &config.html {
+            builder = builder.with_html(html.as_str());
+        }
+
+        if config.transparent {
+            builder = builder.with_transparent(true);
+        }
+
+        if config.devtools {
+            builder = builder.with_devtools(true);
+        }
+
+        // Wake the owning GPUI window whenever the webview starts or finishes a
+        // page load, so its URL-detection poll runs promptly. Without this, the
+        // poll only runs on frames the window happens to draw anyway (e.g. the
+        // URL bar's caret blink), so a link-click navigation - which produces no
+        // GPUI input event - could take hundreds of milliseconds to show up.
+        // The wake is deferred through the foreground executor so we never
+        // borrow the app re-entrantly from inside a WebView2 event callback.
+        let app = cx.to_async();
+        builder = builder.with_on_page_load_handler({
+            move |event, url| {
+                if std::env::var_os("GPUI_TRACE").is_some() {
+                    let ms = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_millis())
+                        .unwrap_or_default();
+                    let phase = match event {
+                        wry::PageLoadEvent::Started => "Started",
+                        wry::PageLoadEvent::Finished => "Finished",
+                    };
+                    eprintln!("TRACE {ms}ms page_load {phase}: {url}");
+                }
+                let app = app.clone();
+                let executor = app.foreground_executor().clone();
+                executor
+                    .spawn(async move { app.update(|cx| cx.refresh_windows()) })
+                    .detach();
+            }
+        });
+
+        let raw_handle = HasWindowHandle::window_handle(window)
+            .expect("failed to get window handle for webview")
+            .as_raw();
+
+        let wrapper = RawWindowHandleWrapper(raw_handle);
+
+        let webview = builder
+            .build_as_child(&wrapper)
+            .expect("failed to create webview");
+
+        if (config.zoom - 1.0).abs() > f32::EPSILON {
+            let _ = webview.zoom(config.zoom as f64);
+        }
+
+        WryWebView { webview }
+    }
+}
+
+impl PlatformWebView for WryWebView {
+    fn set_bounds(&self, bounds: Bounds<Pixels>) {
+        let _ = self.webview.set_bounds(wry::Rect {
+            position: wry::dpi::PhysicalPosition::new(
+                bounds.origin.x.as_f32(),
+                bounds.origin.y.as_f32(),
+            )
+            .into(),
+            size: wry::dpi::PhysicalSize::new(
+                bounds.size.width.as_f32(),
+                bounds.size.height.as_f32(),
+            )
+            .into(),
+        });
+    }
+
+    fn set_visible(&self, visible: bool) {
+        let _ = self.webview.set_visible(visible);
+    }
+
+    fn load_url(&self, url: &str) {
+        let _ = self.webview.load_url(url);
+    }
+
+    fn load_html(&self, html: &str) {
+        let _ = self.webview.load_html(html);
+    }
+
+    fn go_back(&self) {
+        let _ = self.webview.evaluate_script("window.history.back()");
+    }
+
+    fn go_forward(&self) {
+        let _ = self.webview.evaluate_script("window.history.forward()");
+    }
+
+    fn reload(&self) {
+        let _ = self.webview.reload();
+    }
+
+    fn stop_loading(&self) {
+        let _ = self.webview.evaluate_script("window.stop()");
+    }
+
+    fn evaluate_javascript(
+        &self,
+        script: &str,
+        callback: Option<Box<dyn FnOnce(Result<String, String>) + Send>>,
+    ) {
+        match callback {
+            Some(cb) => {
+                let cb = Arc::new(Mutex::new(Some(cb)));
+                let cb_clone = cb.clone();
+                let _ = self
+                    .webview
+                    .evaluate_script_with_callback(script, move |result| {
+                        if let Some(f) = cb_clone.lock().unwrap().take() {
+                            f(Ok(result));
+                        }
+                    });
+            }
+            None => {
+                let _ = self.webview.evaluate_script(script);
+            }
+        }
+    }
+
+    fn title(&self) -> SharedString {
+        SharedString::default()
+    }
+
+    fn url(&self) -> SharedString {
+        self.webview
+            .url()
+            .map(SharedString::from)
+            .unwrap_or_default()
+    }
+
+    fn set_devtools_enabled(&self, _enabled: bool) {
+        // wry devtools are enabled/disabled at creation time via the builder.
+    }
+
+    fn focus(&self) {
+        let _ = self.webview.focus();
+    }
+}
+
+pub(crate) fn create_platform_webview(
+    window: &Window,
+    config: &WebViewConfig,
+    cx: &mut App,
+) -> Box<dyn PlatformWebView> {
+    Box::new(WryWebView::new(window, config, cx))
+}

--- a/crates/gpui_webview/src/webview.rs
+++ b/crates/gpui_webview/src/webview.rs
@@ -1,0 +1,282 @@
+use gpui::{
+    App, Bounds, Element, ElementId, GlobalElementId, InspectorElementId, IntoElement, LayoutId,
+    Pixels, Refineable, SharedString, Style, StyleRefinement, Styled, Window,
+};
+use std::rc::Rc;
+
+use crate::platform::{self, PlatformWebView};
+use crate::webview_handle::WebViewHandle;
+
+/// Configuration for creating a platform webview.
+#[allow(dead_code)]
+pub(crate) struct WebViewConfig {
+    pub url: Option<String>,
+    pub html: Option<String>,
+    pub transparent: bool,
+    pub devtools: bool,
+    pub zoom: f32,
+    pub bounds: Bounds<Pixels>,
+    pub initial_title: Option<SharedString>,
+}
+
+impl Default for WebViewConfig {
+    fn default() -> Self {
+        Self {
+            url: None,
+            html: None,
+            transparent: false,
+            devtools: false,
+            zoom: 1.0,
+            bounds: Bounds::default(),
+            initial_title: None,
+        }
+    }
+}
+
+/// Persistent state for a `WebView` element, stored across frames.
+pub(crate) struct WebViewState {
+    pub(crate) platform_webview: Rc<dyn PlatformWebView>,
+    pub(crate) last_bounds: Bounds<Pixels>,
+    pub(crate) last_known_url: SharedString,
+}
+
+/// A cross-platform native webview element for GPUI.
+///
+/// `WebView` renders a native webview (WebView2 on Windows, WKWebView on macOS)
+/// as a child view embedded inside GPUI's layout system.
+///
+/// # Example
+///
+/// ```ignore
+/// use gpui_webview::WebView;
+///
+/// fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+///     div().child(
+///         WebView::new("my-webview")
+///             .url("https://example.com")
+///             .w(px(800))
+///             .h(px(600))
+///     )
+/// }
+/// ```
+pub struct WebView {
+    id: SharedString,
+    config: WebViewConfig,
+    on_navigation: Option<Box<dyn FnMut(&str) -> bool>>,
+    on_page_load: Option<Box<dyn FnMut(&str)>>,
+    on_url_changed: Option<Box<dyn FnMut(&str, &mut Window, &mut App)>>,
+    on_create_handle: Option<Box<dyn FnMut(WebViewHandle, &mut Window, &mut App)>>,
+    style: StyleRefinement,
+}
+
+impl WebView {
+    /// Create a new WebView element with a unique ID.
+    pub fn new(id: impl Into<SharedString>) -> Self {
+        Self {
+            id: id.into(),
+            config: WebViewConfig::default(),
+            on_navigation: None,
+            on_page_load: None,
+            on_url_changed: None,
+            on_create_handle: None,
+            style: StyleRefinement::default(),
+        }
+    }
+
+    /// Set the initial URL to load.
+    pub fn url(mut self, url: &str) -> Self {
+        self.config.url = Some(url.to_string());
+        self
+    }
+
+    /// Set initial HTML content.
+    pub fn html(mut self, html: &str) -> Self {
+        self.config.html = Some(html.to_string());
+        self
+    }
+
+    /// Set whether the webview background is transparent.
+    pub fn transparent(mut self, transparent: bool) -> Self {
+        self.config.transparent = transparent;
+        self
+    }
+
+    /// Set whether the webview is dev-tools-enabled.
+    pub fn devtools(mut self, enabled: bool) -> Self {
+        self.config.devtools = enabled;
+        self
+    }
+
+    /// Set zoom factor.
+    pub fn zoom(mut self, factor: f32) -> Self {
+        self.config.zoom = factor;
+        self
+    }
+
+    /// Callback fired when navigation is attempted. Return false to block.
+    pub fn on_navigation(mut self, callback: impl FnMut(&str) -> bool + 'static) -> Self {
+        self.on_navigation = Some(Box::new(callback));
+        self
+    }
+
+    /// Callback fired when a page finishes loading.
+    pub fn on_page_load(mut self, callback: impl FnMut(&str) + 'static) -> Self {
+        self.on_page_load = Some(Box::new(callback));
+        self
+    }
+
+    /// Callback fired whenever the webview's main-frame URL changes.
+    ///
+    /// The URL is polled each frame and the callback is invoked with the new
+    /// URL. This is useful for keeping an address bar in sync with internal
+    /// page navigation (link clicks, redirects, etc.).
+    pub fn on_url_changed(
+        mut self,
+        callback: impl FnMut(&str, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_url_changed = Some(Box::new(callback));
+        self
+    }
+
+    /// Callback fired when the webview is first created, providing a handle.
+    pub fn on_create_handle(
+        mut self,
+        callback: impl FnMut(WebViewHandle, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_create_handle = Some(Box::new(callback));
+        self
+    }
+
+    fn element_id(&self) -> ElementId {
+        ElementId::from(self.id.clone())
+    }
+}
+
+impl IntoElement for WebView {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for WebView {
+    type RequestLayoutState = Style;
+    type PrepaintState = Option<WebViewHandle>;
+
+    fn id(&self) -> Option<ElementId> {
+        Some(self.element_id())
+    }
+
+    fn source_location(&self) -> Option<&'static std::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        let mut style = Style::default();
+        style.refine(&self.style);
+        let layout_id = window.request_layout(style.clone(), [], cx);
+        (layout_id, style)
+    }
+
+    fn prepaint(
+        &mut self,
+        id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Self::PrepaintState {
+        window.with_optional_element_state::<WebViewState, Option<WebViewHandle>>(
+            id,
+            |state, window| {
+                let is_first_creation = !matches!(state, Some(Some(_)));
+                let mut webview_state = match state {
+                    Some(Some(ref prev)) => {
+                        // Update bounds if changed
+                        if prev.last_bounds != bounds {
+                            prev.platform_webview.set_bounds(bounds);
+                        }
+                        WebViewState {
+                            platform_webview: prev.platform_webview.clone(),
+                            last_bounds: bounds,
+                            last_known_url: prev.last_known_url.clone(),
+                        }
+                    }
+                    _ => {
+                        // First prepaint: create the native webview
+                        self.config.bounds = bounds;
+                        let platform_webview =
+                            platform::create_platform_webview(window, &self.config, cx);
+                        let rc: Rc<dyn PlatformWebView> = Rc::from(platform_webview);
+                        WebViewState {
+                            platform_webview: rc,
+                            last_bounds: bounds,
+                            last_known_url: SharedString::default(),
+                        }
+                    }
+                };
+
+                let handle = WebViewHandle::new(webview_state.platform_webview.clone());
+
+                // Detect main-frame URL changes (e.g. internal navigation) and
+                // notify observers. `url()` reports the top-level document URL,
+                // so sub-frame navigations don't trigger spurious updates.
+                let current_url = webview_state.platform_webview.url();
+                if current_url != webview_state.last_known_url {
+                    let changed_url = current_url.clone();
+                    webview_state.last_known_url = current_url;
+                    // Ignore the transient blank state right after creation.
+                    if !changed_url.is_empty()
+                        && changed_url != "about:blank"
+                        && let Some(ref mut callback) = self.on_url_changed
+                    {
+                        callback(&changed_url, window, cx);
+                        // Callbacks fired from prepaint run mid-draw, where
+                        // entity-change notifications can't schedule a
+                        // redraw, so request one explicitly.
+                        window.defer(cx, |window, _cx| window.refresh());
+                    }
+                }
+
+                // Fire the on_create_handle callback on first creation
+                if is_first_creation && let Some(ref mut callback) = self.on_create_handle {
+                    callback(handle.clone(), window, cx);
+                }
+
+                (Some(handle), Some(webview_state))
+            },
+        )
+    }
+
+    fn paint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        _prepaint: &mut Self::PrepaintState,
+        _window: &mut Window,
+        _cx: &mut App,
+    ) {
+        // Native webview renders itself via the OS compositor.
+    }
+}
+
+impl Styled for WebView {
+    fn style(&mut self) -> &mut StyleRefinement {
+        &mut self.style
+    }
+}
+
+/// Shorthand for creating a [`WebView`] element.
+pub fn webview(id: impl Into<SharedString>) -> WebView {
+    WebView::new(id)
+}

--- a/crates/gpui_webview/src/webview_handle.rs
+++ b/crates/gpui_webview/src/webview_handle.rs
@@ -1,0 +1,74 @@
+use gpui::SharedString;
+use std::rc::Rc;
+
+use crate::platform::PlatformWebView;
+
+/// A handle for controlling a [`WebView`] after creation.
+///
+/// Obtained via the `on_create_handle` callback or by querying the element tree.
+/// This handle is cloneable and can be used to control the webview from anywhere
+/// in your application.
+#[derive(Clone)]
+pub struct WebViewHandle {
+    inner: Rc<dyn PlatformWebView>,
+}
+
+impl WebViewHandle {
+    pub(crate) fn new(inner: Rc<dyn PlatformWebView>) -> Self {
+        Self { inner }
+    }
+
+    /// Navigate to a URL.
+    pub fn load_url(&self, url: &str) {
+        self.inner.load_url(url);
+    }
+
+    /// Navigate to a data URL with HTML content.
+    pub fn load_html(&self, html: &str) {
+        self.inner.load_html(html);
+    }
+
+    /// Navigate back.
+    pub fn go_back(&self) {
+        self.inner.go_back();
+    }
+
+    /// Navigate forward.
+    pub fn go_forward(&self) {
+        self.inner.go_forward();
+    }
+
+    /// Reload the current page.
+    pub fn reload(&self) {
+        self.inner.reload();
+    }
+
+    /// Stop loading.
+    pub fn stop_loading(&self) {
+        self.inner.stop_loading();
+    }
+
+    /// Execute JavaScript in the webview.
+    pub fn evaluate_javascript(
+        &self,
+        script: &str,
+        callback: Option<Box<dyn FnOnce(Result<String, String>) + Send>>,
+    ) {
+        self.inner.evaluate_javascript(script, callback);
+    }
+
+    /// Get the current page title.
+    pub fn title(&self) -> SharedString {
+        self.inner.title()
+    }
+
+    /// Get the current page URL.
+    pub fn url(&self) -> SharedString {
+        self.inner.url()
+    }
+
+    /// Focus the webview.
+    pub fn focus(&self) {
+        self.inner.focus();
+    }
+}


### PR DESCRIPTION
# Add gpui_ce_webview: native OS webview support

I searched existing issues, PRs, and discussions for prior webview work ("webview", "wry", "browser", "webview2", "wkwebview") and found none.

## Summary

Adds a new `gpui_ce_webview` crate that wraps [`wry`](https://github.com/tauri-apps/wry) behind a GPUI `Element`, so applications can embed a native OS webview (WebView2 on Windows, WKWebView on macOS, WebKitGTK on Linux) inside a GPUI window. Includes a minimal `browser` example that demonstrates an address-bar-driven browser built on top of it.

Per [discussion #38](https://github.com/gpui-ce/gpui-ce/discussions/38), the community favors keeping the core `gpui` crate lean and factoring additional components into separate crates, with the option to re-export later behind a feature flag. This PR follows that shape rather than touching `crates/gpui` at all.

## What's included

- `crates/gpui_webview` (package `gpui_ce_webview`)
  - `webview.rs` the `WebView` element and its paint/layout integration with GPUI.
  - `webview_handle.rs` a cloneable handle for driving navigation (`load_url`, etc.) from outside the element.
  - `platform/wry_backend.rs` the wry-backed implementation (feature `webview`, on by default).
  - `platform/stub.rs` a no-op backend used when the `webview` feature is disabled, so consumers can compile without pulling in `wry` if they don't need it.
  - `examples/browser.rs` a small app with a URL bar and a `WebView`, showing basic navigation and URL-changed callbacks. Runs with `cargo run -p gpui_ce_webview --example browser`.

## Testing

- `cargo check --workspace` passes.
- `cargo fmt -p gpui_ce_webview -- --check` passes.
- `cargo clippy -p gpui_ce_webview --all-targets` passes with no warnings.
- Manually ran `cargo run -p gpui_ce_webview --example browser` and confirmed navigation, URL-bar sync on in-page navigation, and window resizing behave correctly on Windows (WebView2).
- Have not tested Linux (WebKitGTK) backends. Feedback/testing from anyone on those platforms is welcome.

## Open for maintainers

- Naming: I used `gpui_ce_webview` to match the crate-naming convention already used elsewhere in the workspace (`gpui_ce_platform`, `gpui_ce_elements`, etc.)
- Feature default: `webview` (i.e., pulling in `wry`) is on by default for the crate; open to flipping that if you'd rather it be opt-in.
- No CODEOWNERS entry currently applies to this crate specifically.

> AI Disclosure: Used claude for some implementation and examples. I am not a rust expert. 

Corresponding docs PR: https://github.com/gpui-ce/gpui-ce.github.io/pull/6