### PR TITLE
Extend Motion with delays, finite repeats, and auto-reverse playback

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -219,6 +219,10 @@ name = "style_transitions"
 path = "examples/learn/style_transitions.rs"
 
 [[example]]
+name = "motion_patterns"
+path = "examples/learn/motion_patterns.rs"
+
+[[example]]
 name = "haptic_feedback"
 path = "examples/learn/haptic_feedback.rs"
 

--- a/crates/gpui/examples/learn/motion_patterns.rs
+++ b/crates/gpui/examples/learn/motion_patterns.rs
@@ -1,0 +1,196 @@
+//! A showcase of delayed, counted, and alternating motion.
+//!
+//! Run with `cargo run -p gpui-ce --example motion_patterns`.
+
+#[path = "../shared/prelude.rs"]
+mod example_prelude;
+
+use gpui::{
+    App, AppContext, Bounds, Context, Motion, Repeat, Transition, Window, WindowBounds,
+    WindowOptions, div, ease_in_out, millis, prelude::*, px, rgb, size,
+};
+
+struct MotionPatterns;
+
+const WINDOW_PADDING: f32 = 24.;
+const LABEL_WIDTH: f32 = 190.;
+const LANE_GAP: f32 = 12.;
+const DOT_SIZE: f32 = 16.;
+
+fn button(id: &'static str, label: &'static str) -> gpui::Stateful<gpui::Div> {
+    div()
+        .id(id)
+        .px(px(14.))
+        .py(px(10.))
+        .rounded(px(8.))
+        .bg(rgb(0x30394d))
+        .cursor_pointer()
+        .hover(|style| style.bg(rgb(0x45516c)))
+        .child(label)
+}
+
+fn lane(
+    title: &'static str,
+    description: &'static str,
+    value: f32,
+    travel: f32,
+) -> impl IntoElement {
+    div()
+        .flex()
+        .items_center()
+        .gap(px(LANE_GAP))
+        .child(
+            div()
+                .w(px(LABEL_WIDTH))
+                .flex()
+                .flex_col()
+                .gap(px(2.))
+                .child(title)
+                .child(div().text_sm().text_color(rgb(0xaeb9d0)).child(description)),
+        )
+        .child(
+            div()
+                .relative()
+                .h(px(24.))
+                .flex_1()
+                .overflow_hidden()
+                .rounded(px(12.))
+                .bg(rgb(0x101522))
+                .child(
+                    div()
+                        .absolute()
+                        .top(px(4.))
+                        .left(px(travel * value))
+                        .size(px(DOT_SIZE))
+                        .rounded(px(DOT_SIZE / 2.))
+                        .bg(rgb(0x9bbcff)),
+                ),
+        )
+}
+
+impl Render for MotionPatterns {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let patterns = [
+            (
+                "Delay",
+                "350 ms before one pass",
+                Motion::new(millis(900)).with_delay(millis(350)),
+            ),
+            (
+                "Count",
+                "Three forward passes",
+                Motion::new(millis(900)).with_repeat(Repeat::Count(3)),
+            ),
+            (
+                "Auto-reverse",
+                "Two passes return to start",
+                Motion::new(millis(900))
+                    .with_repeat(Repeat::Count(2))
+                    .with_auto_reverse(true),
+            ),
+            (
+                "Forever",
+                "Alternates until Reset",
+                Motion::new(millis(900))
+                    .with_repeat(Repeat::Forever)
+                    .with_auto_reverse(true),
+            ),
+        ];
+
+        let travel = (f32::from(window.viewport_size().width)
+            - 2. * WINDOW_PADDING
+            - LABEL_WIDTH
+            - LANE_GAP
+            - DOT_SIZE)
+            .max(0.);
+        let mut transitions: Vec<Transition<f32>> = Vec::new();
+        let mut lanes = Vec::new();
+        for (index, (title, description, motion)) in patterns.into_iter().enumerate() {
+            let transition = window.use_keyed_transition(
+                ("motion-pattern", index),
+                cx,
+                motion.with_easing(ease_in_out),
+                |_, _| 0.0_f32,
+            );
+
+            if cx.reduce_motion() {
+                let goal = *transition.read_goal(cx);
+                transition.jump_to(goal, cx);
+            }
+
+            let value = *transition.evaluate(window, cx);
+            transitions.push(transition);
+            lanes.push(lane(title, description, value, travel));
+        }
+
+        let play = transitions.clone();
+        let reset = transitions.clone();
+        div()
+            .id("motion-patterns")
+            .size_full()
+            .overflow_y_scroll()
+            .flex()
+            .flex_col()
+            .gap(px(14.))
+            .p(px(WINDOW_PADDING))
+            .bg(rgb(0x141a26))
+            .text_color(rgb(0xe5edff))
+            .child(div().text_xl().child("Motion patterns"))
+            .child(
+                div()
+                    .text_sm()
+                    .text_color(rgb(0xaeb9d0))
+                    .child("One keyed transition, four Motion configurations."),
+            )
+            .child(
+                div()
+                    .flex()
+                    .flex_wrap()
+                    .gap(px(8.))
+                    .child(button("play", "Play").on_click(move |_, _, cx| {
+                        for transition in &play {
+                            transition.update(cx, |value, cx| {
+                                *value = 1.;
+                                cx.notify();
+                            });
+                        }
+                    }))
+                    .child(button("reset", "Reset").on_click(move |_, _, cx| {
+                        for transition in &reset {
+                            transition.reset(cx);
+                        }
+                    }))
+                    .child(
+                        button(
+                            "reduce-motion",
+                            if cx.reduce_motion() {
+                                "Reduced motion: on"
+                            } else {
+                                "Reduced motion: off"
+                            },
+                        )
+                        .on_click(|_, _, cx| cx.set_reduce_motion(!cx.reduce_motion())),
+                    ),
+            )
+            .children(lanes)
+    }
+}
+
+fn main() {
+    gpui_platform::application().run(|cx: &mut App| {
+        let bounds = Bounds::centered(None, size(px(700.), px(500.)), cx);
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
+                ..Default::default()
+            },
+            |window, cx| {
+                window.set_window_title("Motion patterns");
+                cx.new(|_| MotionPatterns)
+            },
+        )
+        .expect("Failed to open window");
+
+        example_prelude::init_example(cx, "Motion patterns");
+    });
+}

--- a/crates/gpui/src/animated.rs
+++ b/crates/gpui/src/animated.rs
@@ -11,7 +11,12 @@ pub struct AnimatedSample<T> {
     /// Whether another sample may produce a different value.
     pub is_active: bool,
 
-    /// Eased progress between the interruption anchor and logical value.
+    /// Eased progress within the current pass, from the interruption anchor
+    /// toward the logical value.
+    ///
+    /// Repeating or auto-reversing motion may reset or decrease this value
+    /// while active. Use `is_active` to determine whether the entire animation
+    /// has completed.
     pub progress: Progress,
 }
 
@@ -60,6 +65,7 @@ where
     }
 
     /// Updates the logical value while preserving positional continuity.
+    /// A changed target starts a new run, including its configured delay.
     pub fn set(&mut self, value: T, motion: &Motion, now: Time) -> bool {
         self.retarget(value, motion, now, true)
     }
@@ -91,7 +97,7 @@ where
     pub fn jump_to(&mut self, value: T) {
         self.value = value.clone();
         self.last_value = value;
-        self.settled_progress = None;
+        self.settled_progress = Some(Progress::END);
         self.started_at = None;
     }
 
@@ -143,12 +149,87 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Repeat;
 
     fn assert_sample(sample: AnimatedSample<f32>, value: f32, progress: Progress, is_active: bool) {
         assert_eq!(
             (sample.value, sample.progress, sample.is_active),
             (value, progress, is_active)
         );
+    }
+
+    #[test]
+    fn delayed_alternating_motion_preserves_position_on_retarget_and_completion() {
+        let motion = Motion::new(Duration::from_secs(1))
+            .with_delay(Duration::from_millis(500))
+            .with_repeat(Repeat::Count(2))
+            .with_auto_reverse(true);
+        let mut animated = Animated::<f32, Duration>::new(0.0, motion.clone());
+        assert!(animated.set(8.0, &motion, Duration::ZERO));
+        assert_sample(animated.sample(Duration::ZERO), 0.0, Progress::START, true);
+        assert_eq!(animated.sample(Duration::from_millis(1_000)).value, 4.0);
+        assert_eq!(animated.sample(Duration::from_millis(1_500)).value, 8.0);
+
+        // Retarget during the reverse pass. Hold the current position for a new
+        // delay, and return to that position when the two new passes finish.
+        assert_eq!(animated.sample(Duration::from_millis(1_750)).value, 6.0);
+        assert!(animated.set(16.0, &motion, Duration::from_millis(1_750)));
+        assert_sample(
+            animated.sample(Duration::from_millis(2_000)),
+            6.0,
+            Progress::START,
+            true,
+        );
+        assert_eq!(animated.sample(Duration::from_millis(2_750)).value, 11.0);
+        for ms in [4_250, 5_000] {
+            assert_sample(
+                animated.sample(Duration::from_millis(ms)),
+                6.0,
+                Progress::START,
+                false,
+            );
+        }
+        assert_eq!(*animated.value(), 16.0);
+        assert!(!animated.set(16.0, &motion, Duration::from_secs(5)));
+        assert_eq!(
+            animated.progress_at(Duration::from_secs(5)),
+            Progress::START
+        );
+    }
+
+    #[test]
+    fn retargeting_during_delay_restarts_delay_and_reset_cancels_it() {
+        let motion = Motion::new(Duration::from_secs(1)).with_delay(Duration::from_secs(1));
+        let mut animated = Animated::<f32, Duration>::new(2.0, motion.clone());
+        assert!(animated.set(10.0, &motion, Duration::ZERO));
+        assert!(animated.set(6.0, &motion, Duration::from_millis(500)));
+        assert_eq!(animated.sample(Duration::from_secs(1)).value, 2.0);
+        assert_eq!(animated.sample(Duration::from_secs(2)).value, 4.0);
+        animated.reset();
+        assert_sample(
+            animated.sample(Duration::from_secs(3)),
+            2.0,
+            Progress::END,
+            false,
+        );
+    }
+
+    #[test]
+    fn jumping_to_a_value_reports_completed_progress() {
+        let motion = Motion::new(Duration::from_secs(1))
+            .with_repeat(Repeat::Count(2))
+            .with_auto_reverse(true);
+        let mut animated = Animated::<f32, Duration>::new(0.0, motion);
+
+        animated.jump_to(8.0);
+
+        assert_sample(
+            animated.sample(Duration::from_secs(10)),
+            8.0,
+            Progress::END,
+            false,
+        );
+        assert_eq!(animated.progress_at(Duration::from_secs(10)), Progress::END);
     }
 
     #[test]

--- a/crates/gpui/src/motion.rs
+++ b/crates/gpui/src/motion.rs
@@ -32,13 +32,9 @@ impl Progress {
         self.0
     }
 
-    /// Returns whether this progress has reached the end.
+    /// Returns whether this progress has reached the end of the current pass.
     pub const fn is_complete(self) -> bool {
         self.0 >= Self::END.0
-    }
-
-    fn repeating(value: f32) -> Self {
-        Self::clamped(value % Self::END.0)
     }
 
     fn contains(value: f32) -> bool {
@@ -87,12 +83,17 @@ impl Default for Easing {
     }
 }
 
-/// Whether motion runs once or repeats indefinitely.
+/// Controls how many passes a motion runs.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum Repeat {
     /// Run once.
     #[default]
     Once,
+
+    /// Run a fixed number of passes, including the first pass.
+    ///
+    /// A count of zero leaves the motion at its starting value and inactive.
+    Count(u32),
 
     /// Repeat and remain active until the owner removes the animation.
     Forever,
@@ -101,24 +102,25 @@ pub enum Repeat {
 /// The result of evaluating motion at a point in time.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MotionSample {
-    /// Eased progress between zero and one.
+    /// Eased progress within the current pass.
+    ///
+    /// Repeating or auto-reversing motion may reset or decrease this value
+    /// while active. Use `is_active` to determine whether the entire motion
+    /// has completed.
     pub progress: Progress,
 
     /// Whether another sample may produce a different value.
     pub is_active: bool,
 }
 
-/// Configuration for one-shot or repeating motion.
+/// Configuration for delayed, one-shot, finite, or repeating motion.
 #[derive(Clone)]
 pub struct Motion {
-    /// How long this motion takes.
-    pub duration: Duration,
-
-    /// Maps linear progress to eased progress.
-    pub easing: Easing,
-
-    /// Whether this motion runs once or forever.
-    pub repeat: Repeat,
+    duration: Duration,
+    easing: Easing,
+    repeat: Repeat,
+    delay: Duration,
+    auto_reverse: bool,
 }
 
 impl Motion {
@@ -128,7 +130,34 @@ impl Motion {
             duration,
             easing: Easing::default(),
             repeat: Repeat::Once,
+            delay: Duration::ZERO,
+            auto_reverse: false,
         }
+    }
+
+    /// Returns the duration of each pass, excluding the initial delay.
+    pub fn duration(&self) -> Duration {
+        self.duration
+    }
+
+    /// Returns the easing function used by this motion.
+    pub fn easing(&self) -> &Easing {
+        &self.easing
+    }
+
+    /// Returns the motion's repeat policy.
+    pub fn repeat(&self) -> Repeat {
+        self.repeat
+    }
+
+    /// Returns the delay before the first pass of each run.
+    pub fn delay(&self) -> Duration {
+        self.delay
+    }
+
+    /// Returns whether every other pass runs in reverse.
+    pub fn auto_reverse(&self) -> bool {
+        self.auto_reverse
     }
 
     /// Replaces the linear easing function.
@@ -137,8 +166,46 @@ impl Motion {
         self
     }
 
+    /// Holds the starting value before the first pass of each run.
+    /// Retargeting an animated value starts a new run with this delay.
+    pub fn with_delay(mut self, delay: Duration) -> Self {
+        self.delay = delay;
+        self
+    }
+
+    /// Sets the motion's repeat policy.
+    pub fn with_repeat(mut self, repeat: Repeat) -> Self {
+        self.repeat = repeat;
+        self
+    }
+
+    /// Reverses every other pass. Two passes make one out-and-back cycle.
+    /// Before easing, finite motion ends at progress zero after an even number
+    /// of alternating passes, and at progress one after an odd number.
+    pub fn with_auto_reverse(mut self, auto_reverse: bool) -> Self {
+        self.auto_reverse = auto_reverse;
+        self
+    }
+
     /// Evaluates this motion after the supplied elapsed time.
+    /// During the delay, progress is zero and the motion remains active.
+    /// Zero-duration motion settles immediately after the delay, even when
+    /// repeating forever. [`Repeat::Count(0)`] is always inactive.
     pub fn sample(&self, elapsed: Duration) -> MotionSample {
+        if self.repeat == Repeat::Count(0) {
+            return MotionSample {
+                progress: Progress::START,
+                is_active: false,
+            };
+        }
+
+        let Some(elapsed) = elapsed.checked_sub(self.delay) else {
+            return MotionSample {
+                progress: Progress::START,
+                is_active: true,
+            };
+        };
+
         if self.duration.is_zero() {
             return MotionSample {
                 progress: self.resting_progress(),
@@ -146,18 +213,32 @@ impl Motion {
             };
         }
 
-        let linear_progress = elapsed.as_secs_f32() / self.duration.as_secs_f32();
-        let (linear_progress, is_active) = match self.repeat {
-            Repeat::Once => {
-                let progress = Progress::clamped(linear_progress);
-                (progress, !progress.is_complete())
-            }
-            Repeat::Forever => (Progress::repeating(linear_progress), true),
+        // Keep pass boundaries and parity exact, including after long runs or
+        // skipped frames. Only the fraction within one pass needs floating point.
+        let duration_nanos = self.duration.as_nanos();
+        let elapsed_nanos = elapsed.as_nanos();
+        let pass = elapsed_nanos / duration_nanos;
+        let finished = match self.repeat {
+            Repeat::Once => pass >= 1,
+            Repeat::Count(count) => pass >= u128::from(count),
+            Repeat::Forever => false,
+        };
+
+        let linear_progress = if finished {
+            self.resting_progress()
+        } else {
+            let fraction = (elapsed_nanos % duration_nanos) as f64 / duration_nanos as f64;
+            let progress = if self.auto_reverse && pass % 2 == 1 {
+                1.0 - fraction
+            } else {
+                fraction
+            };
+            Progress::clamped(progress as f32)
         };
 
         MotionSample {
             progress: self.easing.sample(linear_progress),
-            is_active,
+            is_active: !finished,
         }
     }
 
@@ -172,6 +253,9 @@ impl Motion {
     pub(crate) fn resting_progress(&self) -> Progress {
         match self.repeat {
             Repeat::Once => Progress::END,
+            Repeat::Count(0) => Progress::START,
+            Repeat::Count(count) if self.auto_reverse && count % 2 == 0 => Progress::START,
+            Repeat::Count(_) => Progress::END,
             Repeat::Forever => Progress::START,
         }
     }
@@ -196,6 +280,116 @@ pub type MotionInfo = Motion;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_sample(motion: &Motion, elapsed: Duration, progress: f32, is_active: bool) {
+        assert_eq!(
+            motion.sample(elapsed),
+            MotionSample {
+                progress: Progress::clamped(progress),
+                is_active,
+            },
+            "at {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn delayed_counted_motion_waits_only_before_the_first_pass() {
+        let motion = Motion::new(secs(1))
+            .with_delay(millis(500))
+            .with_repeat(Repeat::Count(3));
+
+        for (ms, progress, active) in [
+            (0, 0.0, true),
+            (499, 0.0, true),
+            (500, 0.0, true),
+            (750, 0.25, true),
+            (1_500, 0.0, true),
+            (1_750, 0.25, true),
+            (2_500, 0.0, true),
+            (3_250, 0.75, true),
+            (3_500, 1.0, false),
+            (9_000, 1.0, false),
+        ] {
+            assert_sample(&motion, millis(ms), progress, active);
+        }
+    }
+
+    #[test]
+    fn alternating_passes_reverse_the_easing_curve_and_settle_by_parity() {
+        let motion = Motion::new(secs(1))
+            .with_easing(|progress| progress * progress)
+            .with_repeat(Repeat::Count(4))
+            .with_auto_reverse(true);
+
+        for (ms, progress, active) in [
+            (250, 0.0625, true),
+            (1_000, 1.0, true),
+            (1_250, 0.5625, true),
+            (2_000, 0.0, true),
+            (3_000, 1.0, true),
+            (4_000, 0.0, false),
+            (9_000, 0.0, false),
+        ] {
+            assert_sample(&motion, millis(ms), progress, active);
+        }
+
+        let odd = motion.clone().with_repeat(Repeat::Count(3));
+        assert_sample(&odd, secs(3), 1.0, false);
+        let forever = motion.with_repeat(Repeat::Forever);
+        assert_sample(&forever, secs(4), 0.0, true);
+        assert_sample(&forever, secs(5), 1.0, true);
+    }
+
+    #[test]
+    fn zero_passes_and_zero_duration_have_finite_activity() {
+        let motion = Motion::new(Duration::ZERO)
+            .with_delay(secs(1))
+            .with_auto_reverse(true);
+        for (repeat, end) in [(Repeat::Once, 1.0), (Repeat::Forever, 0.0)] {
+            let motion = motion.clone().with_repeat(repeat);
+            assert_sample(&motion, millis(999), 0.0, true);
+            assert_sample(&motion, secs(1), end, false);
+            assert_sample(&motion, Duration::MAX, end, false);
+        }
+        for (count, end) in [(1, 1.0), (2, 0.0), (3, 1.0)] {
+            let motion = motion.clone().with_repeat(Repeat::Count(count));
+            assert_sample(&motion, millis(999), 0.0, true);
+            assert_sample(&motion, secs(1), end, false);
+            assert_sample(&motion, Duration::MAX, end, false);
+        }
+        for duration in [Duration::ZERO, secs(1)] {
+            let motion = Motion::new(duration)
+                .with_delay(secs(1))
+                .with_repeat(Repeat::Count(0));
+            assert_sample(&motion, Duration::ZERO, 0.0, false);
+            assert_sample(&motion, Duration::MAX, 0.0, false);
+        }
+    }
+
+    #[test]
+    fn delay_holds_the_origin_even_with_a_nonzero_easing_start() {
+        let motion = Motion::new(secs(1))
+            .with_delay(secs(1))
+            .with_easing(|_| 0.5);
+        assert_sample(&motion, millis(999), 0.0, true);
+        assert_sample(&motion, secs(1), 0.5, true);
+    }
+
+    #[test]
+    fn pass_boundaries_remain_exact_for_long_runs_and_tiny_durations() {
+        let motion = Motion::new(Duration::from_nanos(2))
+            .with_repeat(Repeat::Forever)
+            .with_auto_reverse(true);
+        // The elapsed nanoseconds exceed the integer precision of f32 and f64.
+        assert_sample(&motion, Duration::new(100_000_000, 1), 0.5, true);
+        assert_sample(&motion, Duration::new(100_000_000, 2), 1.0, true);
+        assert_sample(&motion, Duration::MAX, 0.5, true);
+
+        let finite = motion.with_repeat(Repeat::Count(u32::MAX));
+        assert_sample(&finite, Duration::MAX, 1.0, false);
+        let long = Motion::new(Duration::MAX).with_repeat(Repeat::Count(u32::MAX));
+        assert_sample(&long, Duration::MAX, 0.0, true);
+    }
 
     #[test]
     fn creates_durations() {
@@ -245,15 +439,13 @@ mod tests {
         assert_eq!(once.progress, Progress::END);
         assert!(!once.is_active);
 
-        let mut repeating = Motion::new(Duration::ZERO);
-        repeating.repeat = Repeat::Forever;
+        let repeating = Motion::new(Duration::ZERO).with_repeat(Repeat::Forever);
         let sample = repeating.sample(Duration::from_secs(10));
         assert_eq!(sample.progress, Progress::START);
         assert!(!sample.is_active);
 
         let duration = Duration::from_secs(1);
-        let mut motion = Motion::new(duration);
-        motion.repeat = Repeat::Forever;
+        let motion = Motion::new(duration).with_repeat(Repeat::Forever);
 
         assert_eq!(
             motion.sample(Duration::from_millis(250)),

--- a/crates/gpui/src/style_transitions.rs
+++ b/crates/gpui/src/style_transitions.rs
@@ -196,7 +196,9 @@ fn apply_auto_size(
     let sample = animated.sample(now);
     state.authored_goal = Some(authored_goal);
 
-    if sample.is_active {
+    // Counted, alternating motion can finish at its origin rather than the
+    // authored endpoint. Keep that presentation value after playback stops.
+    if sample.is_active || sample.value != endpoint {
         *value = Length::Definite(DefiniteLength::Absolute(AbsoluteLength::Pixels(
             sample.value,
         )));
@@ -282,8 +284,9 @@ where
 
     let restore_none = value.is_none();
     let target = value.clone().unwrap_or_default();
-    let (in_progress, evaluated_value) = evaluate(state, Some(target), motion, now, reduce_motion);
-    *value = if restore_none && !in_progress {
+    let (in_progress, evaluated_value) =
+        evaluate(state, Some(target.clone()), motion, now, reduce_motion);
+    *value = if restore_none && !in_progress && evaluated_value.as_ref() == Some(&target) {
         None
     } else {
         evaluated_value
@@ -355,8 +358,8 @@ mod tests {
     use super::*;
     use crate::{
         AbsoluteLength, AnyWindowHandle, Bounds, Corners, DefiniteLength, InputEvent as _, Length,
-        MouseButton, MouseDownEvent, MouseUpEvent, Pixels, Style, TestAppContext, Window, canvas,
-        div, point, prelude::*, px, rems, size,
+        MouseButton, MouseDownEvent, MouseUpEvent, Pixels, Repeat, Style, TestAppContext, Window,
+        canvas, div, point, prelude::*, px, rems, size,
     };
 
     fn length(value: f32) -> Length {
@@ -370,6 +373,112 @@ mod tests {
             top_right: value,
             bottom_right: value,
             bottom_left: value,
+        }
+    }
+
+    #[test]
+    fn counted_style_motion_keeps_returned_values_and_respects_reduced_motion() {
+        let motion = Motion::new(Duration::from_secs(1))
+            .with_delay(Duration::from_millis(500))
+            .with_repeat(Repeat::Count(2))
+            .with_auto_reverse(true);
+        let transitions = StyleTransitions::default()
+            .w(motion.clone())
+            .opacity(motion);
+        let context = StyleTransitionContext::new(None, px(16.0));
+        let start = Instant::now();
+        let mut state = StyleTransitionState::default();
+        let mut initial = Style {
+            size: size(length(10.0), length(10.0)),
+            opacity: Some(0.0),
+            ..Style::default()
+        };
+        assert!(!transitions.apply(&mut initial, &mut state, context, start, false));
+
+        for (ms, expected, active) in [
+            (0, 0.0, true),
+            (250, 0.0, true),
+            (1_000, 0.5, true),
+            (1_500, 1.0, true),
+            (2_000, 0.5, true),
+            (2_500, 0.0, false),
+            (3_000, 0.0, false),
+        ] {
+            let mut style = Style {
+                size: size(length(20.0), length(10.0)),
+                opacity: Some(1.0),
+                ..Style::default()
+            };
+            assert_eq!(
+                transitions.apply(
+                    &mut style,
+                    &mut state,
+                    context,
+                    start + Duration::from_millis(ms),
+                    false,
+                ),
+                active,
+            );
+            assert_eq!(style.size.width, length(10.0 + 10.0 * expected));
+            assert_eq!(style.opacity, Some(expected));
+        }
+
+        // Enabling reduced motion during a new delayed run immediately applies
+        // the authored values. Disabling it must not restart the old motion.
+        for (ms, reduce_motion) in [(3_000, false), (3_100, true), (3_200, false)] {
+            let mut style = Style {
+                size: size(length(30.0), length(10.0)),
+                opacity: Some(0.25),
+                ..Style::default()
+            };
+            let active = transitions.apply(
+                &mut style,
+                &mut state,
+                context,
+                start + Duration::from_millis(ms),
+                reduce_motion,
+            );
+            assert_eq!(active, ms == 3_000);
+            if ms > 3_000 {
+                assert_eq!(style.size.width, length(30.0));
+                assert_eq!(style.opacity, Some(0.25));
+            }
+        }
+    }
+
+    #[test]
+    fn optional_style_is_not_removed_when_alternating_motion_returns_to_some() {
+        let motion = Motion::new(Duration::from_secs(1))
+            .with_repeat(Repeat::Count(2))
+            .with_auto_reverse(true);
+        let start = Instant::now();
+        let mut state = None;
+        let mut initial = Some(4.0_f32);
+        assert!(!apply_optional(
+            &mut state,
+            &mut initial,
+            Some(&motion),
+            start,
+            false
+        ));
+        for (ms, expected, active) in [
+            (0, Some(4.0), true),
+            (1_000, Some(0.0), true),
+            (2_000, Some(4.0), false),
+            (3_000, Some(4.0), false),
+        ] {
+            let mut value = None;
+            assert_eq!(
+                apply_optional(
+                    &mut state,
+                    &mut value,
+                    Some(&motion),
+                    start + Duration::from_millis(ms),
+                    false,
+                ),
+                active,
+            );
+            assert_eq!(value, expected);
         }
     }
 

--- a/crates/gpui/src/transition.rs
+++ b/crates/gpui/src/transition.rs
@@ -153,9 +153,9 @@ impl<T: Lerp + Clone + PartialEq + 'static> Transition<T> {
 
     /// Evaluates and returns the current progress delta of the transition.
     ///
-    /// Returns a value between 0.0 and 1.0 representing how far the transition
-    /// has progressed, after applying the easing function. A value of 0.0 means
-    /// the transition just started, and 1.0 means it has completed.
+    /// Returns eased progress between 0.0 and 1.0 within the current pass.
+    /// Progress can decrease on a reverse pass or reset when repeating; reaching
+    /// 1.0 does not necessarily mean that the entire motion has completed.
     pub fn evaluate_delta(&self, cx: &App) -> f32 {
         if self.cache.borrow().value.is_some() {
             return self.cache.borrow().progress.get();
@@ -251,7 +251,7 @@ mod tests {
     use std::rc::Rc;
     use std::time::Duration;
 
-    use crate::{AppContext, Context, IntoElement, Render, canvas, px, size};
+    use crate::{AppContext, Context, IntoElement, Render, Repeat, canvas, px, size};
 
     use super::*;
     use gpui::TestAppContext;
@@ -348,6 +348,28 @@ mod tests {
             assert_eq!(*mutators.read_goal(cx), 2.0);
             assert!(mutators.read_cache().is_none());
         });
+    }
+
+    #[test]
+    fn repeating_transition_progress_is_relative_to_the_current_pass() {
+        let motion = Motion::new(Duration::from_secs(1))
+            .with_repeat(Repeat::Count(2))
+            .with_auto_reverse(true);
+        let mut state = Animated::<f32, Duration>::new(0.0_f32, motion.clone());
+        assert!(state.set(10.0, &motion, Duration::ZERO));
+
+        assert_eq!(
+            state.sample(Duration::from_millis(750)).progress.get(),
+            0.75
+        );
+        assert_eq!(
+            state.sample(Duration::from_millis(1_250)).progress.get(),
+            0.75
+        );
+
+        let completed = state.sample(Duration::from_secs(2));
+        assert_eq!(completed.progress, Progress::START);
+        assert!(!completed.is_active);
     }
 
     #[gpui::test]


### PR DESCRIPTION
# Summary

1. `Repeat` is the single playback policy: `Once`, `Count(n)` for a fixed number of passes, or `Forever`. Finite counts are configured with `with_repeat(Repeat::Count(n))`.
2. `Motion` owns its repeat, delay, and auto-reverse configuration; `Easing` only maps normalized progress. Motion configuration is exposed through builders and accessors.
3. `Motion::sample` uses integer nanosecond arithmetic for deterministic pass boundaries and repeat parity across long durations, skipped frames, and very short intervals.
4. Finite auto-reversing motions choose their resting endpoint by pass parity before easing: odd counts use `Progress::END`, even counts use `Progress::START`, and `Count(0)` is inactive at the starting value.
5. `Animated` preserves sampled-value continuity when retargeting, restarts configured delays for new runs, reports completion after an immediate jump, and handles completion and reset consistently.
6. Style transitions preserve the final presentation value of finite alternating motions, including auto-sized and optional style properties. `Transition::evaluate_delta` documents progress within the current pass, which may reset or decrease during repeats and reverse passes.
7. Example: run `cargo run -p gpui-ce --example motion_patterns --locked`. It demonstrates delay, finite repeats, auto-reverse, infinite alternating playback, Play, Reset, and reduced-motion handling using keyed transitions.

# Motivation

`Motion` supports one-shot and indefinitely repeating playback, but common UI patterns also need delayed starts, bounded repetition, alternating playback, and composition with retargeting and style transitions. These capabilities support staggered work, notification entrances, progress indicators, and reversible status feedback.

# Design

`Repeat::Count(n)` represents the total number of passes, including the first. `Count(0)` is an inactive no-op. `with_delay` applies once at the start of each run and restarts when an animated value is retargeted. `with_auto_reverse(true)` reverses every other pass; for finite motion, the pre-easing resting endpoint is the start after an even number of passes and the end after an odd number.

Continuous retargeting preserves the current sampled value while beginning a new delayed run. Pass selection and parity use integer nanoseconds, converting only the fraction within the current pass to floating point. `Motion::new` still creates a linear, one-pass motion with no delay unless other builders are used.

# Integration

The change is implemented through the existing `Motion` -> `Animated` -> `Transition` stack. Style transitions retain their actual final presentation value when a finite alternating motion ends at its origin, including auto-sized and optional properties.

# API Note (breaking change)

`Motion` configuration is now encapsulated behind builders and accessors rather than exposed as public fields. This keeps the existing and newly added playback options consistent and makes the type easier to evolve without exposing its internal representation.

For example, repeat count plus auto-reverse determines the resting endpoint, delay affects each new run, and zero duration/count have special behavior. Encapsulation lets GPUI change the internal representation later without breaking every caller.

It also provides better syntax for animation definitions, for example:

New:
```
let motion = Motion::new(millis(300))
    .with_easing(ease_in_out)
    .with_delay(millis(100))
    .with_repeat(Repeat::Count(2))
    .with_auto_reverse(true);
```
Before:
```
let mut motion = Motion::new(millis(300));
motion.easing = Easing::new(ease_in_out);
motion.delay = millis(100);
motion.repeat = Repeat::Count(2);
motion.auto_reverse = true;
```

Downstream code that directly accesses or modifies `duration`, `easing`, or `repeat` must use the corresponding methods instead.

# Testing

- `cargo fmt --all -- --check`
- `cargo test -p gpui-ce --lib --features test-support --locked --no-fail-fast`
- `cargo build -p gpui-ce --examples --locked`
- `git diff --check`

# AI Disclosure

AI assistance (GPT 5.6) was used for repository analysis and environment setup. AI was used partially in implementation and in the example. I am a software developer, but AI writes better Rust code than me. All code has been read and reviewed by me.
