### PR TITLE
gpui_media: decide the build script's work by target OS, not host, so a Linux host can cross-compile to Darwin

### DIFF
--- a/crates/gpui_media/build.rs
+++ b/crates/gpui_media/build.rs
@@ -1,16 +1,28 @@
 #![allow(clippy::disallowed_methods, reason = "build scripts are exempt")]
-#[cfg(target_os = "macos")]
 fn main() {
     use std::{env, path::PathBuf, process::Command};
 
-    let sdk_path = String::from_utf8(
-        Command::new("xcrun")
-            .args(["--sdk", "macosx", "--show-sdk-path"])
-            .output()
-            .unwrap()
-            .stdout,
-    )
-    .unwrap();
+    // A build script compiles for the host, so `cfg!(target_os)` here would
+    // describe the machine running cargo. The platform being compiled for is
+    // only visible through the environment cargo sets for build scripts.
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("macos") {
+        return;
+    }
+
+    // An explicit SDKROOT (a cross build, or a pinned SDK) wins over asking
+    // Xcode, which a non-Apple host does not have.
+    println!("cargo:rerun-if-env-changed=SDKROOT");
+    let sdk_path = match env::var("SDKROOT") {
+        Ok(root) if !root.is_empty() => root,
+        _ => String::from_utf8(
+            Command::new("xcrun")
+                .args(["--sdk", "macosx", "--show-sdk-path"])
+                .output()
+                .expect("neither SDKROOT nor xcrun can locate the macOS SDK")
+                .stdout,
+        )
+        .unwrap(),
+    };
     let sdk_path = sdk_path.trim_end();
 
     println!("cargo:rerun-if-changed=src/bindings.h");
@@ -39,6 +51,3 @@ fn main() {
         .write_to_file(out_path.join("bindings.rs"))
         .expect("couldn't write dispatch bindings");
 }
-
-#[cfg(not(target_os = "macos"))]
-fn main() {}


### PR DESCRIPTION
Cross-compiling a gpui-ce app to `aarch64-apple-darwin` from a Linux host fails inside `gpui_media`'s build script:

```
error: couldn't read .../gpui_media-.../out/bindings.rs
```

The script gates its work on `#[cfg(target_os = "macos")]`. A build script compiles for the host, so that gate describes the machine running cargo, not the platform being compiled for. On a Linux host it is false, the CoreMedia bindings are never generated, and the crate fails on the missing file. The Cargo book calls this out explicitly in the build scripts chapter: check `CARGO_CFG_TARGET_OS` in a build script, never `cfg!`.

The top-level `gpui/build.rs` already does it the right way, reading `CARGO_CFG_TARGET_OS`. This PR brings `gpui_media` in line: same gate, plus `SDKROOT` is honored before falling back to `xcrun`, which only exists on a Mac. Cross builds and pinned-SDK builds set that variable anyway; on a Mac without it nothing changes.

No public API changes. Behavior on a macOS host is unchanged: the target check is true there and the same code path runs.

Rebased onto #215. That migration removed `gpui_apple`'s Metal build script, which had the same host gate and a macOS-gated `[build-dependencies]` table that cargo also resolved against the host, so the `gpui_apple` half of this PR is no longer needed and was dropped.

Verified:

- On our Linux CI (aarch64, no Xcode, SDK from Apple's Command Line Tools package, zig as linker via cargo-zigbuild) the equivalent patch applied to the published `gpui_ce_media` 0.2.2 takes a gpui-ce application from the error above to a green `cargo clippy --target aarch64-apple-darwin` and a release build whose `.app` launches on an Apple Silicon Mac.
- `cargo check -p gpui_ce_media` on macOS passes both with `SDKROOT` unset (xcrun path) and set (SDKROOT path).

One thing to flag for you rather than fix here: Zed upstream has the same host-gated `cfg` in `crates/media/build.rs`, so a future sync from Zed will bring it back unless this change is carried as a local patch or the sync notices the conflict. How you'd like to handle that is your call.
