### PR TITLE
Add Corner Smoothing

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -227,6 +227,10 @@ name = "blur"
 path = "examples/learn/blur.rs"
 
 [[example]]
+name = "corner_smoothing"
+path = "examples/learn/corner_smoothing.rs"
+
+[[example]]
 name = "keyring"
 path = "examples/learn/keyring.rs"
 

--- a/crates/gpui/examples/learn/corner_smoothing.rs
+++ b/crates/gpui/examples/learn/corner_smoothing.rs
@@ -1,0 +1,346 @@
+//! Corner smoothing
+//!
+//! Adjust a rounded rectangle's smoothing, radius, width, and height.
+
+#[path = "../shared/prelude.rs"]
+mod example_prelude;
+
+use gpui::{
+    App, Bounds, Context, Window, WindowBounds, WindowOptions, actions, div, prelude::*, px, rgb,
+    rgba, size,
+};
+use palette::WithAlpha;
+use slider::Slider;
+
+actions!(app, [Quit]);
+
+const INITIAL_SIZE: f32 = 200.;
+const MIN_SIZE: f32 = 20.;
+const MAX_SIZE: f32 = 280.;
+
+struct CornerSmoothingExample {
+    corner_smoothing: f32,
+    corner_radius: f32,
+    width: f32,
+    height: f32,
+}
+
+impl CornerSmoothingExample {
+    fn clamp_corner_radius(&mut self) {
+        self.corner_radius = self.corner_radius.min(self.width.min(self.height) / 2.);
+    }
+}
+
+impl Render for CornerSmoothingExample {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let max_corner_radius = self.width.min(self.height) / 2.;
+
+        div()
+            .relative()
+            .size_full()
+            .bg(rgb(0x110f15))
+            .child(
+                div()
+                    .absolute()
+                    .inset_0()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .pb(px(200.))
+                    .child(
+                        div().flex().flex_col().items_center().gap(px(28.)).child(
+                            div()
+                                .w(px(self.width))
+                                .h(px(self.height))
+                                .rounded(px(self.corner_radius))
+                                .rounded_smoothing(self.corner_smoothing)
+                                .bg(rgba(0x663399b8).with_alpha(0.5)),
+                        ),
+                    ),
+            )
+            .child(
+                div()
+                    .absolute()
+                    .left(px(0.))
+                    .right(px(0.))
+                    .bottom(px(48.))
+                    .flex()
+                    .justify_center()
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .items_center()
+                            .gap(px(20.))
+                            .child(
+                                div()
+                                    .flex()
+                                    .gap(px(32.))
+                                    .child(
+                                        Slider::new(
+                                            "corner-smoothing-slider",
+                                            "Corner smoothing",
+                                            self.corner_smoothing,
+                                            0.,
+                                            1.,
+                                        )
+                                        .display_value(format!("{:.2}", self.corner_smoothing))
+                                        .on_change(
+                                            cx.processor(|this, smoothing, _window, cx| {
+                                                this.corner_smoothing = smoothing;
+                                                cx.notify();
+                                            }),
+                                        ),
+                                    )
+                                    .child(
+                                        Slider::new(
+                                            "radius-slider",
+                                            "Radius",
+                                            self.corner_radius,
+                                            0.,
+                                            max_corner_radius,
+                                        )
+                                        .on_change(
+                                            cx.processor(|this, radius, _window, cx| {
+                                                this.corner_radius = radius;
+                                                cx.notify();
+                                            }),
+                                        ),
+                                    ),
+                            )
+                            .child(
+                                div()
+                                    .flex()
+                                    .gap(px(32.))
+                                    .child(
+                                        Slider::new(
+                                            "width-slider",
+                                            "Width",
+                                            self.width,
+                                            MIN_SIZE,
+                                            MAX_SIZE,
+                                        )
+                                        .on_change(
+                                            cx.processor(|this, width, _window, cx| {
+                                                this.width = width;
+                                                this.clamp_corner_radius();
+                                                cx.notify();
+                                            }),
+                                        ),
+                                    )
+                                    .child(
+                                        Slider::new(
+                                            "height-slider",
+                                            "Height",
+                                            self.height,
+                                            MIN_SIZE,
+                                            MAX_SIZE,
+                                        )
+                                        .on_change(
+                                            cx.processor(|this, height, _window, cx| {
+                                                this.height = height;
+                                                this.clamp_corner_radius();
+                                                cx.notify();
+                                            }),
+                                        ),
+                                    ),
+                            ),
+                    ),
+            )
+    }
+}
+
+fn main() {
+    gpui_platform::application().run(|cx: &mut App| {
+        let bounds = Bounds::centered(None, size(px(500.), px(650.)), cx);
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
+                ..Default::default()
+            },
+            |_, cx| {
+                cx.new(|_| CornerSmoothingExample {
+                    corner_smoothing: 1.,
+                    corner_radius: 40.,
+                    width: INITIAL_SIZE,
+                    height: INITIAL_SIZE,
+                })
+            },
+        )
+        .expect("Failed to open window");
+
+        example_prelude::init_example(cx, "Corner Smoothing");
+    });
+}
+
+mod slider {
+    use std::{cell::Cell, rc::Rc};
+
+    use gpui::{
+        App, Bounds, ColorExt, Context, DragMoveEvent, MouseButton, Pixels, Window, div,
+        prelude::*, px, relative, rgb,
+    };
+
+    const WIDTH: f32 = 180.;
+
+    type ChangeHandler = Rc<dyn Fn(f32, &mut Window, &mut App)>;
+
+    #[derive(Clone)]
+    struct SliderDrag {
+        id: &'static str,
+    }
+
+    impl Render for SliderDrag {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            gpui::Empty
+        }
+    }
+
+    #[derive(IntoElement)]
+    pub struct Slider {
+        id: &'static str,
+        label: &'static str,
+        value: f32,
+        min: f32,
+        max: f32,
+        value_text: String,
+        on_change: Option<ChangeHandler>,
+    }
+
+    impl Slider {
+        pub fn new(id: &'static str, label: &'static str, value: f32, min: f32, max: f32) -> Self {
+            Self {
+                id,
+                label,
+                value,
+                min,
+                max,
+                value_text: format!("{value:.0}px"),
+                on_change: None,
+            }
+        }
+
+        pub fn display_value(mut self, value: impl Into<String>) -> Self {
+            self.value_text = value.into();
+            self
+        }
+
+        pub fn on_change(
+            mut self,
+            callback: impl Fn(f32, &mut Window, &mut App) + 'static,
+        ) -> Self {
+            self.on_change = Some(Rc::new(callback));
+            self
+        }
+
+        fn value_from_position(
+            position_x: Pixels,
+            bounds: Bounds<Pixels>,
+            min: f32,
+            max: f32,
+        ) -> f32 {
+            let position = (position_x - bounds.left()).clamp(px(0.), bounds.size.width);
+            let percentage = position / bounds.size.width;
+            min + (max - min) * percentage
+        }
+    }
+
+    impl RenderOnce for Slider {
+        fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+            let percentage = ((self.value - self.min) / (self.max - self.min)).clamp(0., 1.);
+            let track_bounds = Rc::new(Cell::new(None));
+
+            let click_bounds = track_bounds.clone();
+            let click_handler = self.on_change.clone();
+            let drag_handler = self.on_change.clone();
+            let id = self.id;
+            let min = self.min;
+            let max = self.max;
+
+            let track = div()
+                .id(id)
+                .relative()
+                .w_full()
+                .h(px(24.))
+                .flex()
+                .items_center()
+                .cursor_pointer()
+                .on_mouse_down(MouseButton::Left, move |event, window, cx| {
+                    if let (Some(bounds), Some(handler)) = (click_bounds.get(), &click_handler) {
+                        handler(
+                            Slider::value_from_position(event.position.x, bounds, min, max),
+                            window,
+                            cx,
+                        );
+                    }
+                })
+                .on_drag(SliderDrag { id }, |drag, _, _, cx| cx.new(|_| drag.clone()))
+                .on_drag_move(move |event: &DragMoveEvent<SliderDrag>, window, cx| {
+                    let is_active_slider = event.drag(cx).id == id;
+                    if is_active_slider && let Some(handler) = &drag_handler {
+                        handler(
+                            Slider::value_from_position(
+                                event.event.position.x,
+                                event.bounds,
+                                min,
+                                max,
+                            ),
+                            window,
+                            cx,
+                        );
+                    }
+                })
+                .child(
+                    div()
+                        .relative()
+                        .w_full()
+                        .h(px(6.))
+                        .rounded_full()
+                        .bg(rgb(0xffffff).opacity(0.18))
+                        .child(
+                            div()
+                                .absolute()
+                                .left(px(0.))
+                                .right(relative(1. - percentage))
+                                .h_full()
+                                .rounded_full()
+                                .bg(rgb(0x9b6dce)),
+                        )
+                        .child(
+                            div()
+                                .absolute()
+                                .top(px(-5.))
+                                .left(relative(percentage))
+                                .ml(px(-8.))
+                                .size(px(16.))
+                                .rounded_full()
+                                .bg(rgb(0xe8dff2))
+                                .shadow_md(),
+                        ),
+                );
+
+            div()
+                .w(px(WIDTH))
+                .flex()
+                .flex_col()
+                .gap(px(8.))
+                .child(
+                    div()
+                        .flex()
+                        .justify_between()
+                        .text_sm()
+                        .text_color(rgb(0xe8dff2))
+                        .child(self.label)
+                        .child(self.value_text),
+                )
+                .child(
+                    div()
+                        .w_full()
+                        .on_children_prepainted(move |bounds, _window, _cx| {
+                            track_bounds.set(bounds.first().copied());
+                        })
+                        .child(track),
+                )
+        }
+    }
+}

--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -493,10 +493,11 @@ impl Element for Img {
                         .get_bounds(bounds, data.size(layout_state.frame_index));
                     let corner_radii = style.corner_radii.to_pixels(window.rem_size());
                     window
-                        .paint_image(
+                        .paint_image_with_corner_smoothing(
                             bounds,
                             new_bounds,
                             corner_radii,
+                            style.corner_smoothing.unwrap_or_default(),
                             data,
                             layout_state.frame_index,
                             self.style.grayscale,

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -469,6 +469,10 @@ fn precedes_limit(
     limit.is_none_or(|limit| (order, kind) < limit)
 }
 
+fn has_corner_smoothing(corner_smoothing: f32) -> bool {
+    corner_smoothing > 0.0
+}
+
 impl<'a> Iterator for BatchIterator<'a> {
     type Item = PrimitiveBatch;
 
@@ -535,32 +539,48 @@ impl<'a> Iterator for BatchIterator<'a> {
 
         match batch_kind {
             PrimitiveKind::Shadow => {
+                let smoothed =
+                    has_corner_smoothing(self.shadows_iter.peek().unwrap().corner_smoothing);
                 let shadows_start = self.shadows_start;
                 let mut shadows_end = shadows_start + 1;
                 self.shadows_iter.next();
                 while self
                     .shadows_iter
-                    .next_if(|shadow| precedes_limit(shadow.order, batch_kind, max_order_and_kind))
+                    .next_if(|shadow| {
+                        precedes_limit(shadow.order, batch_kind, max_order_and_kind)
+                            && has_corner_smoothing(shadow.corner_smoothing) == smoothed
+                    })
                     .is_some()
                 {
                     shadows_end += 1;
                 }
                 self.shadows_start = shadows_end;
-                Some(PrimitiveBatch::Shadows(shadows_start..shadows_end))
+                Some(PrimitiveBatch::Shadows {
+                    range: shadows_start..shadows_end,
+                    smoothed,
+                })
             }
             PrimitiveKind::Quad => {
+                let smoothed =
+                    has_corner_smoothing(self.quads_iter.peek().unwrap().corner_smoothing);
                 let quads_start = self.quads_start;
                 let mut quads_end = quads_start + 1;
                 self.quads_iter.next();
                 while self
                     .quads_iter
-                    .next_if(|quad| precedes_limit(quad.order, batch_kind, max_order_and_kind))
+                    .next_if(|quad| {
+                        precedes_limit(quad.order, batch_kind, max_order_and_kind)
+                            && has_corner_smoothing(quad.corner_smoothing) == smoothed
+                    })
                     .is_some()
                 {
                     quads_end += 1;
                 }
                 self.quads_start = quads_end;
-                Some(PrimitiveBatch::Quads(quads_start..quads_end))
+                Some(PrimitiveBatch::Quads {
+                    range: quads_start..quads_end,
+                    smoothed,
+                })
             }
             PrimitiveKind::Path => {
                 let paths_start = self.paths_start;
@@ -650,7 +670,9 @@ impl<'a> Iterator for BatchIterator<'a> {
                 })
             }
             PrimitiveKind::PolychromeSprite => {
-                let texture_id = self.polychrome_sprites_iter.peek().unwrap().tile.texture_id;
+                let first_sprite = self.polychrome_sprites_iter.peek().unwrap();
+                let texture_id = first_sprite.tile.texture_id;
+                let smoothed = has_corner_smoothing(first_sprite.corner_smoothing);
                 let sprites_start = self.polychrome_sprites_start;
                 let mut sprites_end = sprites_start + 1;
                 self.polychrome_sprites_iter.next();
@@ -659,6 +681,7 @@ impl<'a> Iterator for BatchIterator<'a> {
                     .next_if(|sprite| {
                         precedes_limit(sprite.order, batch_kind, max_order_and_kind)
                             && sprite.tile.texture_id == texture_id
+                            && has_corner_smoothing(sprite.corner_smoothing) == smoothed
                     })
                     .is_some()
                 {
@@ -668,6 +691,7 @@ impl<'a> Iterator for BatchIterator<'a> {
                 Some(PrimitiveBatch::PolychromeSprites {
                     texture_id,
                     range: sprites_start..sprites_end,
+                    smoothed,
                 })
             }
             PrimitiveKind::Surface => {
@@ -1216,7 +1240,7 @@ impl PathVertex<Pixels> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Point, Size};
+    use crate::{AtlasTextureKind, DevicePixels, Point, ShaderBool, Size, TileId};
 
     fn sp(value: f32) -> ScaledPixels {
         ScaledPixels(value)
@@ -1249,6 +1273,181 @@ mod tests {
             content_mask: mask(),
             ..Default::default()
         }
+    }
+
+    fn shadow() -> Shadow {
+        Shadow {
+            order: 0,
+            blur_radius: sp(0.0),
+            bounds: full_bounds(),
+            corner_radii: Corners::default(),
+            content_mask: mask(),
+            color: Default::default(),
+            element_bounds: full_bounds(),
+            element_corner_radii: Corners::default(),
+            inset: ShaderBool::Disabled,
+            corner_smoothing: 0.0,
+        }
+    }
+
+    fn polychrome_sprite(texture_index: u32) -> PolychromeSprite {
+        PolychromeSprite {
+            order: 0,
+            grayscale: ShaderBool::Disabled,
+            opacity: 1.0,
+            corner_smoothing: 0.0,
+            bounds: full_bounds(),
+            content_mask: mask(),
+            corner_radii: Corners::default(),
+            tile: AtlasTile {
+                texture_id: AtlasTextureId {
+                    index: texture_index,
+                    kind: AtlasTextureKind::Polychrome,
+                },
+                tile_id: TileId(0),
+                padding: 0,
+                bounds: Bounds::<DevicePixels>::default(),
+            },
+        }
+    }
+
+    fn batches(scene: &mut Scene) -> Vec<PrimitiveBatch> {
+        scene.finish();
+        scene.batches().collect()
+    }
+
+    #[test]
+    fn unsmoothed_primitives_each_remain_one_batch() {
+        let mut quad_scene = Scene::default();
+        let mut shadow_scene = Scene::default();
+        let mut sprite_scene = Scene::default();
+        for _ in 0..3 {
+            quad_scene.insert_primitive(quad());
+            shadow_scene.insert_primitive(shadow());
+            sprite_scene.insert_primitive(polychrome_sprite(0));
+        }
+
+        assert_eq!(
+            batches(&mut quad_scene),
+            vec![PrimitiveBatch::Quads {
+                range: 0..3,
+                smoothed: false,
+            }]
+        );
+        assert_eq!(
+            batches(&mut shadow_scene),
+            vec![PrimitiveBatch::Shadows {
+                range: 0..3,
+                smoothed: false,
+            }]
+        );
+        assert_eq!(
+            batches(&mut sprite_scene),
+            vec![PrimitiveBatch::PolychromeSprites {
+                texture_id: AtlasTextureId {
+                    index: 0,
+                    kind: AtlasTextureKind::Polychrome,
+                },
+                range: 0..3,
+                smoothed: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn mixed_smoothing_splits_only_at_mode_changes() {
+        let mut quad_scene = Scene::default();
+        let mut shadow_scene = Scene::default();
+        let mut sprite_scene = Scene::default();
+        for smoothing in [0.0, 0.0, 0.5, 1.0, 0.0] {
+            let mut quad = quad();
+            quad.corner_smoothing = smoothing;
+            quad_scene.insert_primitive(quad);
+
+            let mut shadow = shadow();
+            shadow.corner_smoothing = smoothing;
+            shadow_scene.insert_primitive(shadow);
+
+            let mut sprite = polychrome_sprite(0);
+            sprite.corner_smoothing = smoothing;
+            sprite_scene.insert_primitive(sprite);
+        }
+
+        let expected_ranges = [(0..2, false), (2..4, true), (4..5, false)];
+        assert_eq!(
+            batches(&mut quad_scene),
+            expected_ranges
+                .iter()
+                .map(|(range, smoothed)| PrimitiveBatch::Quads {
+                    range: range.clone(),
+                    smoothed: *smoothed,
+                })
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            batches(&mut shadow_scene),
+            expected_ranges
+                .iter()
+                .map(|(range, smoothed)| PrimitiveBatch::Shadows {
+                    range: range.clone(),
+                    smoothed: *smoothed,
+                })
+                .collect::<Vec<_>>()
+        );
+        let texture_id = AtlasTextureId {
+            index: 0,
+            kind: AtlasTextureKind::Polychrome,
+        };
+        assert_eq!(
+            batches(&mut sprite_scene),
+            expected_ranges
+                .iter()
+                .map(|(range, smoothed)| PrimitiveBatch::PolychromeSprites {
+                    texture_id,
+                    range: range.clone(),
+                    smoothed: *smoothed,
+                })
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn polychrome_sprites_preserve_texture_grouping_with_smoothing_splits() {
+        let mut scene = Scene::default();
+        for (texture, smoothing) in [
+            (0, 0.0),
+            (0, 0.0),
+            (0, 0.5),
+            (0, 1.0),
+            (1, 1.0),
+            (1, 0.5),
+            (1, 0.0),
+        ] {
+            let mut sprite = polychrome_sprite(texture);
+            sprite.corner_smoothing = smoothing;
+            scene.insert_primitive(sprite);
+        }
+
+        let batch_ranges_and_modes = batches(&mut scene)
+            .into_iter()
+            .map(|batch| match batch {
+                PrimitiveBatch::PolychromeSprites {
+                    texture_id,
+                    range,
+                    smoothed,
+                } => (texture_id.index, range, smoothed),
+                other => panic!("unexpected batch: {other:?}"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            batch_ranges_and_modes,
+            vec![
+                (0, 0..2, false),
+                (0, 2..4, true),
+                (1, 4..6, true),
+                (1, 6..7, false),
+            ]
+        );
     }
 
     /// A 100x100 quad whose bounds don't overlap `full_bounds()` (used to exercise the
@@ -1300,7 +1499,7 @@ mod tests {
         scene
             .batches()
             .map(|batch| match batch {
-                PrimitiveBatch::Quads(_) => "quad",
+                PrimitiveBatch::Quads { .. } => "quad",
                 PrimitiveBatch::BackdropFilters(_) => "backdrop",
                 PrimitiveBatch::FilterBoundary(ix) => {
                     if scene.filter_boundaries[ix].is_start {
@@ -1402,7 +1601,7 @@ mod tests {
             .render_commands()
             .iter()
             .map(|command| match command {
-                RenderCommand::Batch(PrimitiveBatch::Quads(_)) => "quad".to_string(),
+                RenderCommand::Batch(PrimitiveBatch::Quads { .. }) => "quad".to_string(),
                 RenderCommand::BeginFilter {
                     boundary_index,
                     target,
@@ -1463,7 +1662,7 @@ mod tests {
                     format!("begin:{target:?}")
                 }
                 RenderCommand::EndFilter { target, .. } => format!("end:{target:?}"),
-                RenderCommand::Batch(PrimitiveBatch::Quads(_)) => "quad".to_string(),
+                RenderCommand::Batch(PrimitiveBatch::Quads { .. }) => "quad".to_string(),
                 RenderCommand::Batch(other) => panic!("unexpected batch: {other:?}"),
             })
             .collect();
@@ -1496,7 +1695,7 @@ mod tests {
         ));
         assert!(matches!(
             commands.next(),
-            Some(RenderCommand::Batch(PrimitiveBatch::Quads(_)))
+            Some(RenderCommand::Batch(PrimitiveBatch::Quads { .. }))
         ));
         assert!(commands.next().is_none());
         assert!(!scene.requires_offscreen_rendering());
@@ -1543,7 +1742,8 @@ mod tests {
 
         assert!(matches!(
             scene.render_commands(),
-            [RenderCommand::Batch(PrimitiveBatch::Quads(range))] if range == &(0..1)
+            [RenderCommand::Batch(PrimitiveBatch::Quads { range, smoothed: false })]
+                if range == &(0..1)
         ));
     }
 

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -1361,103 +1361,20 @@ mod tests {
     }
 
     #[test]
-    fn unsmoothed_primitives_each_remain_one_batch() {
-        let mut quad_scene = Scene::default();
-        let mut shadow_scene = Scene::default();
-        let mut sprite_scene = Scene::default();
-        for _ in 0..3 {
-            quad_scene.insert_primitive(quad());
-            shadow_scene.insert_primitive(shadow());
-            sprite_scene.insert_primitive(polychrome_sprite(0));
-        }
-
-        assert_eq!(
-            batches(&mut quad_scene),
-            vec![PrimitiveBatch::Quads {
-                range: 0..3,
-                smoothed: false,
-            }]
-        );
-        assert_eq!(
-            batches(&mut shadow_scene),
-            vec![PrimitiveBatch::Shadows {
-                range: 0..3,
-                smoothed: false,
-            }]
-        );
-        assert_eq!(
-            batches(&mut sprite_scene),
-            vec![PrimitiveBatch::PolychromeSprites {
-                texture_id: AtlasTextureId {
-                    index: 0,
-                    kind: AtlasTextureKind::Polychrome,
-                },
-                range: 0..3,
-                smoothed: false,
-            }]
-        );
-    }
-
-    #[test]
-    fn mixed_smoothing_splits_only_at_mode_changes() {
-        let mut quad_scene = Scene::default();
-        let mut shadow_scene = Scene::default();
-        let mut sprite_scene = Scene::default();
+    fn smoothing_and_texture_changes_define_batches() {
+        let mut scene = Scene::default();
         for smoothing in [0.0, 0.0, 0.5, 1.0, 0.0] {
             let mut quad = quad();
             quad.corner_smoothing = smoothing;
-            quad_scene.insert_primitive(quad);
-
-            let mut shadow = shadow();
-            shadow.corner_smoothing = smoothing;
-            shadow_scene.insert_primitive(shadow);
-
-            let mut sprite = polychrome_sprite(0);
-            sprite.corner_smoothing = smoothing;
-            sprite_scene.insert_primitive(sprite);
+            scene.insert_primitive(quad);
         }
 
-        let expected_ranges = [(0..2, false), (2..4, true), (4..5, false)];
-        assert_eq!(
-            batches(&mut quad_scene),
-            expected_ranges
-                .iter()
-                .map(|(range, smoothed)| PrimitiveBatch::Quads {
-                    range: range.clone(),
-                    smoothed: *smoothed,
-                })
-                .collect::<Vec<_>>()
-        );
-        assert_eq!(
-            batches(&mut shadow_scene),
-            expected_ranges
-                .iter()
-                .map(|(range, smoothed)| PrimitiveBatch::Shadows {
-                    range: range.clone(),
-                    smoothed: *smoothed,
-                })
-                .collect::<Vec<_>>()
-        );
-        let texture_id = AtlasTextureId {
-            index: 0,
-            kind: AtlasTextureKind::Polychrome,
-        };
-        assert_eq!(
-            batches(&mut sprite_scene),
-            expected_ranges
-                .iter()
-                .map(|(range, smoothed)| PrimitiveBatch::PolychromeSprites {
-                    texture_id,
-                    range: range.clone(),
-                    smoothed: *smoothed,
-                })
-                .collect::<Vec<_>>()
-        );
-    }
+        for smoothing in [0.0, 0.0, 0.5, 1.0, 0.0] {
+            let mut shadow = shadow();
+            shadow.corner_smoothing = smoothing;
+            scene.insert_primitive(shadow);
+        }
 
-    #[test]
-    fn polychrome_sprites_preserve_texture_grouping_with_smoothing_splits() {
-        let mut scene = Scene::default();
         for (texture, smoothing) in [
             (0, 0.0),
             (0, 0.0),
@@ -1472,24 +1389,32 @@ mod tests {
             scene.insert_primitive(sprite);
         }
 
-        let batch_ranges_and_modes = batches(&mut scene)
+        let batch_signatures = batches(&mut scene)
             .into_iter()
             .map(|batch| match batch {
+                PrimitiveBatch::Quads { range, smoothed } => ("quad", None, range, smoothed),
+                PrimitiveBatch::Shadows { range, smoothed } => ("shadow", None, range, smoothed),
                 PrimitiveBatch::PolychromeSprites {
                     texture_id,
                     range,
                     smoothed,
-                } => (texture_id.index, range, smoothed),
+                } => ("polychrome", Some(texture_id.index), range, smoothed),
                 other => panic!("unexpected batch: {other:?}"),
             })
             .collect::<Vec<_>>();
         assert_eq!(
-            batch_ranges_and_modes,
+            batch_signatures,
             vec![
-                (0, 0..2, false),
-                (0, 2..4, true),
-                (1, 4..6, true),
-                (1, 6..7, false),
+                ("quad", None, 0..2, false),
+                ("quad", None, 2..4, true),
+                ("quad", None, 4..5, false),
+                ("shadow", None, 0..2, false),
+                ("shadow", None, 2..4, true),
+                ("shadow", None, 4..5, false),
+                ("polychrome", Some(0), 0..2, false),
+                ("polychrome", Some(0), 2..4, true),
+                ("polychrome", Some(1), 4..6, true),
+                ("polychrome", Some(1), 6..7, false),
             ]
         );
     }

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -726,6 +726,8 @@ pub struct Quad {
     pub border_color: SceneHsla,
     pub corner_radii: Corners<ScaledPixels>,
     pub border_widths: Edges<ScaledPixels>,
+    pub corner_smoothing: f32,
+    pub padding: u32,
 }
 
 impl From<Quad> for Primitive {
@@ -767,7 +769,7 @@ pub struct Shadow {
     pub element_corner_radii: Corners<ScaledPixels>,
     /// Whether this shadow is rendered inside the element instead of outside it.
     pub inset: ShaderBool,
-    pub padding: u32,
+    pub corner_smoothing: f32,
 }
 
 impl From<Shadow> for Primitive {
@@ -786,6 +788,7 @@ pub struct BackdropFilter {
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
     pub corner_radii: Corners<ScaledPixels>,
+    pub corner_smoothing: f32,
     /// The filter chain applied to the backdrop, in scene (device-pixel) space. Identity filters
     /// are dropped at paint time, so a `BackdropFilter` is only emitted when this is non-empty.
     ///
@@ -821,6 +824,7 @@ pub struct FilterBoundary {
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
     pub corner_radii: Corners<ScaledPixels>,
+    pub corner_smoothing: f32,
     /// The filter chain applied to the isolated group, in scene (device-pixel) space. Identity
     /// filters are dropped at paint time, so a `FilterBoundary` is only emitted when non-empty.
     /// Inline capacity 4 (same struct size as 1 here — see [`BackdropFilter::filters`]).
@@ -1010,9 +1014,9 @@ impl From<SubpixelSprite> for Primitive {
 #[expect(missing_docs)]
 pub struct PolychromeSprite {
     pub order: DrawOrder,
-    pub padding: u32,
     pub grayscale: ShaderBool,
     pub opacity: f32,
+    pub corner_smoothing: f32,
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
     pub corner_radii: Corners<ScaledPixels>,
@@ -1273,6 +1277,7 @@ mod tests {
             bounds: full_bounds(),
             content_mask: mask(),
             corner_radii: Corners::default(),
+            corner_smoothing: 0.0,
             filters: smallvec::smallvec![ScaledFilter::Blur(sp(8.0))],
             opacity: 1.0,
             is_start,

--- a/crates/gpui/src/scene/abi.rs
+++ b/crates/gpui/src/scene/abi.rs
@@ -64,7 +64,9 @@ pub const SCENE_BUFFER_LAYOUTS: &[SceneBufferLayout] = &[
         background,
         border_color,
         corner_radii,
-        border_widths
+        border_widths,
+        corner_smoothing,
+        padding
     ),
     layout!(
         Shadow,
@@ -78,7 +80,7 @@ pub const SCENE_BUFFER_LAYOUTS: &[SceneBufferLayout] = &[
         element_bounds,
         element_corner_radii,
         inset,
-        padding
+        corner_smoothing
     ),
     layout!(
         Underline,
@@ -117,9 +119,9 @@ pub const SCENE_BUFFER_LAYOUTS: &[SceneBufferLayout] = &[
         PolychromeSprite,
         "PolychromeSprite",
         order,
-        padding,
         grayscale,
         opacity,
+        corner_smoothing,
         bounds,
         content_mask,
         corner_radii,

--- a/crates/gpui/src/scene/plan.rs
+++ b/crates/gpui/src/scene/plan.rs
@@ -160,8 +160,8 @@ impl ScenePlan {
 impl ScenePlanRequirements {
     fn include_batch(&mut self, batch: &PrimitiveBatch) {
         match batch {
-            PrimitiveBatch::Shadows(range)
-            | PrimitiveBatch::Quads(range)
+            PrimitiveBatch::Shadows { range, .. }
+            | PrimitiveBatch::Quads { range, .. }
             | PrimitiveBatch::Underlines(range) => {
                 self.instance_batch_count += usize::from(!range.is_empty());
             }
@@ -229,8 +229,14 @@ impl SceneLengths {
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[allow(missing_docs)]
 pub enum PrimitiveBatch {
-    Shadows(Range<usize>),
-    Quads(Range<usize>),
+    Shadows {
+        range: Range<usize>,
+        smoothed: bool,
+    },
+    Quads {
+        range: Range<usize>,
+        smoothed: bool,
+    },
     Paths {
         range: Range<usize>,
         rasterization_vertex_count: usize,
@@ -248,6 +254,7 @@ pub enum PrimitiveBatch {
     PolychromeSprites {
         texture_id: AtlasTextureId,
         range: Range<usize>,
+        smoothed: bool,
     },
     Surfaces(Range<usize>),
     BackdropFilters(Range<usize>),
@@ -312,8 +319,16 @@ impl PrimitiveBatch {
     /// A diagnostic label suitable for GPU debug annotations.
     pub fn label(&self) -> String {
         match self {
-            Self::Shadows(range) => format!("shadows ({})", range.len()),
-            Self::Quads(range) => format!("quads ({})", range.len()),
+            Self::Shadows { range, smoothed } => format!(
+                "{}shadows ({})",
+                if *smoothed { "smoothed " } else { "" },
+                range.len()
+            ),
+            Self::Quads { range, smoothed } => format!(
+                "{}quads ({})",
+                if *smoothed { "smoothed " } else { "" },
+                range.len()
+            ),
             Self::Paths { range, .. } => format!("paths ({})", range.len()),
             Self::Underlines(range) => format!("underlines ({})", range.len()),
             Self::MonochromeSprites { texture_id, range } => format!(
@@ -326,8 +341,13 @@ impl PrimitiveBatch {
                 range.len(),
                 texture_id.index
             ),
-            Self::PolychromeSprites { texture_id, range } => format!(
-                "polychrome sprites ({}) on atlas {}",
+            Self::PolychromeSprites {
+                texture_id,
+                range,
+                smoothed,
+            } => format!(
+                "{}polychrome sprites ({}) on atlas {}",
+                if *smoothed { "smoothed " } else { "" },
                 range.len(),
                 texture_id.index
             ),

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -323,6 +323,10 @@ pub struct Style {
     #[refineable]
     pub corner_radii: Corners<AbsoluteLength>,
 
+    /// Controls the transition from each rounded corner to the straight edges.
+    /// `0.0` produces circular corners. `1.0` applies maximum smoothing.
+    pub corner_smoothing: Option<f32>,
+
     /// Box shadow of the element
     pub box_shadow: Vec<BoxShadow>,
 
@@ -824,18 +828,34 @@ impl Style {
             .corner_radii
             .to_pixels(rem_size)
             .clamp_radii_for_quad_size(bounds.size);
+        let corner_smoothing = self.corner_smoothing.unwrap_or_default();
 
         let current_color = self.text.color.unwrap_or_else(|| window.text_style().color);
 
-        window.paint_drop_shadows(bounds, corner_radii, &self.box_shadow);
+        window.paint_drop_shadows_with_corner_smoothing(
+            bounds,
+            corner_radii,
+            corner_smoothing,
+            &self.box_shadow,
+        );
         if let Some(ring) = self.ring.shadow(current_color, false) {
-            window.paint_drop_shadows(bounds, corner_radii, std::slice::from_ref(&ring));
+            window.paint_drop_shadows_with_corner_smoothing(
+                bounds,
+                corner_radii,
+                corner_smoothing,
+                std::slice::from_ref(&ring),
+            );
         }
 
         // Blur the content behind this element before its (typically translucent) background
         // is painted on top, so the background tints the frosted backdrop (CSS `backdrop-filter`).
         if !self.backdrop_filter.is_empty() {
-            window.paint_backdrop_filter(bounds, corner_radii, &self.backdrop_filter);
+            window.paint_backdrop_filter_with_corner_smoothing(
+                bounds,
+                corner_radii,
+                corner_smoothing,
+                &self.backdrop_filter,
+            );
         }
 
         // The element's own box — background, inset shadows, children, and border — painted as a
@@ -859,20 +879,33 @@ impl Style {
                     None => Hsla::default(),
                 };
                 border_color.alpha = 0.;
-                window.paint_quad(quad(
-                    bounds,
-                    corner_radii,
-                    background_color.unwrap_or_default(),
-                    Edges::default(),
-                    border_color,
-                    self.border_style,
-                ));
+                window.paint_quad_with_corner_smoothing(
+                    quad(
+                        bounds,
+                        corner_radii,
+                        background_color.unwrap_or_default(),
+                        Edges::default(),
+                        border_color,
+                        self.border_style,
+                    ),
+                    corner_smoothing,
+                );
             }
 
             if let Some(ring) = self.inset_ring.shadow(current_color, true) {
-                window.paint_inset_shadows(bounds, corner_radii, std::slice::from_ref(&ring));
+                window.paint_inset_shadows_with_corner_smoothing(
+                    bounds,
+                    corner_radii,
+                    corner_smoothing,
+                    std::slice::from_ref(&ring),
+                );
             }
-            window.paint_inset_shadows(bounds, corner_radii, &self.box_shadow);
+            window.paint_inset_shadows_with_corner_smoothing(
+                bounds,
+                corner_radii,
+                corner_smoothing,
+                &self.box_shadow,
+            );
 
             continuation(window, cx);
 
@@ -880,23 +913,32 @@ impl Style {
                 let border_widths = self.border_widths.to_pixels(rem_size);
                 let mut background = self.border_color.unwrap_or_default();
                 background.alpha = 0.;
-                window.paint_quad(quad(
-                    bounds,
-                    corner_radii,
-                    background,
-                    border_widths,
-                    self.border_color.unwrap_or_default(),
-                    self.border_style,
-                ));
+                window.paint_quad_with_corner_smoothing(
+                    quad(
+                        bounds,
+                        corner_radii,
+                        background,
+                        border_widths,
+                        self.border_color.unwrap_or_default(),
+                        self.border_style,
+                    ),
+                    corner_smoothing,
+                );
             }
         };
 
         if self.filter.is_empty() {
             paint_box(window, cx);
         } else {
-            window.with_filter_layer(bounds, corner_radii, &self.filter, |window| {
-                paint_box(window, cx);
-            });
+            window.with_filter_layer_with_corner_smoothing(
+                bounds,
+                corner_radii,
+                corner_smoothing,
+                &self.filter,
+                |window| {
+                    paint_box(window, cx);
+                },
+            );
         }
 
         #[cfg(debug_assertions)]
@@ -948,6 +990,7 @@ impl Default for Style {
             border_color: None,
             border_style: BorderStyle::default(),
             corner_radii: Corners::default(),
+            corner_smoothing: None,
             box_shadow: Default::default(),
             ring: Default::default(),
             inset_ring: Default::default(),

--- a/crates/gpui/src/style_transitions.rs
+++ b/crates/gpui/src/style_transitions.rs
@@ -111,6 +111,7 @@ pub(crate) struct StyleTransitionState {
     border_widths: EdgesTransitionState<AbsoluteLength>,
     gap: SizeTransitionState<DefiniteLength>,
     corner_radii: CornersTransitionState<AbsoluteLength>,
+    corner_smoothing: Option<StyleTransitionPropertyState<f32>>,
     scrollbar_width: Option<StyleTransitionPropertyState<AbsoluteLength>>,
     aspect_ratio: Option<StyleTransitionPropertyState<f32>>,
     flex_basis: Option<StyleTransitionPropertyState<Length>>,
@@ -658,7 +659,8 @@ mod tests {
         let mut state = StyleTransitionState::default();
         let transitions = StyleTransitions::new()
             .opacity(Duration::from_secs(1))
-            .rounded(Duration::from_secs(1));
+            .rounded(Duration::from_secs(1))
+            .rounded_smoothing(Duration::from_secs(1));
         let context = StyleTransitionContext::new(
             Some(Bounds {
                 origin: point(px(0.0), px(0.0)),
@@ -668,19 +670,23 @@ mod tests {
         );
         let mut style = Style {
             corner_radii: corners(30.0),
+            corner_smoothing: Some(0.0),
             ..Style::default()
         };
 
         assert!(!transitions.apply(&mut style, &mut state, context, started_at, false,));
         assert_eq!(style.opacity, None);
         assert_eq!(style.corner_radii, corners(30.0));
+        assert_eq!(style.corner_smoothing, Some(0.0));
 
         style.opacity = Some(0.5);
         style.corner_radii = corners(0.0);
+        style.corner_smoothing = Some(1.0);
         assert!(transitions.apply(&mut style, &mut state, context, started_at, false,));
 
         style.opacity = Some(0.5);
         style.corner_radii = corners(0.0);
+        style.corner_smoothing = Some(1.0);
         assert!(transitions.apply(
             &mut style,
             &mut state,
@@ -690,6 +696,7 @@ mod tests {
         ));
         assert_eq!(style.opacity, Some(0.25));
         assert_eq!(style.corner_radii, corners(15.0));
+        assert_eq!(style.corner_smoothing, Some(0.5));
 
         let pixels = AbsoluteLength::Pixels(px(10.0));
         let rems = AbsoluteLength::Rems(rems(2.0));

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -968,4 +968,21 @@ pub trait Styled: Sized {
         self.style().debug_below = Some(true);
         self
     }
+
+    /// Sets the amount of smoothing applied to rounded corners.
+    /// Use values from `0.0` for circular corners to `1.0` for maximum smoothing.
+    fn rounded_smoothing(mut self, amount: f32) -> Self {
+        debug_assert!(
+            (0.0..=1.0).contains(&amount),
+            "corner smoothing must be between 0 and 1"
+        );
+        self.style().corner_smoothing = Some(amount);
+        self
+    }
+
+    /// Sets corner smoothing to `0.6` for iOS-style corners.
+    fn rounded_smoothing_ios(mut self) -> Self {
+        self.style().corner_smoothing = Some(0.6);
+        self
+    }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4074,6 +4074,18 @@ impl Window {
         corner_radii: Corners<Pixels>,
         shadows: &[BoxShadow],
     ) {
+        self.paint_drop_shadows_with_corner_smoothing(bounds, corner_radii, 0.0, shadows);
+    }
+
+    /// Paints drop shadows with smoothed element and shadow corners.
+    /// Inset shadows in `shadows` are ignored.
+    pub fn paint_drop_shadows_with_corner_smoothing(
+        &mut self,
+        bounds: Bounds<Pixels>,
+        corner_radii: Corners<Pixels>,
+        corner_smoothing: f32,
+        shadows: &[BoxShadow],
+    ) {
         self.invalidator.debug_assert_paint();
 
         let scale_factor = self.scale_factor();
@@ -4081,6 +4093,7 @@ impl Window {
         let opacity = self.element_opacity();
         let element_bounds = self.cover_bounds(bounds);
         let element_corner_radii = corner_radii.scale(scale_factor);
+        let corner_smoothing = corner_smoothing.clamp(0.0, 1.0);
         for shadow in shadows {
             if shadow.inset {
                 continue;
@@ -4096,7 +4109,7 @@ impl Window {
                 element_bounds,
                 element_corner_radii,
                 inset: false.into(),
-                padding: 0,
+                corner_smoothing,
             });
         }
     }
@@ -4110,6 +4123,18 @@ impl Window {
         corner_radii: Corners<Pixels>,
         shadows: &[BoxShadow],
     ) {
+        self.paint_inset_shadows_with_corner_smoothing(bounds, corner_radii, 0.0, shadows);
+    }
+
+    /// Paints inset shadows with smoothed element and shadow corners.
+    /// Drop shadows in `shadows` are ignored.
+    pub fn paint_inset_shadows_with_corner_smoothing(
+        &mut self,
+        bounds: Bounds<Pixels>,
+        corner_radii: Corners<Pixels>,
+        corner_smoothing: f32,
+        shadows: &[BoxShadow],
+    ) {
         self.invalidator.debug_assert_paint();
 
         let scale_factor = self.scale_factor();
@@ -4117,6 +4142,7 @@ impl Window {
         let opacity = self.element_opacity();
         let element_bounds = self.cover_bounds(bounds);
         let element_corner_radii = corner_radii.scale(scale_factor);
+        let corner_smoothing = corner_smoothing.clamp(0.0, 1.0);
         for shadow in shadows {
             if !shadow.inset {
                 continue;
@@ -4141,7 +4167,7 @@ impl Window {
                 element_bounds,
                 element_corner_radii,
                 inset: true.into(),
-                padding: 0,
+                corner_smoothing,
             });
         }
     }
@@ -4161,6 +4187,17 @@ impl Window {
         corner_radii: Corners<Pixels>,
         filters: &[Filter],
     ) {
+        self.paint_backdrop_filter_with_corner_smoothing(bounds, corner_radii, 0.0, filters);
+    }
+
+    /// Paints a backdrop filter clipped to smoothed corners.
+    pub fn paint_backdrop_filter_with_corner_smoothing(
+        &mut self,
+        bounds: Bounds<Pixels>,
+        corner_radii: Corners<Pixels>,
+        corner_smoothing: f32,
+        filters: &[Filter],
+    ) {
         self.invalidator.debug_assert_paint();
 
         let scale_factor = self.scale_factor();
@@ -4178,6 +4215,7 @@ impl Window {
             bounds: self.snap_bounds(bounds),
             content_mask: self.snapped_content_mask(),
             corner_radii: corner_radii.scale(scale_factor),
+            corner_smoothing: corner_smoothing.clamp(0.0, 1.0),
             filters,
             opacity: self.element_opacity(),
         });
@@ -4196,6 +4234,18 @@ impl Window {
         &mut self,
         bounds: Bounds<Pixels>,
         corner_radii: Corners<Pixels>,
+        filters: &[Filter],
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        self.with_filter_layer_with_corner_smoothing(bounds, corner_radii, 0.0, filters, f)
+    }
+
+    /// Runs `f` in a content-filter group clipped to smoothed corners.
+    pub fn with_filter_layer_with_corner_smoothing<R>(
+        &mut self,
+        bounds: Bounds<Pixels>,
+        corner_radii: Corners<Pixels>,
+        corner_smoothing: f32,
         filters: &[Filter],
         f: impl FnOnce(&mut Self) -> R,
     ) -> R {
@@ -4223,6 +4273,7 @@ impl Window {
             bounds: self.snap_bounds(bounds),
             content_mask: self.snapped_content_mask(),
             corner_radii: corner_radii.scale(scale_factor),
+            corner_smoothing: corner_smoothing.clamp(0.0, 1.0),
             filters,
             opacity: 1.0,
             is_start: true,
@@ -4241,11 +4292,12 @@ impl Window {
     fn largest_border_interior(quad: &Quad) -> Bounds<ScaledPixels> {
         let radii = &quad.corner_radii;
         let widths = &quad.border_widths;
-        let edge_radii = Edges {
-            top: radii.top_left.max(radii.top_right),
-            right: radii.top_right.max(radii.bottom_right),
-            bottom: radii.bottom_left.max(radii.bottom_right),
-            left: radii.top_left.max(radii.bottom_left),
+        let reach_factor = 1.0 + quad.corner_smoothing;
+        let edge_reaches = Edges {
+            top: radii.top_left.max(radii.top_right) * reach_factor,
+            right: radii.top_right.max(radii.bottom_right) * reach_factor,
+            bottom: radii.bottom_left.max(radii.bottom_right) * reach_factor,
+            left: radii.top_left.max(radii.bottom_left) * reach_factor,
         };
 
         let antialias_inset = point(ScaledPixels(1.0), ScaledPixels(1.0));
@@ -4259,12 +4311,12 @@ impl Window {
         // Rounded corners need only be excluded on one axis. Either candidate
         // is empty of border pixels, so use the larger interior.
         let horizontal_band = inset_bounds(
-            point(widths.left, widths.top.max(edge_radii.top)),
-            point(widths.right, widths.bottom.max(edge_radii.bottom)),
+            point(widths.left, widths.top.max(edge_reaches.top)),
+            point(widths.right, widths.bottom.max(edge_reaches.bottom)),
         );
         let vertical_band = inset_bounds(
-            point(widths.left.max(edge_radii.left), widths.top),
-            point(widths.right.max(edge_radii.right), widths.bottom),
+            point(widths.left.max(edge_reaches.left), widths.top),
+            point(widths.right.max(edge_reaches.right), widths.bottom),
         );
 
         let area = |bounds: &Bounds<ScaledPixels>| {
@@ -4287,6 +4339,11 @@ impl Window {
     /// where the circular arcs meet. This will not display well when combined with dashed borders.
     /// Use `Corners::clamp_radii_for_quad_size` if the radii should fit within the bounds.
     pub fn paint_quad(&mut self, quad: PaintQuad) {
+        self.paint_quad_with_corner_smoothing(quad, 0.0);
+    }
+
+    /// Paints `quad` with smoothed corners.
+    pub fn paint_quad_with_corner_smoothing(&mut self, quad: PaintQuad, corner_smoothing: f32) {
         self.invalidator.debug_assert_paint();
 
         let opacity = self.element_opacity();
@@ -4301,6 +4358,8 @@ impl Window {
             corner_radii: quad.corner_radii.scale(self.scale_factor()),
             border_widths: snapped_border_widths,
             border_style: quad.border_style,
+            corner_smoothing: corner_smoothing.clamp(0.0, 1.0),
+            padding: 0,
         };
 
         if !quad.background.is_transparent() {
@@ -4595,8 +4654,8 @@ impl Window {
 
             self.next_frame.scene.insert_primitive(PolychromeSprite {
                 order: 0,
-                padding: 0,
                 grayscale: false.into(),
+                corner_smoothing: 0.0,
                 bounds,
                 corner_radii: Default::default(),
                 content_mask,
@@ -4689,6 +4748,28 @@ impl Window {
         frame_index: usize,
         grayscale: bool,
     ) -> Result<()> {
+        self.paint_image_with_corner_smoothing(
+            bounds,
+            image_bounds,
+            corner_radii,
+            0.0,
+            data,
+            frame_index,
+            grayscale,
+        )
+    }
+
+    /// Paints an image with smoothed corners.
+    pub fn paint_image_with_corner_smoothing(
+        &mut self,
+        bounds: Bounds<Pixels>,
+        image_bounds: Bounds<Pixels>,
+        corner_radii: Corners<Pixels>,
+        corner_smoothing: f32,
+        data: Arc<RenderImage>,
+        frame_index: usize,
+        grayscale: bool,
+    ) -> Result<()> {
         self.invalidator.debug_assert_paint();
 
         let visible_bounds = bounds.intersect(&image_bounds);
@@ -4767,8 +4848,8 @@ impl Window {
 
         self.next_frame.scene.insert_primitive(PolychromeSprite {
             order: 0,
-            padding: 0,
             grayscale: grayscale.into(),
+            corner_smoothing: corner_smoothing.clamp(0.0, 1.0),
             bounds: visible_bounds_snapped,
             content_mask,
             corner_radii,
@@ -7304,17 +7385,21 @@ mod tests {
         cell::{Cell, RefCell},
         path::PathBuf,
         rc::Rc,
+        sync::Arc,
         time::Duration,
     };
 
     use crate::{
-        AnyWindowHandle, AppContext as _, Bounds, Context, DispatchPhase, DragMoveEvent, Empty,
-        ExternalDragPayload, ExternalPaths, FileDragPaths, FileDropEvent, FocusHandle,
-        InputEvent as _, InteractiveElement as _, IntoElement, LongPressEvent, MouseButton,
-        MouseDownEvent, MouseMoveEvent, ParentElement, Pixels, Point, Render, RequestFrameOptions,
-        StatefulInteractiveElement as _, Styled, TestAppContext, TouchDragEvent, TouchEvent,
-        TouchId, TouchPhase, Window, WindowAppearance, WindowOptions, canvas, div, point, px, size,
+        AnyWindowHandle, AppContext as _, Bounds, BoxShadow, ColorExt as _, Context, DispatchPhase,
+        DragMoveEvent, Empty, ExternalDragPayload, ExternalPaths, FileDragPaths, FileDropEvent,
+        FocusHandle, ImageSource, InputEvent as _, InteractiveElement as _, IntoElement,
+        LongPressEvent, MouseButton, MouseDownEvent, MouseMoveEvent, ParentElement, Pixels, Point,
+        Render, RenderImage, RequestFrameOptions, ShaderBool, StatefulInteractiveElement as _,
+        Styled, TestAppContext, TouchDragEvent, TouchEvent, TouchId, TouchPhase, Window,
+        WindowAppearance, WindowOptions, canvas, div, img, point, px, size,
     };
+    use image::{Frame as ImageFrame, ImageBuffer, Rgba};
+    use smallvec::smallvec;
 
     struct EmptyView;
 
@@ -7322,6 +7407,119 @@ mod tests {
         fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
             div()
         }
+    }
+
+    struct CornerSmoothingSceneView {
+        image: Arc<RenderImage>,
+    }
+
+    fn assert_smoothing(name: &str, minimum_count: usize, values: impl IntoIterator<Item = f32>) {
+        let values = values.into_iter().collect::<Vec<_>>();
+        assert!(values.len() >= minimum_count, "missing {name}");
+        assert!(
+            values.iter().all(|&value| value == 1.0),
+            "{name}: {values:?}"
+        );
+    }
+
+    impl Render for CornerSmoothingSceneView {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            let mut image = img(ImageSource::Render(self.image.clone()))
+                .size(px(24.))
+                .rounded(px(8.));
+            image.style().corner_smoothing = Some(1.5);
+
+            let mut root = div()
+                .size(px(80.))
+                .rounded(px(24.))
+                .bg(crate::blue())
+                .border_t(px(2.))
+                .border_r(px(4.))
+                .border_b(px(6.))
+                .border_l(px(8.))
+                .border_color(crate::white())
+                .ring(px(3.))
+                .inset_ring(px(2.))
+                .shadow(vec![
+                    BoxShadow::new(px(2.), px(3.), crate::black().opacity(0.5))
+                        .blur_radius(px(5.))
+                        .spread_radius(px(1.)),
+                    BoxShadow::new(px(1.), px(1.), crate::white().opacity(0.4))
+                        .blur_radius(px(3.))
+                        .inset(),
+                ])
+                .backdrop_blur(px(4.))
+                .blur(px(2.))
+                .child(image);
+            root.style().corner_smoothing = Some(1.5);
+            root
+        }
+    }
+
+    #[gpui::test]
+    fn corner_smoothing_reaches_every_styled_scene_primitive(cx: &mut TestAppContext) {
+        let frame = ImageFrame::new(ImageBuffer::from_pixel(2, 2, Rgba([255, 255, 255, 255])));
+        let image = Arc::new(RenderImage::new(smallvec![frame]));
+        let window = cx.add_window(move |_, _| CornerSmoothingSceneView { image });
+
+        window
+            .update(cx, |_, window, _| {
+                let scene = &window.rendered_frame.scene;
+                assert_smoothing(
+                    "quads",
+                    2,
+                    scene.quads.iter().map(|quad| quad.corner_smoothing),
+                );
+                assert_smoothing(
+                    "shadows",
+                    4,
+                    scene.shadows.iter().map(|shadow| shadow.corner_smoothing),
+                );
+                assert_smoothing(
+                    "backdrop filters",
+                    1,
+                    scene
+                        .backdrop_filters
+                        .iter()
+                        .map(|filter| filter.corner_smoothing),
+                );
+                assert_smoothing(
+                    "filter boundaries",
+                    2,
+                    scene
+                        .filter_boundaries
+                        .iter()
+                        .map(|boundary| boundary.corner_smoothing),
+                );
+                assert_smoothing(
+                    "images",
+                    1,
+                    scene
+                        .polychrome_sprites
+                        .iter()
+                        .map(|image| image.corner_smoothing),
+                );
+                for inset in [ShaderBool::Disabled, ShaderBool::Enabled] {
+                    assert!(scene.shadows.iter().any(|shadow| shadow.inset == inset));
+                }
+
+                let border = scene
+                    .quads
+                    .iter()
+                    .find(|quad| quad.border_widths.top.0 > 0.0)
+                    .expect("border quad");
+                let scale = window.scale_factor();
+                assert_eq!(
+                    [
+                        border.border_widths.top.0,
+                        border.border_widths.right.0,
+                        border.border_widths.bottom.0,
+                        border.border_widths.left.0,
+                    ],
+                    [2.0, 4.0, 6.0, 8.0].map(|width| width * scale)
+                );
+            })
+            .unwrap();
     }
 
     struct OpensWindowOnPaint {

--- a/crates/gpui_apple/src/metal_renderer.rs
+++ b/crates/gpui_apple/src/metal_renderer.rs
@@ -225,16 +225,20 @@ pub struct MetalRenderer {
     paths_rasterization_pipeline_state: metal::RenderPipelineState,
     path_sprites_pipeline_state: metal::RenderPipelineState,
     shadows_pipeline_state: metal::RenderPipelineState,
+    smoothed_shadows_pipeline_state: metal::RenderPipelineState,
     quads_pipeline_state: metal::RenderPipelineState,
+    smoothed_quads_pipeline_state: metal::RenderPipelineState,
     underlines_pipeline_state: metal::RenderPipelineState,
     monochrome_sprites_pipeline_state: metal::RenderPipelineState,
     polychrome_sprites_pipeline_state: metal::RenderPipelineState,
+    smoothed_polychrome_sprites_pipeline_state: metal::RenderPipelineState,
     surfaces_pipeline_state: metal::RenderPipelineState,
     // Blur pipelines: downsample (no blend, also used for the final blit), separable gaussian
     // (no blend), and composite (alpha blend into a rounded rect), from shared shader sources.
     blur_downsample_pipeline_state: metal::RenderPipelineState,
     blur_pipeline_state: metal::RenderPipelineState,
     blur_composite_pipeline_state: metal::RenderPipelineState,
+    smoothed_blur_composite_pipeline_state: metal::RenderPipelineState,
     sampler: metal::SamplerState,
     #[allow(clippy::arc_with_non_send_sync)]
     instance_buffer_pool: Arc<Mutex<InstanceBufferPool>>,
@@ -381,11 +385,25 @@ impl MetalRenderer {
             shadows_shader,
             MTLPixelFormat::BGRA8Unorm,
         );
+        let (smoothed_shadows_shader, smoothed_shadows_library) = pipeline("smoothed_shadows");
+        let smoothed_shadows_pipeline_state = build_pipeline_state(
+            &device,
+            &smoothed_shadows_library,
+            smoothed_shadows_shader,
+            MTLPixelFormat::BGRA8Unorm,
+        );
         let (quads_shader, quads_library) = pipeline("quads");
         let quads_pipeline_state = build_pipeline_state(
             &device,
             &quads_library,
             quads_shader,
+            MTLPixelFormat::BGRA8Unorm,
+        );
+        let (smoothed_quads_shader, smoothed_quads_library) = pipeline("smoothed_quads");
+        let smoothed_quads_pipeline_state = build_pipeline_state(
+            &device,
+            &smoothed_quads_library,
+            smoothed_quads_shader,
             MTLPixelFormat::BGRA8Unorm,
         );
         let (underlines_shader, underlines_library) = pipeline("underlines");
@@ -407,6 +425,14 @@ impl MetalRenderer {
             &device,
             &polychrome_library,
             polychrome_shader,
+            MTLPixelFormat::BGRA8Unorm,
+        );
+        let (smoothed_polychrome_shader, smoothed_polychrome_library) =
+            pipeline("smoothed_polychrome_sprites");
+        let smoothed_polychrome_sprites_pipeline_state = build_pipeline_state(
+            &device,
+            &smoothed_polychrome_library,
+            smoothed_polychrome_shader,
             MTLPixelFormat::BGRA8Unorm,
         );
         let (surfaces_shader, surfaces_library) = pipeline("surfaces");
@@ -439,6 +465,14 @@ impl MetalRenderer {
             blur_composite_shader,
             MTLPixelFormat::BGRA8Unorm,
         );
+        let (smoothed_blur_composite_shader, smoothed_blur_composite_library) =
+            pipeline("smoothed_blur_composite");
+        let smoothed_blur_composite_pipeline_state = build_path_sprite_pipeline_state(
+            &device,
+            &smoothed_blur_composite_library,
+            smoothed_blur_composite_shader,
+            MTLPixelFormat::BGRA8Unorm,
+        );
 
         let sampler_descriptor = SamplerDescriptor::new();
         sampler_descriptor.set_min_filter(metal::MTLSamplerMinMagFilter::Linear);
@@ -461,14 +495,18 @@ impl MetalRenderer {
             paths_rasterization_pipeline_state,
             path_sprites_pipeline_state,
             shadows_pipeline_state,
+            smoothed_shadows_pipeline_state,
             quads_pipeline_state,
+            smoothed_quads_pipeline_state,
             underlines_pipeline_state,
             monochrome_sprites_pipeline_state,
             polychrome_sprites_pipeline_state,
+            smoothed_polychrome_sprites_pipeline_state,
             surfaces_pipeline_state,
             blur_downsample_pipeline_state,
             blur_pipeline_state,
             blur_composite_pipeline_state,
+            smoothed_blur_composite_pipeline_state,
             sampler,
             instance_buffer_pool,
             sprite_atlas,
@@ -892,15 +930,18 @@ impl MetalRenderer {
 
         for command in scene.render_commands() {
             let ok = match command {
-                RenderCommand::Batch(PrimitiveBatch::Shadows(range)) => self.draw_shadows(
-                    &scene.shadows[range.clone()],
-                    instance_buffer,
-                    &mut instance_offset,
-                    &scene_uniforms,
-                    command_encoder,
-                ),
-                RenderCommand::Batch(PrimitiveBatch::Quads(range)) => self.draw_quads(
+                RenderCommand::Batch(PrimitiveBatch::Shadows { range, smoothed }) => self
+                    .draw_shadows(
+                        &scene.shadows[range.clone()],
+                        *smoothed,
+                        instance_buffer,
+                        &mut instance_offset,
+                        &scene_uniforms,
+                        command_encoder,
+                    ),
+                RenderCommand::Batch(PrimitiveBatch::Quads { range, smoothed }) => self.draw_quads(
                     &scene.quads[range.clone()],
+                    *smoothed,
                     instance_buffer,
                     &mut instance_offset,
                     &scene_uniforms,
@@ -965,16 +1006,19 @@ impl MetalRenderer {
                         command_encoder,
                     )
                 }
-                RenderCommand::Batch(PrimitiveBatch::PolychromeSprites { texture_id, range }) => {
-                    self.draw_polychrome_sprites(
-                        *texture_id,
-                        &scene.polychrome_sprites[range.clone()],
-                        instance_buffer,
-                        &mut instance_offset,
-                        &scene_uniforms,
-                        command_encoder,
-                    )
-                }
+                RenderCommand::Batch(PrimitiveBatch::PolychromeSprites {
+                    texture_id,
+                    range,
+                    smoothed,
+                }) => self.draw_polychrome_sprites(
+                    *texture_id,
+                    &scene.polychrome_sprites[range.clone()],
+                    *smoothed,
+                    instance_buffer,
+                    &mut instance_offset,
+                    &scene_uniforms,
+                    command_encoder,
+                ),
                 RenderCommand::Batch(PrimitiveBatch::Surfaces(range)) => self.draw_surfaces(
                     &scene.surfaces[range.clone()],
                     &scene_uniforms,
@@ -1308,7 +1352,12 @@ impl MetalRenderer {
                 color_attachment.set_load_action(metal::MTLLoadAction::Load);
             },
         );
-        encoder.set_render_pipeline_state(&self.blur_composite_pipeline_state);
+        let pipeline = if composite_uniforms.corner_smoothing > 0.0 {
+            &self.smoothed_blur_composite_pipeline_state
+        } else {
+            &self.blur_composite_pipeline_state
+        };
+        encoder.set_render_pipeline_state(pipeline);
         bind_scene_uniforms(encoder, scene_uniforms);
         encoder.set_vertex_bytes(
             DATA_SLOT,
@@ -1406,6 +1455,7 @@ impl MetalRenderer {
     fn draw_shadows(
         &self,
         shadows: &[Shadow],
+        smoothed: bool,
         instance_buffer: &mut InstanceBuffer,
         instance_offset: &mut usize,
         scene_uniforms: &SceneUniforms,
@@ -1422,7 +1472,12 @@ impl MetalRenderer {
             return false;
         }
 
-        command_encoder.set_render_pipeline_state(&self.shadows_pipeline_state);
+        let pipeline = if smoothed {
+            &self.smoothed_shadows_pipeline_state
+        } else {
+            &self.shadows_pipeline_state
+        };
+        command_encoder.set_render_pipeline_state(pipeline);
         bind_scene_uniforms(command_encoder, scene_uniforms);
 
         let buffer_contents =
@@ -1454,6 +1509,7 @@ impl MetalRenderer {
     fn draw_quads(
         &self,
         quads: &[Quad],
+        smoothed: bool,
         instance_buffer: &mut InstanceBuffer,
         instance_offset: &mut usize,
         scene_uniforms: &SceneUniforms,
@@ -1470,7 +1526,12 @@ impl MetalRenderer {
             return false;
         }
 
-        command_encoder.set_render_pipeline_state(&self.quads_pipeline_state);
+        let pipeline = if smoothed {
+            &self.smoothed_quads_pipeline_state
+        } else {
+            &self.quads_pipeline_state
+        };
+        command_encoder.set_render_pipeline_state(pipeline);
         bind_scene_uniforms(command_encoder, scene_uniforms);
 
         let buffer_contents =
@@ -1669,6 +1730,7 @@ impl MetalRenderer {
         &self,
         texture_id: AtlasTextureId,
         sprites: &[PolychromeSprite],
+        smoothed: bool,
         instance_buffer: &mut InstanceBuffer,
         instance_offset: &mut usize,
         scene_uniforms: &SceneUniforms,
@@ -1686,7 +1748,12 @@ impl MetalRenderer {
         }
 
         let texture = self.sprite_atlas.metal_texture(texture_id);
-        command_encoder.set_render_pipeline_state(&self.polychrome_sprites_pipeline_state);
+        let pipeline = if smoothed {
+            &self.smoothed_polychrome_sprites_pipeline_state
+        } else {
+            &self.polychrome_sprites_pipeline_state
+        };
+        command_encoder.set_render_pipeline_state(pipeline);
         bind_scene_uniforms(command_encoder, scene_uniforms);
 
         let buffer_contents =
@@ -1968,8 +2035,8 @@ fn required_instance_buffer_size(scene: &Scene) -> usize {
             continue;
         };
         match batch {
-            PrimitiveBatch::Shadows(range) => reserve(mem::size_of::<Shadow>(), range.len()),
-            PrimitiveBatch::Quads(range) => reserve(mem::size_of::<Quad>(), range.len()),
+            PrimitiveBatch::Shadows { range, .. } => reserve(mem::size_of::<Shadow>(), range.len()),
+            PrimitiveBatch::Quads { range, .. } => reserve(mem::size_of::<Quad>(), range.len()),
             PrimitiveBatch::Paths {
                 rasterization_vertex_count,
                 sprite_count,

--- a/crates/gpui_apple/src/metal_renderer.rs
+++ b/crates/gpui_apple/src/metal_renderer.rs
@@ -997,6 +997,7 @@ impl MetalRenderer {
                                 filter.bounds,
                                 filter.content_mask.bounds,
                                 filter.corner_radii,
+                                filter.corner_smoothing,
                                 filter.max_blur_radius(),
                                 filter.opacity,
                                 true,
@@ -1056,6 +1057,7 @@ impl MetalRenderer {
                             boundary.bounds,
                             boundary.content_mask.bounds,
                             boundary.corner_radii,
+                            boundary.corner_smoothing,
                             boundary.max_blur_radius(),
                             boundary.opacity,
                             false,
@@ -1210,6 +1212,7 @@ impl MetalRenderer {
         bounds: Bounds<ScaledPixels>,
         content_mask: Bounds<ScaledPixels>,
         corner_radii: Corners<ScaledPixels>,
+        corner_smoothing: f32,
         blur_radius: f32,
         opacity: f32,
         // Backdrop clips to the rounded rect; content (`filter`) bleeds past its bounds.
@@ -1291,6 +1294,7 @@ impl MetalRenderer {
             composite_bounds,
             content_mask,
             corner_radii,
+            corner_smoothing,
             opacity,
             clip,
             blur_size,
@@ -2353,7 +2357,7 @@ mod tests {
             element_bounds: box_bounds,
             element_corner_radii: Corners::all(ScaledPixels(2.0)),
             inset: gpui::ShaderBool::Disabled,
-            padding: 0,
+            corner_smoothing: 0.0,
         });
         shadow.finish();
         assert_legacy_fixture(
@@ -2427,9 +2431,9 @@ mod tests {
         let mut sprite = Scene::default();
         sprite.insert_primitive(PolychromeSprite {
             order: 0,
-            padding: 0,
             grayscale: gpui::ShaderBool::Disabled,
             opacity: 0.75,
+            corner_smoothing: 0.0,
             bounds: sprite_bounds,
             content_mask: ContentMask {
                 bounds: sprite_bounds,

--- a/crates/gpui_macros/src/styles.rs
+++ b/crates/gpui_macros/src/styles.rs
@@ -388,6 +388,10 @@ fn style_transition_specs() -> Vec<StyleTransitionSpec> {
             name: "opacity",
             fields: vec![StyleTransitionField::optional(quote! { opacity })],
         },
+        StyleTransitionSpec {
+            name: "rounded_smoothing",
+            fields: vec![StyleTransitionField::optional(quote! { corner_smoothing })],
+        },
     ]);
 
     specs
@@ -922,6 +926,12 @@ struct CornerStyleSuffix {
     doc_string_suffix: &'static str,
 }
 
+struct CornerSmoothingStyleSuffix {
+    suffix: &'static str,
+    amount_tokens: TokenStream2,
+    doc_string: &'static str,
+}
+
 struct BorderStylePrefix {
     prefix: &'static str,
     fields: Vec<TokenStream2>,
@@ -1023,7 +1033,28 @@ fn generate_methods() -> Vec<TokenStream2> {
         }
     }
 
+    methods.extend(generate_corner_smoothing_methods(visibility));
+
     methods
+}
+
+fn generate_corner_smoothing_methods(visibility: Visibility) -> Vec<TokenStream2> {
+    corner_smoothing_suffixes()
+        .into_iter()
+        .map(|suffix| {
+            let method_name = format_ident!("rounded_smoothing_{}", suffix.suffix);
+            let amount_tokens = suffix.amount_tokens;
+            let doc_string = suffix.doc_string;
+
+            quote! {
+                #[doc = #doc_string]
+                #visibility fn #method_name(mut self) -> Self {
+                    self.style().corner_smoothing = Some(#amount_tokens);
+                    self
+                }
+            }
+        })
+        .collect()
 }
 
 fn generate_predefined_setter(
@@ -1677,6 +1708,66 @@ fn corner_suffixes() -> Vec<CornerStyleSuffix> {
             suffix: "full",
             radius_tokens: quote! {  px(9999.) },
             doc_string_suffix: "9999px",
+        },
+    ]
+}
+
+fn corner_smoothing_suffixes() -> Vec<CornerSmoothingStyleSuffix> {
+    vec![
+        CornerSmoothingStyleSuffix {
+            suffix: "0",
+            amount_tokens: quote! { 0.0 },
+            doc_string: "Keeps circular corners by setting rounded corner smoothing to `0.0`.",
+        },
+        CornerSmoothingStyleSuffix {
+            suffix: "0p1",
+            amount_tokens: quote! { 0.1 },
+            doc_string: "Sets rounded corner smoothing to `0.1`.",
+        },
+        CornerSmoothingStyleSuffix {
+            suffix: "0p2",
+            amount_tokens: quote! { 0.2 },
+            doc_string: "Sets rounded corner smoothing to `0.2`.",
+        },
+        CornerSmoothingStyleSuffix {
+            suffix: "0p3",
+            amount_tokens: quote! { 0.3 },
+            doc_string: "Sets rounded corner smoothing to `0.3`.",
+        },
+        CornerSmoothingStyleSuffix {
+            suffix: "0p4",
+            amount_tokens: quote! { 0.4 },
+            doc_string: "Sets rounded corner smoothing to `0.4`.",
+        },
+        CornerSmoothingStyleSuffix {
+            suffix: "0p5",
+            amount_tokens: quote! { 0.5 },
+            doc_string: "Sets rounded corner smoothing to `0.5`.",
+        },
+        CornerSmoothingStyleSuffix {
+            suffix: "0p6",
+            amount_tokens: quote! { 0.6 },
+            doc_string: "Sets rounded corner smoothing to `0.6`.",
+        },
+        CornerSmoothingStyleSuffix {
+            suffix: "0p7",
+            amount_tokens: quote! { 0.7 },
+            doc_string: "Sets rounded corner smoothing to `0.7`.",
+        },
+        CornerSmoothingStyleSuffix {
+            suffix: "0p8",
+            amount_tokens: quote! { 0.8 },
+            doc_string: "Sets rounded corner smoothing to `0.8`.",
+        },
+        CornerSmoothingStyleSuffix {
+            suffix: "0p9",
+            amount_tokens: quote! { 0.9 },
+            doc_string: "Sets rounded corner smoothing to `0.9`.",
+        },
+        CornerSmoothingStyleSuffix {
+            suffix: "1",
+            amount_tokens: quote! { 1.0 },
+            doc_string: "Requests maximum rounded corner smoothing by setting it to `1.0`.",
         },
     ]
 }

--- a/crates/gpui_render/THIRD_PARTY_NOTICES.md
+++ b/crates/gpui_render/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,30 @@
+# Third-party notices
+
+## figma-squircle
+
+Portions of the Figma-style corner-smoothing shader implementation are derived
+from figma-squircle by Tien Pham.
+
+Source: <https://github.com/phamfoo/figma-squircle>
+
+MIT License
+
+Copyright (c) 2021 Tien Pham
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/gpui_render/build.rs
+++ b/crates/gpui_render/build.rs
@@ -772,8 +772,20 @@ fn write_native_shaders(out_dir: &std::path::Path) {
             requires_dual_source_lowering: false,
         },
         NativeShaderModule {
+            pipeline: &SMOOTHED_QUADS,
+            pipeline_path: "SMOOTHED_QUADS",
+            source: &shaders::quad::WGSL_SOURCE,
+            requires_dual_source_lowering: false,
+        },
+        NativeShaderModule {
             pipeline: &SHADOWS,
             pipeline_path: "SHADOWS",
+            source: &shaders::shadow::WGSL_SOURCE,
+            requires_dual_source_lowering: false,
+        },
+        NativeShaderModule {
+            pipeline: &SMOOTHED_SHADOWS,
+            pipeline_path: "SMOOTHED_SHADOWS",
             source: &shaders::shadow::WGSL_SOURCE,
             requires_dual_source_lowering: false,
         },
@@ -814,6 +826,12 @@ fn write_native_shaders(out_dir: &std::path::Path) {
             requires_dual_source_lowering: false,
         },
         NativeShaderModule {
+            pipeline: &SMOOTHED_POLYCHROME_SPRITES,
+            pipeline_path: "SMOOTHED_POLYCHROME_SPRITES",
+            source: &shaders::polychrome_sprite::WGSL_SOURCE,
+            requires_dual_source_lowering: false,
+        },
+        NativeShaderModule {
             pipeline: &SURFACES,
             pipeline_path: "SURFACES",
             source: &shaders::surface::WGSL_SOURCE,
@@ -840,6 +858,12 @@ fn write_native_shaders(out_dir: &std::path::Path) {
         NativeShaderModule {
             pipeline: &BLUR_COMPOSITE,
             pipeline_path: "BLUR_COMPOSITE",
+            source: &shaders::blur::WGSL_SOURCE,
+            requires_dual_source_lowering: false,
+        },
+        NativeShaderModule {
+            pipeline: &SMOOTHED_BLUR_COMPOSITE,
+            pipeline_path: "SMOOTHED_BLUR_COMPOSITE",
             source: &shaders::blur::WGSL_SOURCE,
             requires_dual_source_lowering: false,
         },

--- a/crates/gpui_render/src/blur.rs
+++ b/crates/gpui_render/src/blur.rs
@@ -35,6 +35,7 @@ pub struct FilterCompositeParameters {
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: Bounds<ScaledPixels>,
     pub corner_radii: Corners<ScaledPixels>,
+    pub corner_smoothing: f32,
     pub blur_radius: f32,
     pub opacity: f32,
     pub clip: FilterCompositeClip,
@@ -99,6 +100,7 @@ impl BlurUniforms {
         bounds: Bounds<ScaledPixels>,
         content_mask: Bounds<ScaledPixels>,
         corner_radii: Corners<ScaledPixels>,
+        corner_smoothing: f32,
         opacity: f32,
         clip: FilterCompositeClip,
         source_size: [f32; 2],
@@ -108,6 +110,7 @@ impl BlurUniforms {
             bounds: bounds.into(),
             content_mask: content_mask.into(),
             corner_radii: corner_radii.into(),
+            corner_smoothing,
             opacity,
             composite_clip: match clip {
                 FilterCompositeClip::RoundedBounds => ShaderBlurCompositeClip::RoundedBounds,
@@ -222,6 +225,10 @@ fn empty_uniforms(downsample_mode: DownsampleMode) -> BlurUniforms {
         downsample_mode,
         source_size: vec2f(1.0, 1.0),
         target_size: vec2f(1.0, 1.0),
+        corner_smoothing: 0.0,
+        padding0: 0,
+        padding1: 0,
+        padding2: 0,
     }
 }
 

--- a/crates/gpui_render/src/shaders/common.rs
+++ b/crates/gpui_render/src/shaders/common.rs
@@ -553,6 +553,12 @@ mod source {
             corner_radius,
         )
     }
+
+    pub fn gaussian_signed_distance_coverage(distance: f32, standard_deviation: f32) -> f32 {
+        let normalized = distance / (sqrt(2.0) * standard_deviation);
+        saturate(0.5 - 0.5 * approximate_error_function(vec2f(normalized, normalized)).x)
+    }
+
     pub fn blend_color(color: Vec4f, alpha_factor: f32) -> Vec4f {
         let alpha = color.w * alpha_factor;
         let multiplier = select(1.0, alpha, is_enabled(get!(GLOBALS).premultiplied_alpha));

--- a/crates/gpui_render/src/shaders/corner_smoothing.rs
+++ b/crates/gpui_render/src/shaders/corner_smoothing.rs
@@ -39,16 +39,14 @@ mod source {
     ) -> bool {
         let radii = max(corner_values(corner_radii), vec4f(0.0, 0.0, 0.0, 0.0));
         let reaches = normalized_superellipse_reaches(corner_radii, corner_smoothing);
-        let half_short_side = 0.5 * min(size.x, size.y);
-
         corner_smoothing > 0.0
             && size.x > 0.0
             && size.y > 0.0
             && (radii.x > 0.0 || radii.y > 0.0 || radii.z > 0.0 || radii.w > 0.0)
-            && reaches.x <= half_short_side
-            && reaches.y <= half_short_side
-            && reaches.z <= half_short_side
-            && reaches.w <= half_short_side
+            && reaches.x + reaches.y <= size.x
+            && reaches.y + reaches.z <= size.y
+            && reaches.z + reaches.w <= size.x
+            && reaches.w + reaches.x <= size.y
     }
 
     pub fn normalized_superellipse_signed_distance_from_corner(
@@ -71,7 +69,16 @@ mod source {
         extent * (powered.x + powered.y - 1.0) / max(gradient, FIGMA_EPSILON)
     }
 
-    pub fn normalized_superellipse_signed_distance(
+    pub fn can_use_compact_corner_selection(size: Vec2f, reaches: Vec4f) -> bool {
+        let half_short_side = 0.5 * min(size.x, size.y);
+
+        reaches.x <= half_short_side
+            && reaches.y <= half_short_side
+            && reaches.z <= half_short_side
+            && reaches.w <= half_short_side
+    }
+
+    pub fn compact_normalized_superellipse_signed_distance(
         point: Vec2f,
         bounds: Bounds,
         corner_radii: Corners,
@@ -87,6 +94,74 @@ mod source {
             corner_to_point,
             corner_radius,
             corner_smoothing,
+            power,
+        )
+    }
+
+    pub fn reach_aware_normalized_superellipse_signed_distance(
+        point: Vec2f,
+        bounds: Bounds,
+        corner_radii: Corners,
+        corner_smoothing: f32,
+        reaches: Vec4f,
+        power: f32,
+    ) -> f32 {
+        let local_point = point - bounds.origin;
+        let radii = corner_values(corner_radii);
+        let mut distance =
+            figma_nearest_straight_sample(local_point, bounds.size, reaches, reaches).distance;
+        let mut corner = 0u32;
+
+        while corner < 4u32 {
+            if figma_is_corner_candidate(
+                local_point,
+                bounds.size,
+                reaches[corner],
+                reaches[corner],
+                corner,
+            ) {
+                let candidate = normalized_superellipse_signed_distance_from_corner(
+                    figma_corner_to_point(local_point, bounds.size, corner),
+                    radii[corner],
+                    corner_smoothing,
+                    power,
+                );
+
+                if abs(candidate) <= abs(distance) {
+                    distance = candidate;
+                }
+            }
+
+            corner += 1u32;
+        }
+
+        distance
+    }
+
+    pub fn normalized_superellipse_signed_distance(
+        point: Vec2f,
+        bounds: Bounds,
+        corner_radii: Corners,
+        corner_smoothing: f32,
+        reaches: Vec4f,
+        power: f32,
+    ) -> f32 {
+        if can_use_compact_corner_selection(bounds.size, reaches) {
+            return compact_normalized_superellipse_signed_distance(
+                point,
+                bounds,
+                corner_radii,
+                corner_smoothing,
+                power,
+            );
+        }
+
+        reach_aware_normalized_superellipse_signed_distance(
+            point,
+            bounds,
+            corner_radii,
+            corner_smoothing,
+            reaches,
             power,
         )
     }
@@ -927,6 +1002,7 @@ mod source {
                 bounds,
                 corner_radii,
                 corner_smoothing,
+                prepared.horizontal_reaches,
                 prepared.superellipse_power,
             );
         }
@@ -1034,5 +1110,122 @@ mod tests {
         assert_eq!(circular.horizontal_reaches.x, 20.0);
         assert!(smoothed.horizontal_reaches.x > circular.horizontal_reaches.x);
         assert!(smoothed.vertical_reaches.x > circular.vertical_reaches.x);
+    }
+
+    #[test]
+    fn normalized_shortcut_checks_adjacent_corner_overlap_boundaries() {
+        let size = vec2f(100.0, 80.0);
+        let corners = |top_left, top_right, bottom_right, bottom_left| Corners {
+            top_left,
+            top_right,
+            bottom_right,
+            bottom_left,
+        };
+        let exact_fit = [
+            corners(20.0, 30.0, 0.0, 0.0),
+            corners(0.0, 20.0, 20.0, 0.0),
+            corners(0.0, 0.0, 30.0, 20.0),
+            corners(20.0, 0.0, 0.0, 20.0),
+        ];
+        let just_fitting = [
+            corners(20.0, 29.999, 0.0, 0.0),
+            corners(0.0, 20.0, 19.999, 0.0),
+            corners(0.0, 0.0, 30.0, 19.999),
+            corners(20.0, 0.0, 0.0, 19.999),
+        ];
+        let overlapping = [
+            corners(20.0, 30.001, 0.0, 0.0),
+            corners(0.0, 20.0, 20.001, 0.0),
+            corners(0.0, 0.0, 30.0, 20.001),
+            corners(20.0, 0.0, 0.0, 20.001),
+        ];
+
+        for radii in exact_fit {
+            assert!(can_use_normalized_superellipse(size, radii, 1.0));
+        }
+        for radii in just_fitting {
+            assert!(can_use_normalized_superellipse(size, radii, 1.0));
+        }
+        for radii in overlapping {
+            assert!(!can_use_normalized_superellipse(size, radii, 1.0));
+        }
+
+        let preservation = prepare_corners(size, exact_fit[0], 1.0, false);
+        assert_eq!(preservation.superellipse_power, 0.0);
+    }
+
+    #[test]
+    fn normalized_shortcut_preserves_compact_corner_selection() {
+        let bounds = Bounds {
+            origin: vec2f(0.0, 0.0),
+            size: vec2f(120.0, 80.0),
+        };
+        let radii = Corners {
+            top_left: 20.0,
+            top_right: 8.0,
+            bottom_right: 16.0,
+            bottom_left: 4.0,
+        };
+        let smoothing = 0.6;
+        let prepared = prepare_corners(bounds.size, radii, smoothing, true);
+
+        assert!(prepared.superellipse_power > 0.0);
+        assert!(can_use_compact_corner_selection(
+            bounds.size,
+            prepared.horizontal_reaches,
+        ));
+
+        for y in 0..=8 {
+            for x in 0..=12 {
+                let point = vec2f(x as f32 * 10.0, y as f32 * 10.0);
+                let expected = compact_normalized_superellipse_signed_distance(
+                    point,
+                    bounds,
+                    radii,
+                    smoothing,
+                    prepared.superellipse_power,
+                );
+                let actual =
+                    prepared_corner_signed_distance(point, bounds, radii, smoothing, prepared);
+                assert_eq!(actual, expected, "compact distance at {point:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn normalized_shortcut_uses_asymmetric_corner_reach_regions() {
+        let bounds = Bounds {
+            origin: vec2f(0.0, 0.0),
+            size: vec2f(120.0, 80.0),
+        };
+        let radii = Corners {
+            top_left: 35.0,
+            top_right: 0.0,
+            bottom_right: 0.0,
+            bottom_left: 0.0,
+        };
+        let smoothing = 1.0;
+        let prepared = prepare_corners(bounds.size, radii, smoothing, true);
+
+        assert!(prepared.superellipse_power > 0.0);
+        assert!(!can_use_compact_corner_selection(
+            bounds.size,
+            prepared.horizontal_reaches,
+        ));
+
+        let shoulder = vec2f(65.0, 0.0);
+        let expected = normalized_superellipse_signed_distance_from_corner(
+            -shoulder,
+            radii.top_left,
+            smoothing,
+            prepared.superellipse_power,
+        );
+        let actual = prepared_corner_signed_distance(shoulder, bounds, radii, smoothing, prepared);
+        assert!((actual - expected).abs() < 0.0001);
+        assert!(actual > 0.0);
+
+        let deep_interior =
+            prepared_corner_signed_distance(vec2f(65.0, 65.0), bounds, radii, smoothing, prepared);
+        assert!((deep_interior + 15.0).abs() < 0.0001);
     }
 }

--- a/crates/gpui_render/src/shaders/corner_smoothing.rs
+++ b/crates/gpui_render/src/shaders/corner_smoothing.rs
@@ -1,0 +1,1038 @@
+#[allow(clippy::manual_swap)]
+#[wgsl_rs::wgsl]
+mod source {
+    use super::super::common::*;
+    use wgsl_rs::std::*;
+
+    pub const SUPERELLIPSE_DIAGONAL_INSET: f32 = 0.2928932188134524;
+    pub const FIGMA_SEGMENT_STRAIGHT: u32 = 0u32;
+    pub const FIGMA_SEGMENT_FIRST_CUBIC: u32 = 1u32;
+    pub const FIGMA_SEGMENT_ARC: u32 = 2u32;
+    pub const FIGMA_SEGMENT_SECOND_CUBIC: u32 = 3u32;
+    pub const FIGMA_NO_CORNER: u32 = 4u32;
+    pub const FIGMA_EPSILON: f32 = 0.000001;
+
+    pub fn corner_values(corner_radii: Corners) -> Vec4f {
+        vec4f(
+            corner_radii.top_left,
+            corner_radii.top_right,
+            corner_radii.bottom_right,
+            corner_radii.bottom_left,
+        )
+    }
+
+    pub fn normalized_superellipse_power(corner_smoothing: f32) -> f32 {
+        let smoothing = clamp(corner_smoothing, 0.0, 1.0);
+        let normalized_diagonal = 1.0 - SUPERELLIPSE_DIAGONAL_INSET / (1.0 + smoothing);
+        -log(2.0) / log(normalized_diagonal)
+    }
+
+    pub fn normalized_superellipse_reaches(corner_radii: Corners, corner_smoothing: f32) -> Vec4f {
+        max(corner_values(corner_radii), vec4f(0.0, 0.0, 0.0, 0.0))
+            * (1.0 + clamp(corner_smoothing, 0.0, 1.0))
+    }
+
+    pub fn can_use_normalized_superellipse(
+        size: Vec2f,
+        corner_radii: Corners,
+        corner_smoothing: f32,
+    ) -> bool {
+        let radii = max(corner_values(corner_radii), vec4f(0.0, 0.0, 0.0, 0.0));
+        let reaches = normalized_superellipse_reaches(corner_radii, corner_smoothing);
+        let half_short_side = 0.5 * min(size.x, size.y);
+
+        corner_smoothing > 0.0
+            && size.x > 0.0
+            && size.y > 0.0
+            && (radii.x > 0.0 || radii.y > 0.0 || radii.z > 0.0 || radii.w > 0.0)
+            && reaches.x <= half_short_side
+            && reaches.y <= half_short_side
+            && reaches.z <= half_short_side
+            && reaches.w <= half_short_side
+    }
+
+    pub fn normalized_superellipse_signed_distance_from_corner(
+        corner_to_point: Vec2f,
+        corner_radius: f32,
+        corner_smoothing: f32,
+        power: f32,
+    ) -> f32 {
+        let extent = max(corner_radius, 0.0) * (1.0 + clamp(corner_smoothing, 0.0, 1.0));
+        let corner_center_to_point = corner_to_point + extent;
+
+        if extent <= 0.0 || corner_center_to_point.x <= 0.0 || corner_center_to_point.y <= 0.0 {
+            return max(corner_to_point.x, corner_to_point.y);
+        }
+
+        let normalized = corner_center_to_point / extent;
+        let powered = pow(normalized, vec2f(power, power));
+        let gradient = power * length(pow(normalized, vec2f(power - 1.0, power - 1.0)));
+
+        extent * (powered.x + powered.y - 1.0) / max(gradient, FIGMA_EPSILON)
+    }
+
+    pub fn normalized_superellipse_signed_distance(
+        point: Vec2f,
+        bounds: Bounds,
+        corner_radii: Corners,
+        corner_smoothing: f32,
+        power: f32,
+    ) -> f32 {
+        let half_size = Bounds::half_size(bounds);
+        let center_to_point = point - Bounds::center(bounds);
+        let corner_radius = pick_corner_radius(center_to_point, corner_radii);
+        let corner_to_point = abs(center_to_point) - half_size;
+
+        normalized_superellipse_signed_distance_from_corner(
+            corner_to_point,
+            corner_radius,
+            corner_smoothing,
+            power,
+        )
+    }
+
+    // This corner construction derives from Tien Pham's figma-squircle.
+    // See ../../THIRD_PARTY_NOTICES.md.
+    #[derive(Clone, Copy, Wgsl)]
+    pub struct FigmaCornerLayout {
+        pub horizontal_budgets: Vec4f,
+        pub vertical_budgets: Vec4f,
+    }
+
+    #[derive(Clone, Copy, Wgsl)]
+    pub struct FigmaCornerExtents {
+        pub horizontal: Vec4f,
+        pub vertical: Vec4f,
+    }
+
+    pub fn figma_split_side(length: f32, first_radius: f32, second_radius: f32) -> Vec2f {
+        let total_radius = first_radius + second_radius;
+
+        if total_radius == 0.0 {
+            return vec2f(0.0, 0.0);
+        }
+
+        let first_budget = length * first_radius / total_radius;
+
+        vec2f(first_budget, length - first_budget)
+    }
+
+    pub fn figma_corner_layout(size: Vec2f, corner_radii: Corners) -> FigmaCornerLayout {
+        let mut radii = [
+            max(corner_radii.top_left, 0.0),
+            max(corner_radii.top_right, 0.0),
+            max(corner_radii.bottom_right, 0.0),
+            max(corner_radii.bottom_left, 0.0),
+        ];
+        let mut budgets = [-1.0, -1.0, -1.0, -1.0];
+        let mut order = [0u32, 1u32, 3u32, 2u32];
+
+        let mut sort_pass = 0u32;
+
+        while sort_pass < 3u32 {
+            let mut index = 0u32;
+
+            while index < 3u32 - sort_pass {
+                if radii[order[index as usize] as usize]
+                    < radii[order[(index + 1u32) as usize] as usize]
+                {
+                    let swap = order[index as usize];
+                    order[index as usize] = order[(index + 1u32) as usize];
+                    order[(index + 1u32) as usize] = swap;
+                }
+
+                index += 1u32;
+            }
+
+            sort_pass += 1u32;
+        }
+
+        let mut rank = 0u32;
+        while rank < 4u32 {
+            let corner = order[rank as usize];
+            let radius = radii[corner as usize];
+            let mut horizontal_neighbor = 0u32;
+            let mut vertical_neighbor = 0u32;
+
+            match corner {
+                0u32 => {
+                    horizontal_neighbor = 1u32;
+                    vertical_neighbor = 3u32;
+                }
+                1u32 => {
+                    horizontal_neighbor = 0u32;
+                    vertical_neighbor = 2u32;
+                }
+                2u32 => {
+                    horizontal_neighbor = 3u32;
+                    vertical_neighbor = 1u32;
+                }
+                _ => {
+                    horizontal_neighbor = 2u32;
+                    vertical_neighbor = 0u32;
+                }
+            }
+
+            let horizontal_radius = radii[horizontal_neighbor as usize];
+            let mut horizontal_budget = 0.0;
+
+            if radius != 0.0 || horizontal_radius != 0.0 {
+                if budgets[horizontal_neighbor as usize] >= 0.0 {
+                    horizontal_budget = size.x - budgets[horizontal_neighbor as usize];
+                } else {
+                    horizontal_budget = size.x * radius / (radius + horizontal_radius);
+                }
+            }
+
+            let vertical_radius = radii[vertical_neighbor as usize];
+            let mut vertical_budget = 0.0;
+
+            if radius != 0.0 || vertical_radius != 0.0 {
+                if budgets[vertical_neighbor as usize] >= 0.0 {
+                    vertical_budget = size.y - budgets[vertical_neighbor as usize];
+                } else {
+                    vertical_budget = size.y * radius / (radius + vertical_radius);
+                }
+            }
+
+            let budget = max(0.0, min(horizontal_budget, vertical_budget));
+            budgets[corner as usize] = budget;
+            radii[corner as usize] = min(radius, budget);
+            rank += 1u32;
+        }
+
+        let top = figma_split_side(size.x, radii[0usize], radii[1usize]);
+        let bottom = figma_split_side(size.x, radii[3usize], radii[2usize]);
+        let left = figma_split_side(size.y, radii[0usize], radii[3usize]);
+        let right = figma_split_side(size.y, radii[1usize], radii[2usize]);
+
+        FigmaCornerLayout {
+            horizontal_budgets: vec4f(top.x, top.y, bottom.y, bottom.x),
+            vertical_budgets: vec4f(left.x, right.x, right.y, left.y),
+        }
+    }
+
+    #[derive(Clone, Copy, Wgsl)]
+    pub struct FigmaAxisParams {
+        pub a: f32,
+        pub b: f32,
+        pub p: f32,
+    }
+
+    #[derive(Clone, Copy, Wgsl)]
+    pub struct FigmaCornerParams {
+        pub radius: f32,
+        pub smoothing: f32,
+        pub arc_sweep: f32,
+        pub c: f32,
+        pub d: f32,
+        pub horizontal: FigmaAxisParams,
+        pub vertical: FigmaAxisParams,
+    }
+
+    #[derive(Clone, Copy, Wgsl)]
+    pub struct CubicClosestPoint {
+        pub point: Vec2f,
+        pub tangent: Vec2f,
+        pub distance: f32,
+        pub path_t: f32,
+    }
+
+    #[derive(Clone, Copy, Wgsl)]
+    pub struct SignedDistanceSample {
+        pub distance: f32,
+        pub normal: Vec2f,
+        pub path_t: f32,
+        pub segment: u32,
+    }
+
+    #[derive(Clone, Copy, Wgsl)]
+    pub struct FigmaRectangleSample {
+        pub signed_distance: SignedDistanceSample,
+        pub corner: u32,
+    }
+
+    #[derive(Clone, Copy, Wgsl)]
+    pub struct PreparedCorners {
+        pub horizontal_reaches: Vec4f,
+        pub vertical_reaches: Vec4f,
+        pub smoothing_factors: Vec4f,
+        pub superellipse_power: f32,
+    }
+
+    pub fn figma_smoothing_factors(corner_smoothing: f32) -> Vec4f {
+        let smoothing = clamp(corner_smoothing, 0.0, 1.0);
+        let arc_sweep = 0.5 * PI * (1.0 - smoothing);
+        let beta = (PI / 4.0) * smoothing;
+        let join_handle_factor = tan(0.5 * beta);
+
+        vec4f(
+            smoothing,
+            sin(0.5 * arc_sweep) * sqrt(2.0),
+            join_handle_factor * cos(beta),
+            join_handle_factor * sin(beta),
+        )
+    }
+
+    pub fn figma_corner_params(
+        corner_radius: f32,
+        horizontal_reach: f32,
+        vertical_reach: f32,
+        smoothing_factors: Vec4f,
+    ) -> FigmaCornerParams {
+        let safe_horizontal_reach = max(horizontal_reach, 0.0);
+        let safe_vertical_reach = max(vertical_reach, 0.0);
+        let radius = min(
+            max(corner_radius, 0.0),
+            min(safe_horizontal_reach, safe_vertical_reach),
+        );
+        let smoothing = select(0.0, smoothing_factors.x, radius > FIGMA_EPSILON);
+        let desired_reach = radius * (1.0 + smoothing);
+        let arc_sweep = 0.5 * PI * (1.0 - smoothing);
+        let arc_delta = smoothing_factors.y * radius;
+        let c = smoothing_factors.z * radius;
+        let d = smoothing_factors.w * radius;
+        let core_length = arc_delta + c + d;
+        let ideal_b = max((desired_reach - core_length) / 3.0, 0.0);
+        let horizontal_available = max(safe_horizontal_reach - core_length, 0.0);
+        let vertical_available = max(safe_vertical_reach - core_length, 0.0);
+        let shared_b = min(
+            ideal_b,
+            min(
+                horizontal_available * (5.0 / 6.0),
+                vertical_available * (5.0 / 6.0),
+            ),
+        );
+
+        FigmaCornerParams {
+            radius,
+            smoothing,
+            arc_sweep,
+            c,
+            d,
+            horizontal: FigmaAxisParams {
+                a: horizontal_available - shared_b,
+                b: shared_b,
+                p: safe_horizontal_reach,
+            },
+            vertical: FigmaAxisParams {
+                a: vertical_available - shared_b,
+                b: shared_b,
+                p: safe_vertical_reach,
+            },
+        }
+    }
+
+    pub fn figma_corner_extent(
+        radius: f32,
+        horizontal_budget: f32,
+        vertical_budget: f32,
+        corner_smoothing: f32,
+    ) -> Vec2f {
+        let horizontal_budget = max(horizontal_budget, 0.0);
+        let vertical_budget = max(vertical_budget, 0.0);
+        let radius = min(max(radius, 0.0), min(horizontal_budget, vertical_budget));
+        let desired_reach = radius * (1.0 + clamp(corner_smoothing, 0.0, 1.0));
+
+        vec2f(
+            min(desired_reach, horizontal_budget),
+            min(desired_reach, vertical_budget),
+        )
+    }
+
+    pub fn figma_corner_extents(
+        corner_radii: Corners,
+        horizontal_budgets: Vec4f,
+        vertical_budgets: Vec4f,
+        corner_smoothing: f32,
+    ) -> FigmaCornerExtents {
+        let radii = corner_values(corner_radii);
+        let top_left = figma_corner_extent(
+            radii.x,
+            horizontal_budgets.x,
+            vertical_budgets.x,
+            corner_smoothing,
+        );
+        let top_right = figma_corner_extent(
+            radii.y,
+            horizontal_budgets.y,
+            vertical_budgets.y,
+            corner_smoothing,
+        );
+        let bottom_right = figma_corner_extent(
+            radii.z,
+            horizontal_budgets.z,
+            vertical_budgets.z,
+            corner_smoothing,
+        );
+        let bottom_left = figma_corner_extent(
+            radii.w,
+            horizontal_budgets.w,
+            vertical_budgets.w,
+            corner_smoothing,
+        );
+
+        FigmaCornerExtents {
+            horizontal: vec4f(top_left.x, top_right.x, bottom_right.x, bottom_left.x),
+            vertical: vec4f(top_left.y, top_right.y, bottom_right.y, bottom_left.y),
+        }
+    }
+
+    pub fn prepare_corners(
+        size: Vec2f,
+        radii: Corners,
+        smoothing: f32,
+        allow_superellipse: bool,
+    ) -> PreparedCorners {
+        let radius_values = corner_values(radii);
+        let mut prepared = PreparedCorners {
+            horizontal_reaches: radius_values,
+            vertical_reaches: radius_values,
+            smoothing_factors: vec4f(0.0, 1.0, 0.0, 0.0),
+            superellipse_power: 0.0,
+        };
+
+        if smoothing <= 0.0 {
+            return prepared;
+        }
+
+        if allow_superellipse && can_use_normalized_superellipse(size, radii, smoothing) {
+            let reaches = normalized_superellipse_reaches(radii, smoothing);
+            prepared.horizontal_reaches = reaches;
+            prepared.vertical_reaches = reaches;
+            prepared.superellipse_power = normalized_superellipse_power(smoothing);
+            return prepared;
+        }
+
+        let corner_layout = figma_corner_layout(size, radii);
+        let extents = figma_corner_extents(
+            radii,
+            corner_layout.horizontal_budgets,
+            corner_layout.vertical_budgets,
+            smoothing,
+        );
+
+        prepared.horizontal_reaches = extents.horizontal;
+        prepared.vertical_reaches = extents.vertical;
+        prepared.smoothing_factors = figma_smoothing_factors(smoothing);
+        prepared
+    }
+
+    pub fn figma_cubic_point(axis: FigmaAxisParams, c: f32, d: f32, t: f32) -> Vec2f {
+        let x1 = 3.0 * axis.a;
+        let x2 = 3.0 * (axis.b - axis.a);
+        let x3 = axis.a - 2.0 * axis.b + c;
+        let t2 = t * t;
+
+        vec2f(t * (x1 + t * (x2 + t * x3)), d * t2 * t)
+    }
+
+    pub fn figma_cubic_derivative(axis: FigmaAxisParams, c: f32, d: f32, t: f32) -> Vec2f {
+        let x1 = 3.0 * axis.a;
+        let x2 = 3.0 * (axis.b - axis.a);
+        let x3 = axis.a - 2.0 * axis.b + c;
+        let t2 = t * t;
+
+        vec2f(x1 + 2.0 * x2 * t + 3.0 * x3 * t2, 3.0 * d * t2)
+    }
+
+    pub fn figma_cubic_second_derivative(axis: FigmaAxisParams, c: f32, d: f32, t: f32) -> Vec2f {
+        let x2 = 3.0 * (axis.b - axis.a);
+        let x3 = axis.a - 2.0 * axis.b + c;
+
+        vec2f(2.0 * x2 + 6.0 * x3 * t, 6.0 * d * t)
+    }
+
+    pub fn closest_figma_cubic(
+        point: Vec2f,
+        axis: FigmaAxisParams,
+        c: f32,
+        d: f32,
+    ) -> CubicClosestPoint {
+        let y_seed = pow(clamp(point.y / max(d, 0.00001), 0.0, 1.0), 1.0 / 3.0);
+        let chord = figma_cubic_point(axis, c, d, 1.0);
+        let chord_seed = clamp(
+            dot(point, chord) / max(dot(chord, chord), FIGMA_EPSILON),
+            0.0,
+            1.0,
+        );
+        let y_delta = figma_cubic_point(axis, c, d, y_seed) - point;
+        let chord_delta = figma_cubic_point(axis, c, d, chord_seed) - point;
+        let mut t = select(
+            y_seed,
+            chord_seed,
+            dot(chord_delta, chord_delta) < dot(y_delta, y_delta),
+        );
+
+        let mut iteration = 0u32;
+        while iteration < 4u32 {
+            let curve_point = figma_cubic_point(axis, c, d, t);
+            let tangent = figma_cubic_derivative(axis, c, d, t);
+            let second_derivative = figma_cubic_second_derivative(axis, c, d, t);
+            let delta = curve_point - point;
+            let denominator = dot(tangent, tangent) + dot(delta, second_derivative);
+
+            if abs(denominator) > FIGMA_EPSILON {
+                t = clamp(t - dot(delta, tangent) / denominator, 0.0, 1.0);
+            }
+
+            iteration += 1u32;
+        }
+
+        let mut closest_t = t;
+        let mut closest_point = figma_cubic_point(axis, c, d, t);
+        let mut closest_distance = length(point - closest_point);
+        let start = vec2f(0.0, 0.0);
+        let start_distance = length(point - start);
+
+        if start_distance < closest_distance {
+            closest_t = 0.0;
+            closest_point = start;
+            closest_distance = start_distance;
+        }
+
+        let end_distance = length(point - chord);
+
+        if end_distance < closest_distance {
+            closest_t = 1.0;
+            closest_point = chord;
+            closest_distance = end_distance;
+        }
+
+        CubicClosestPoint {
+            point: closest_point,
+            tangent: figma_cubic_derivative(axis, c, d, closest_t),
+            distance: closest_distance,
+            path_t: closest_t,
+        }
+    }
+
+    pub fn figma_signed_distance(delta: Vec2f, normal: Vec2f, distance: f32) -> f32 {
+        select(-distance, distance, dot(delta, normal) >= 0.0)
+    }
+
+    pub fn figma_cross_2d(a: Vec2f, b: Vec2f) -> f32 {
+        a.x * b.y - a.y * b.x
+    }
+
+    pub fn figma_unfold_normal(normal: Vec2f, mirrored: bool) -> Vec2f {
+        select(
+            vec2f(normal.x, -normal.y),
+            vec2f(-normal.y, normal.x),
+            mirrored,
+        )
+    }
+
+    pub fn figma_corner_signed_distance(
+        corner_to_point: Vec2f,
+        params: FigmaCornerParams,
+    ) -> SignedDistanceSample {
+        let z = corner_to_point + vec2f(params.horizontal.p, params.vertical.p);
+
+        if params.radius <= FIGMA_EPSILON || z.x <= 0.0 || z.y <= 0.0 {
+            return SignedDistanceSample {
+                distance: max(corner_to_point.x, corner_to_point.y),
+                normal: select(
+                    vec2f(0.0, 1.0),
+                    vec2f(1.0, 0.0),
+                    corner_to_point.x > corner_to_point.y,
+                ),
+                path_t: 0.0,
+                segment: FIGMA_SEGMENT_STRAIGHT,
+            };
+        }
+
+        let horizontal_point = vec2f(z.x, params.vertical.p - z.y);
+        let vertical_point = vec2f(z.y, params.horizontal.p - z.x);
+        let circle_center = vec2f(params.horizontal.p - params.radius, params.radius);
+        let join = vec2f(
+            params.horizontal.a + params.horizontal.b + params.c,
+            params.d,
+        );
+        let start_direction = (join - circle_center) / params.radius;
+        let to_point = horizontal_point - circle_center;
+        let to_point_length = length(to_point);
+        let point_direction = select(
+            start_direction,
+            to_point / max(to_point_length, FIGMA_EPSILON),
+            to_point_length > FIGMA_EPSILON,
+        );
+
+        let arc_angle = clamp(
+            atan2(
+                figma_cross_2d(start_direction, point_direction),
+                dot(start_direction, point_direction),
+            ),
+            0.0,
+            params.arc_sweep,
+        );
+        let arc_sine = sin(arc_angle);
+        let arc_cosine = cos(arc_angle);
+        let arc_normal = vec2f(
+            arc_cosine * start_direction.x - arc_sine * start_direction.y,
+            arc_sine * start_direction.x + arc_cosine * start_direction.y,
+        );
+        let arc_point = circle_center + params.radius * arc_normal;
+        let arc_delta = horizontal_point - arc_point;
+        let arc_t = select(
+            0.0,
+            arc_angle / max(params.arc_sweep, FIGMA_EPSILON),
+            params.arc_sweep > FIGMA_EPSILON,
+        );
+
+        let mut sample = SignedDistanceSample {
+            distance: figma_signed_distance(arc_delta, arc_normal, length(arc_delta)),
+            normal: figma_unfold_normal(arc_normal, false),
+            path_t: arc_t,
+            segment: FIGMA_SEGMENT_ARC,
+        };
+
+        if params.smoothing > FIGMA_EPSILON {
+            let horizontal_bounds_delta = max(
+                vec2f(0.0, 0.0),
+                max(-horizontal_point, horizontal_point - join),
+            );
+
+            if dot(horizontal_bounds_delta, horizontal_bounds_delta)
+                <= sample.distance * sample.distance * 1.000001 + FIGMA_EPSILON
+            {
+                let cubic =
+                    closest_figma_cubic(horizontal_point, params.horizontal, params.c, params.d);
+                let normal = normalize(vec2f(cubic.tangent.y, -cubic.tangent.x));
+                let distance =
+                    figma_signed_distance(horizontal_point - cubic.point, normal, cubic.distance);
+
+                if abs(distance) <= abs(sample.distance) {
+                    sample.distance = distance;
+                    sample.normal = figma_unfold_normal(normal, false);
+                    sample.path_t = cubic.path_t;
+                    sample.segment = FIGMA_SEGMENT_FIRST_CUBIC;
+                }
+            }
+
+            let vertical_join = vec2f(params.vertical.a + params.vertical.b + params.c, params.d);
+            let vertical_bounds_delta = max(
+                vec2f(0.0, 0.0),
+                max(-vertical_point, vertical_point - vertical_join),
+            );
+
+            if dot(vertical_bounds_delta, vertical_bounds_delta)
+                <= sample.distance * sample.distance * 1.000001 + FIGMA_EPSILON
+            {
+                let cubic =
+                    closest_figma_cubic(vertical_point, params.vertical, params.c, params.d);
+                let normal = normalize(vec2f(cubic.tangent.y, -cubic.tangent.x));
+                let distance =
+                    figma_signed_distance(vertical_point - cubic.point, normal, cubic.distance);
+                if abs(distance) <= abs(sample.distance) {
+                    sample.distance = distance;
+                    sample.normal = figma_unfold_normal(normal, true);
+                    sample.path_t = cubic.path_t;
+                    sample.segment = FIGMA_SEGMENT_SECOND_CUBIC;
+                }
+            }
+        }
+
+        sample
+    }
+
+    pub fn figma_cubic_length(params: FigmaCornerParams, axis: FigmaAxisParams, end_t: f32) -> f32 {
+        let half_t = clamp(end_t, 0.0, 1.0) / 2.0;
+        if half_t <= 0.0 || params.smoothing <= 0.0 {
+            return 0.0;
+        }
+
+        let center = half_t;
+        let offset1 = half_t * 0.5384693101;
+        let offset2 = half_t * 0.9061798459;
+        let speed0 = length(figma_cubic_derivative(axis, params.c, params.d, center));
+        let speed1 = length(figma_cubic_derivative(
+            axis,
+            params.c,
+            params.d,
+            center - offset1,
+        )) + length(figma_cubic_derivative(
+            axis,
+            params.c,
+            params.d,
+            center + offset1,
+        ));
+        let speed2 = length(figma_cubic_derivative(
+            axis,
+            params.c,
+            params.d,
+            center - offset2,
+        )) + length(figma_cubic_derivative(
+            axis,
+            params.c,
+            params.d,
+            center + offset2,
+        ));
+
+        half_t * (0.5688888889 * speed0 + 0.4786286705 * speed1 + 0.2369268851 * speed2)
+    }
+
+    pub fn figma_corner_length(params: FigmaCornerParams) -> f32 {
+        figma_cubic_length(params, params.horizontal, 1.0)
+            + params.radius * params.arc_sweep
+            + figma_cubic_length(params, params.vertical, 1.0)
+    }
+
+    pub fn figma_corner_progress(
+        params: FigmaCornerParams,
+        sample: SignedDistanceSample,
+        total_length: f32,
+    ) -> f32 {
+        if sample.segment == FIGMA_SEGMENT_FIRST_CUBIC {
+            return figma_cubic_length(params, params.horizontal, sample.path_t);
+        }
+
+        if sample.segment == FIGMA_SEGMENT_ARC {
+            return figma_cubic_length(params, params.horizontal, 1.0)
+                + params.radius * params.arc_sweep * sample.path_t;
+        }
+
+        if sample.segment == FIGMA_SEGMENT_SECOND_CUBIC {
+            return total_length - figma_cubic_length(params, params.vertical, sample.path_t);
+        }
+
+        0.0
+    }
+
+    #[rustfmt::skip]
+    pub fn figma_is_corner_candidate(
+        point: Vec2f,
+        size: Vec2f,
+        horizontal_extent: f32,
+        vertical_extent: f32,
+        corner: u32,
+    ) -> bool {
+        if horizontal_extent <= FIGMA_EPSILON || vertical_extent <= FIGMA_EPSILON {
+            return false;
+        }
+
+        match corner {
+            0u32 => { point.x <= horizontal_extent && point.y <= vertical_extent },
+            1u32 => { size.x - point.x <= horizontal_extent && point.y <= vertical_extent },
+            2u32 => { size.x - point.x <= horizontal_extent && size.y - point.y <= vertical_extent },
+            _ => { point.x <= horizontal_extent && size.y - point.y <= vertical_extent },
+        }
+    }
+
+    pub fn figma_has_corner_candidate(
+        point: Vec2f,
+        size: Vec2f,
+        horizontal_extents: Vec4f,
+        vertical_extents: Vec4f,
+    ) -> bool {
+        figma_is_corner_candidate(point, size, horizontal_extents.x, vertical_extents.x, 0u32)
+            || figma_is_corner_candidate(
+                point,
+                size,
+                horizontal_extents.y,
+                vertical_extents.y,
+                1u32,
+            )
+            || figma_is_corner_candidate(
+                point,
+                size,
+                horizontal_extents.z,
+                vertical_extents.z,
+                2u32,
+            )
+            || figma_is_corner_candidate(
+                point,
+                size,
+                horizontal_extents.w,
+                vertical_extents.w,
+                3u32,
+            )
+    }
+
+    #[rustfmt::skip]
+    pub fn figma_corner_to_point(point: Vec2f, size: Vec2f, corner: u32) -> Vec2f {
+        match corner {
+            0u32 => { -point },
+            1u32 => { vec2f(point.x - size.x, -point.y) },
+            2u32 => { point - size },
+            _ => { vec2f(-point.x, point.y - size.y) },
+        }
+    }
+
+    #[rustfmt::skip]
+    pub fn figma_orient_corner_normal(normal: Vec2f, corner: u32) -> Vec2f {
+        match corner {
+            0u32 => { -normal },
+            1u32 => { vec2f(normal.x, -normal.y) },
+            2u32 => { normal },
+            _ => { vec2f(-normal.x, normal.y) },
+        }
+    }
+
+    pub fn figma_nearest_straight_sample(
+        point: Vec2f,
+        size: Vec2f,
+        horizontal_extents: Vec4f,
+        vertical_extents: Vec4f,
+    ) -> SignedDistanceSample {
+        let mut nearest_delta = point
+            - vec2f(
+                clamp(
+                    point.x,
+                    horizontal_extents.x,
+                    max(horizontal_extents.x, size.x - horizontal_extents.y),
+                ),
+                0.0,
+            );
+        let mut nearest_normal = vec2f(0.0, -1.0);
+        let mut nearest_distance_squared = dot(nearest_delta, nearest_delta);
+        let mut candidate_delta = point
+            - vec2f(
+                size.x,
+                clamp(
+                    point.y,
+                    vertical_extents.y,
+                    max(vertical_extents.y, size.y - vertical_extents.z),
+                ),
+            );
+
+        let mut candidate_distance_squared = dot(candidate_delta, candidate_delta);
+        if candidate_distance_squared < nearest_distance_squared {
+            nearest_delta = candidate_delta;
+            nearest_normal = vec2f(1.0, 0.0);
+            nearest_distance_squared = candidate_distance_squared;
+        }
+
+        candidate_delta = point
+            - vec2f(
+                clamp(
+                    point.x,
+                    horizontal_extents.w,
+                    max(horizontal_extents.w, size.x - horizontal_extents.z),
+                ),
+                size.y,
+            );
+
+        candidate_distance_squared = dot(candidate_delta, candidate_delta);
+        if candidate_distance_squared < nearest_distance_squared {
+            nearest_delta = candidate_delta;
+            nearest_normal = vec2f(0.0, 1.0);
+            nearest_distance_squared = candidate_distance_squared;
+        }
+
+        candidate_delta = point
+            - vec2f(
+                0.0,
+                clamp(
+                    point.y,
+                    vertical_extents.x,
+                    max(vertical_extents.x, size.y - vertical_extents.w),
+                ),
+            );
+
+        candidate_distance_squared = dot(candidate_delta, candidate_delta);
+        if candidate_distance_squared < nearest_distance_squared {
+            nearest_delta = candidate_delta;
+            nearest_normal = vec2f(-1.0, 0.0);
+            nearest_distance_squared = candidate_distance_squared;
+        }
+
+        SignedDistanceSample {
+            distance: figma_signed_distance(
+                nearest_delta,
+                nearest_normal,
+                sqrt(nearest_distance_squared),
+            ),
+            normal: nearest_normal,
+            path_t: 0.0,
+            segment: FIGMA_SEGMENT_STRAIGHT,
+        }
+    }
+
+    pub fn figma_smooth_rectangle_sample(
+        point: Vec2f,
+        bounds: Bounds,
+        corner_radii: Corners,
+        horizontal_reaches: Vec4f,
+        vertical_reaches: Vec4f,
+        smoothing_factors: Vec4f,
+    ) -> FigmaRectangleSample {
+        let local_point = point - bounds.origin;
+        let radii = corner_values(corner_radii);
+        let mut result = FigmaRectangleSample {
+            signed_distance: figma_nearest_straight_sample(
+                local_point,
+                bounds.size,
+                horizontal_reaches,
+                vertical_reaches,
+            ),
+            corner: FIGMA_NO_CORNER,
+        };
+
+        if !figma_has_corner_candidate(
+            local_point,
+            bounds.size,
+            horizontal_reaches,
+            vertical_reaches,
+        ) {
+            return result;
+        }
+
+        let mut corner = 0u32;
+        while corner < 4u32 {
+            if figma_is_corner_candidate(
+                local_point,
+                bounds.size,
+                horizontal_reaches[corner],
+                vertical_reaches[corner],
+                corner,
+            ) {
+                let params = figma_corner_params(
+                    radii[corner],
+                    horizontal_reaches[corner],
+                    vertical_reaches[corner],
+                    smoothing_factors,
+                );
+
+                if params.radius > FIGMA_EPSILON {
+                    let mut candidate = figma_corner_signed_distance(
+                        figma_corner_to_point(local_point, bounds.size, corner),
+                        params,
+                    );
+                    candidate.normal = figma_orient_corner_normal(candidate.normal, corner);
+
+                    if abs(candidate.distance) <= abs(result.signed_distance.distance) {
+                        result.signed_distance = candidate;
+                        result.corner = corner;
+                    }
+                }
+            }
+
+            corner += 1u32;
+        }
+
+        result
+    }
+
+    pub fn prepared_corner_signed_distance(
+        point: Vec2f,
+        bounds: Bounds,
+        corner_radii: Corners,
+        corner_smoothing: f32,
+        prepared: PreparedCorners,
+    ) -> f32 {
+        if prepared.superellipse_power > 0.0 {
+            return normalized_superellipse_signed_distance(
+                point,
+                bounds,
+                corner_radii,
+                corner_smoothing,
+                prepared.superellipse_power,
+            );
+        }
+
+        if prepared.smoothing_factors.x <= 0.0 {
+            return rounded_rectangle_signed_distance(point, bounds, corner_radii);
+        }
+
+        figma_smooth_rectangle_sample(
+            point,
+            bounds,
+            corner_radii,
+            prepared.horizontal_reaches,
+            prepared.vertical_reaches,
+            prepared.smoothing_factors,
+        )
+        .signed_distance
+        .distance
+    }
+}
+
+pub use source::*;
+
+#[cfg(test)]
+mod tests {
+    use super::super::common::*;
+    use super::*;
+    use wgsl_rs::std::vec2f;
+
+    fn distance(
+        point: wgsl_rs::std::Vec2f,
+        bounds: Bounds,
+        radii: Corners,
+        smoothing: f32,
+        allow_superellipse: bool,
+    ) -> f32 {
+        let prepared = prepare_corners(bounds.size, radii, smoothing, allow_superellipse);
+        prepared_corner_signed_distance(point, bounds, radii, smoothing, prepared)
+    }
+
+    #[test]
+    fn smoothed_corner_geometry_preserves_core_invariants() {
+        let bounds = Bounds {
+            origin: vec2f(0.0, 0.0),
+            size: vec2f(120.0, 80.0),
+        };
+        let corners = |top_left, top_right, bottom_right, bottom_left| Corners {
+            top_left,
+            top_right,
+            bottom_right,
+            bottom_left,
+        };
+        let cases = [
+            corners(20.0, 20.0, 20.0, 20.0),
+            corners(28.0, 8.0, 22.0, 2.0),
+            corners(70.0, 45.0, 60.0, 35.0),
+            corners(0.0, 0.0, 0.0, 0.0),
+        ];
+
+        for radii in cases {
+            for smoothing in [0.0, 0.6, 1.0] {
+                for y in -1..=9 {
+                    for x in -1..=13 {
+                        let point = vec2f(x as f32 * 10.0, y as f32 * 10.0);
+                        let actual = distance(point, bounds, radii, smoothing, false);
+                        assert!(actual.is_finite(), "non-finite SDF at {point:?}");
+
+                        if smoothing == 0.0 {
+                            let circular = rounded_rectangle_signed_distance(point, bounds, radii);
+                            assert_eq!(actual, circular);
+                        }
+                    }
+                }
+
+                assert!(distance(vec2f(60.0, 40.0), bounds, radii, smoothing, false) < 0.0);
+                assert!(distance(vec2f(-2.0, -2.0), bounds, radii, smoothing, false) > 0.0);
+            }
+        }
+
+        let square = Bounds {
+            origin: vec2f(0.0, 0.0),
+            size: vec2f(100.0, 100.0),
+        };
+        let uniform = corners(20.0, 20.0, 20.0, 20.0);
+
+        for smoothing in [0.0, 0.6, 1.0] {
+            let a = distance(vec2f(8.0, 17.0), square, uniform, smoothing, true);
+            let b = distance(vec2f(83.0, 8.0), square, uniform, smoothing, true);
+            let c = distance(vec2f(92.0, 83.0), square, uniform, smoothing, true);
+            let d = distance(vec2f(17.0, 92.0), square, uniform, smoothing, true);
+            assert!(
+                [b, c, d]
+                    .into_iter()
+                    .all(|value| (a - value).abs() < 0.0001)
+            );
+
+            let diagonal = 20.0 * SUPERELLIPSE_DIAGONAL_INSET;
+            let diagonal_distance =
+                distance(vec2f(diagonal, diagonal), square, uniform, smoothing, true);
+            assert!(diagonal_distance.abs() < 0.0001);
+        }
+
+        let circular = prepare_corners(square.size, uniform, 0.0, false);
+        let smoothed = prepare_corners(square.size, uniform, 0.6, false);
+        assert_eq!(circular.horizontal_reaches.x, 20.0);
+        assert!(smoothed.horizontal_reaches.x > circular.horizontal_reaches.x);
+        assert!(smoothed.vertical_reaches.x > circular.vertical_reaches.x);
+    }
+}

--- a/crates/gpui_render/src/shaders/filters.rs
+++ b/crates/gpui_render/src/shaders/filters.rs
@@ -80,6 +80,7 @@ pub mod surface {
 #[wgsl_rs::wgsl]
 pub mod blur {
     use super::super::common::*;
+    use super::super::corner_smoothing::*;
     use wgsl_rs::std::*;
 
     #[repr(C)]
@@ -97,6 +98,10 @@ pub mod blur {
         pub downsample_mode: DownsampleMode,
         pub source_size: Vec2f,
         pub target_size: Vec2f,
+        pub corner_smoothing: f32,
+        pub padding0: u32,
+        pub padding1: u32,
+        pub padding2: u32,
     }
     uniform!(group(1), binding(0), BLUR_LOCALS: BlurUniforms);
     texture!(group(1), binding(1), BLUR_TEXTURE: Texture2D<f32>);
@@ -108,8 +113,20 @@ pub mod blur {
         pub position: Vec4f,
         #[location(0)]
         pub texture_coordinates: Vec2f,
+        #[location(1)]
+        #[interpolate(flat)]
+        pub horizontal_corner_reaches: Vec4f,
+        #[location(2)]
+        #[interpolate(flat)]
+        pub vertical_corner_reaches: Vec4f,
         #[location(3)]
         pub clip_distances: Vec4f,
+        #[location(4)]
+        #[interpolate(flat)]
+        pub smoothing_factors: Vec4f,
+        #[location(5)]
+        #[interpolate(flat)]
+        pub superellipse_power: f32,
     }
 
     #[vertex]
@@ -118,7 +135,11 @@ pub mod blur {
         BlurVarying {
             position: vertex.clip_position,
             texture_coordinates: vertex.texture_coordinates,
+            horizontal_corner_reaches: vec4f(0.0, 0.0, 0.0, 0.0),
+            vertical_corner_reaches: vec4f(0.0, 0.0, 0.0, 0.0),
             clip_distances: unclipped_distances(),
+            smoothing_factors: vec4f(0.0, 0.0, 0.0, 0.0),
+            superellipse_power: 0.0,
         }
     }
 
@@ -167,13 +188,23 @@ pub mod blur {
     #[vertex]
     pub fn vertex_blur_composite(#[builtin(vertex_index)] vertex_id: u32) -> BlurVarying {
         let vertex = rectangle_vertex(vertex_id, get!(BLUR_LOCALS).bounds);
+        let prepared = prepare_corners(
+            get!(BLUR_LOCALS).bounds.size,
+            get!(BLUR_LOCALS).corner_radii,
+            get!(BLUR_LOCALS).corner_smoothing,
+            true,
+        );
         BlurVarying {
             position: vertex.clip_position,
             texture_coordinates: vertex.unit_position,
+            horizontal_corner_reaches: prepared.horizontal_reaches,
+            vertical_corner_reaches: prepared.vertical_reaches,
             clip_distances: clip_distances(
                 vertex.viewport_position,
                 get!(BLUR_LOCALS).content_mask,
             ),
+            smoothing_factors: prepared.smoothing_factors,
+            superellipse_power: prepared.superellipse_power,
         }
     }
 
@@ -190,10 +221,17 @@ pub mod blur {
         );
         let coverage = select(
             1.0,
-            antialiased_coverage(rounded_rectangle_signed_distance(
+            antialiased_coverage(prepared_corner_signed_distance(
                 input.position.xy(),
                 get!(BLUR_LOCALS).bounds,
                 get!(BLUR_LOCALS).corner_radii,
+                get!(BLUR_LOCALS).corner_smoothing,
+                PreparedCorners {
+                    horizontal_reaches: input.horizontal_corner_reaches,
+                    vertical_reaches: input.vertical_corner_reaches,
+                    smoothing_factors: input.smoothing_factors,
+                    superellipse_power: input.superellipse_power,
+                },
             )),
             get!(BLUR_LOCALS).composite_clip == BlurCompositeClip::RoundedBounds,
         );

--- a/crates/gpui_render/src/shaders/filters.rs
+++ b/crates/gpui_render/src/shaders/filters.rs
@@ -113,20 +113,8 @@ pub mod blur {
         pub position: Vec4f,
         #[location(0)]
         pub texture_coordinates: Vec2f,
-        #[location(1)]
-        #[interpolate(flat)]
-        pub horizontal_corner_reaches: Vec4f,
-        #[location(2)]
-        #[interpolate(flat)]
-        pub vertical_corner_reaches: Vec4f,
         #[location(3)]
         pub clip_distances: Vec4f,
-        #[location(4)]
-        #[interpolate(flat)]
-        pub smoothing_factors: Vec4f,
-        #[location(5)]
-        #[interpolate(flat)]
-        pub superellipse_power: f32,
     }
 
     #[vertex]
@@ -135,11 +123,7 @@ pub mod blur {
         BlurVarying {
             position: vertex.clip_position,
             texture_coordinates: vertex.texture_coordinates,
-            horizontal_corner_reaches: vec4f(0.0, 0.0, 0.0, 0.0),
-            vertical_corner_reaches: vec4f(0.0, 0.0, 0.0, 0.0),
             clip_distances: unclipped_distances(),
-            smoothing_factors: vec4f(0.0, 0.0, 0.0, 0.0),
-            superellipse_power: 0.0,
         }
     }
 
@@ -188,13 +172,79 @@ pub mod blur {
     #[vertex]
     pub fn vertex_blur_composite(#[builtin(vertex_index)] vertex_id: u32) -> BlurVarying {
         let vertex = rectangle_vertex(vertex_id, get!(BLUR_LOCALS).bounds);
+        BlurVarying {
+            position: vertex.clip_position,
+            texture_coordinates: vertex.unit_position,
+            clip_distances: clip_distances(
+                vertex.viewport_position,
+                get!(BLUR_LOCALS).content_mask,
+            ),
+        }
+    }
+
+    #[fragment]
+    pub fn fragment_blur_composite(input: BlurVarying) -> Vec4f {
+        if is_clipped(input.clip_distances) {
+            return transparent();
+        }
+        let blurred = texture_sample_level(
+            BLUR_TEXTURE,
+            BLUR_SAMPLER,
+            input.position.xy() / get!(BLUR_LOCALS).target_size,
+            0.0,
+        );
+        let coverage = select(
+            1.0,
+            antialiased_coverage(rounded_rectangle_signed_distance(
+                input.position.xy(),
+                get!(BLUR_LOCALS).bounds,
+                get!(BLUR_LOCALS).corner_radii,
+            )),
+            get!(BLUR_LOCALS).composite_clip == BlurCompositeClip::RoundedBounds,
+        );
+        let factor = coverage * get!(BLUR_LOCALS).opacity;
+        vec4f(
+            blurred.x * factor,
+            blurred.y * factor,
+            blurred.z * factor,
+            blurred.w * factor,
+        )
+    }
+
+    #[derive(Wgsl)]
+    pub struct SmoothedBlurVarying {
+        #[builtin(position)]
+        pub position: Vec4f,
+        #[location(0)]
+        pub texture_coordinates: Vec2f,
+        #[location(1)]
+        #[interpolate(flat)]
+        pub horizontal_corner_reaches: Vec4f,
+        #[location(2)]
+        #[interpolate(flat)]
+        pub vertical_corner_reaches: Vec4f,
+        #[location(3)]
+        pub clip_distances: Vec4f,
+        #[location(4)]
+        #[interpolate(flat)]
+        pub smoothing_factors: Vec4f,
+        #[location(5)]
+        #[interpolate(flat)]
+        pub superellipse_power: f32,
+    }
+
+    #[vertex]
+    pub fn vertex_smoothed_blur_composite(
+        #[builtin(vertex_index)] vertex_id: u32,
+    ) -> SmoothedBlurVarying {
+        let vertex = rectangle_vertex(vertex_id, get!(BLUR_LOCALS).bounds);
         let prepared = prepare_corners(
             get!(BLUR_LOCALS).bounds.size,
             get!(BLUR_LOCALS).corner_radii,
             get!(BLUR_LOCALS).corner_smoothing,
             true,
         );
-        BlurVarying {
+        SmoothedBlurVarying {
             position: vertex.clip_position,
             texture_coordinates: vertex.unit_position,
             horizontal_corner_reaches: prepared.horizontal_reaches,
@@ -209,7 +259,7 @@ pub mod blur {
     }
 
     #[fragment]
-    pub fn fragment_blur_composite(input: BlurVarying) -> Vec4f {
+    pub fn fragment_smoothed_blur_composite(input: SmoothedBlurVarying) -> Vec4f {
         if is_clipped(input.clip_distances) {
             return transparent();
         }

--- a/crates/gpui_render/src/shaders/filters.rs
+++ b/crates/gpui_render/src/shaders/filters.rs
@@ -111,6 +111,41 @@ pub mod blur {
     texture!(group(1), binding(1), BLUR_TEXTURE: Texture2D<f32>);
     sampler!(group(1), binding(2), BLUR_SAMPLER: Sampler);
 
+    #[derive(Clone, Copy, Wgsl)]
+    pub struct BlurCompositeVertexData {
+        pub position: Vec4f,
+        pub texture_coordinates: Vec2f,
+        pub clip_distances: Vec4f,
+    }
+
+    pub fn prepare_blur_composite_vertex(vertex_id: u32) -> BlurCompositeVertexData {
+        let vertex = rectangle_vertex(vertex_id, get!(BLUR_LOCALS).bounds);
+        BlurCompositeVertexData {
+            position: vertex.clip_position,
+            texture_coordinates: vertex.unit_position,
+            clip_distances: clip_distances(
+                vertex.viewport_position,
+                get!(BLUR_LOCALS).content_mask,
+            ),
+        }
+    }
+
+    pub fn blur_composite_color(position: Vec2f, coverage: f32) -> Vec4f {
+        let blurred = texture_sample_level(
+            BLUR_TEXTURE,
+            BLUR_SAMPLER,
+            position / get!(BLUR_LOCALS).target_size,
+            0.0,
+        );
+        let factor = coverage * get!(BLUR_LOCALS).opacity;
+        vec4f(
+            blurred.x * factor,
+            blurred.y * factor,
+            blurred.z * factor,
+            blurred.w * factor,
+        )
+    }
+
     #[derive(Wgsl)]
     pub struct BlurVarying {
         #[builtin(position)]
@@ -175,14 +210,11 @@ pub mod blur {
 
     #[vertex]
     pub fn vertex_blur_composite(#[builtin(vertex_index)] vertex_id: u32) -> BlurVarying {
-        let vertex = rectangle_vertex(vertex_id, get!(BLUR_LOCALS).bounds);
+        let vertex = prepare_blur_composite_vertex(vertex_id);
         BlurVarying {
-            position: vertex.clip_position,
-            texture_coordinates: vertex.unit_position,
-            clip_distances: clip_distances(
-                vertex.viewport_position,
-                get!(BLUR_LOCALS).content_mask,
-            ),
+            position: vertex.position,
+            texture_coordinates: vertex.texture_coordinates,
+            clip_distances: vertex.clip_distances,
         }
     }
 
@@ -191,12 +223,6 @@ pub mod blur {
         if is_clipped(input.clip_distances) {
             return transparent();
         }
-        let blurred = texture_sample_level(
-            BLUR_TEXTURE,
-            BLUR_SAMPLER,
-            input.position.xy() / get!(BLUR_LOCALS).target_size,
-            0.0,
-        );
         let coverage = select(
             1.0,
             antialiased_coverage(rounded_rectangle_signed_distance(
@@ -206,13 +232,7 @@ pub mod blur {
             )),
             get!(BLUR_LOCALS).composite_clip == BlurCompositeClip::RoundedBounds,
         );
-        let factor = coverage * get!(BLUR_LOCALS).opacity;
-        vec4f(
-            blurred.x * factor,
-            blurred.y * factor,
-            blurred.z * factor,
-            blurred.w * factor,
-        )
+        blur_composite_color(input.position.xy(), coverage)
     }
 
     #[derive(Wgsl)]
@@ -241,7 +261,7 @@ pub mod blur {
     pub fn vertex_smoothed_blur_composite(
         #[builtin(vertex_index)] vertex_id: u32,
     ) -> SmoothedBlurVarying {
-        let vertex = rectangle_vertex(vertex_id, get!(BLUR_LOCALS).bounds);
+        let vertex = prepare_blur_composite_vertex(vertex_id);
         let prepared = prepare_corners(
             get!(BLUR_LOCALS).bounds.size,
             get!(BLUR_LOCALS).corner_radii,
@@ -249,14 +269,11 @@ pub mod blur {
             true,
         );
         SmoothedBlurVarying {
-            position: vertex.clip_position,
-            texture_coordinates: vertex.unit_position,
+            position: vertex.position,
+            texture_coordinates: vertex.texture_coordinates,
             horizontal_corner_reaches: prepared.horizontal_reaches,
             vertical_corner_reaches: prepared.vertical_reaches,
-            clip_distances: clip_distances(
-                vertex.viewport_position,
-                get!(BLUR_LOCALS).content_mask,
-            ),
+            clip_distances: vertex.clip_distances,
             smoothing_factors: prepared.smoothing_factors,
             superellipse_power: prepared.superellipse_power,
         }
@@ -267,12 +284,6 @@ pub mod blur {
         if is_clipped(input.clip_distances) {
             return transparent();
         }
-        let blurred = texture_sample_level(
-            BLUR_TEXTURE,
-            BLUR_SAMPLER,
-            input.position.xy() / get!(BLUR_LOCALS).target_size,
-            0.0,
-        );
         let coverage = select(
             1.0,
             antialiased_coverage(prepared_corner_signed_distance(
@@ -289,12 +300,6 @@ pub mod blur {
             )),
             get!(BLUR_LOCALS).composite_clip == BlurCompositeClip::RoundedBounds,
         );
-        let factor = coverage * get!(BLUR_LOCALS).opacity;
-        vec4f(
-            blurred.x * factor,
-            blurred.y * factor,
-            blurred.z * factor,
-            blurred.w * factor,
-        )
+        blur_composite_color(input.position.xy(), coverage)
     }
 }

--- a/crates/gpui_render/src/shaders/interface.rs
+++ b/crates/gpui_render/src/shaders/interface.rs
@@ -97,17 +97,21 @@ macro_rules! define_pipelines {
 
 define_pipelines! {
     QUADS: "quads", vertex_quad, fragment_quad, TriangleStrip, Instances, Rectangle;
+    SMOOTHED_QUADS: "smoothed_quads", vertex_smoothed_quad, fragment_smoothed_quad, TriangleStrip, Instances, Rectangle;
     SHADOWS: "shadows", vertex_shadow, fragment_shadow, TriangleStrip, Instances, Rectangle;
+    SMOOTHED_SHADOWS: "smoothed_shadows", vertex_smoothed_shadow, fragment_smoothed_shadow, TriangleStrip, Instances, Rectangle;
     PATH_RASTERIZATION: "path_rasterization", vertex_path_rasterization, fragment_path_rasterization, TriangleList, Instances, Dynamic;
     PATHS: "paths", vertex_path, fragment_path, TriangleStrip, TexturedInstances, Rectangle;
     UNDERLINES: "underlines", vertex_underline, fragment_underline, TriangleStrip, Instances, Rectangle;
     MONOCHROME_SPRITES: "monochrome_sprites", vertex_monochrome_sprite, fragment_monochrome_sprite, TriangleStrip, MonochromeSprites, Rectangle;
     SUBPIXEL_SPRITES: "subpixel_sprites", vertex_subpixel_sprite, fragment_subpixel_sprite, TriangleStrip, SubpixelSprites, Rectangle;
     POLYCHROME_SPRITES: "polychrome_sprites", vertex_polychrome_sprite, fragment_polychrome_sprite, TriangleStrip, TexturedInstances, Rectangle;
+    SMOOTHED_POLYCHROME_SPRITES: "smoothed_polychrome_sprites", vertex_smoothed_polychrome_sprite, fragment_smoothed_polychrome_sprite, TriangleStrip, TexturedInstances, Rectangle;
     SURFACES: "surfaces", vertex_surface, fragment_surface, TriangleStrip, Surface, Rectangle;
     BLUR_DOWNSAMPLE: "blur_downsample", vertex_blur_fullscreen, fragment_blur_downsample, TriangleList, Blur, FullscreenTriangle;
     BLUR: "blur", vertex_blur_fullscreen, fragment_blur, TriangleList, Blur, FullscreenTriangle;
     BLUR_COMPOSITE: "blur_composite", vertex_blur_composite, fragment_blur_composite, TriangleStrip, Blur, Rectangle;
+    SMOOTHED_BLUR_COMPOSITE: "smoothed_blur_composite", vertex_smoothed_blur_composite, fragment_smoothed_blur_composite, TriangleStrip, Blur, Rectangle;
 }
 
 pub const EMOJI_RASTERIZATION: Pipeline = Pipeline {

--- a/crates/gpui_render/src/shaders/interface.rs
+++ b/crates/gpui_render/src/shaders/interface.rs
@@ -218,7 +218,11 @@ pub const RENDER_BUFFER_LAYOUTS: &[gpui::SceneBufferLayout] = &[
         composite_clip,
         downsample_mode,
         source_size,
-        target_size
+        target_size,
+        corner_smoothing,
+        padding0,
+        padding1,
+        padding2
     ),
     render_layout!(crate::path_types::PathSprite, "PathSprite", bounds),
     render_layout!(

--- a/crates/gpui_render/src/shaders/mod.rs
+++ b/crates/gpui_render/src/shaders/mod.rs
@@ -1,4 +1,7 @@
 //! Rust-authored shader sources, split by ABI and rendering domain.
+//!
+//! Ordinary and smoothed entry points share vertex preparation, but keep distinct stage-output
+//! structs so ordinary primitives do not reserve or interpolate corner-smoothing data.
 
 #![allow(dead_code, unused_assignments, unused_imports)]
 

--- a/crates/gpui_render/src/shaders/mod.rs
+++ b/crates/gpui_render/src/shaders/mod.rs
@@ -5,6 +5,7 @@
 pub mod common;
 pub mod interface;
 
+mod corner_smoothing;
 mod emoji;
 mod filters;
 mod linkage;

--- a/crates/gpui_render/src/shaders/quads.rs
+++ b/crates/gpui_render/src/shaders/quads.rs
@@ -526,21 +526,6 @@ pub mod quad {
         #[location(5)]
         #[interpolate(flat)]
         pub background_color1: Vec4f,
-        #[location(6)]
-        #[interpolate(flat)]
-        pub horizontal_corner_reaches: Vec4f,
-        #[location(7)]
-        #[interpolate(flat)]
-        pub vertical_corner_reaches: Vec4f,
-        #[location(8)]
-        #[interpolate(flat)]
-        pub corner_lengths: Vec4f,
-        #[location(9)]
-        #[interpolate(flat)]
-        pub smoothing_factors: Vec4f,
-        #[location(10)]
-        #[interpolate(flat)]
-        pub superellipse_power: f32,
     }
 
     #[vertex]
@@ -551,13 +536,6 @@ pub mod quad {
         let quad = get!(QUADS)[instance_id as usize];
         let vertex = rectangle_vertex(vertex_id, quad.bounds);
         let gradient = prepare_background(quad.background);
-        let prepared = prepare_corners(
-            quad.bounds.size,
-            quad.corner_radii,
-            quad.corner_smoothing,
-            quad.border_style == BorderStyle::Solid && Edges::is_zero(quad.border_widths),
-        );
-
         QuadVarying {
             position: vertex.clip_position,
             border_color: hsla_to_rgba(quad.border_color),
@@ -566,11 +544,6 @@ pub mod quad {
             background_solid: gradient.solid,
             background_color0: gradient.color0,
             background_color1: gradient.color1,
-            horizontal_corner_reaches: prepared.horizontal_reaches,
-            vertical_corner_reaches: prepared.vertical_reaches,
-            corner_lengths: smoothed_corner_lengths(quad, prepared),
-            smoothing_factors: prepared.smoothing_factors,
-            superellipse_power: prepared.superellipse_power,
         }
     }
 
@@ -590,127 +563,6 @@ pub mod quad {
                 color1: input.background_color1,
             },
         );
-        let prepared = PreparedCorners {
-            horizontal_reaches: input.horizontal_corner_reaches,
-            vertical_reaches: input.vertical_corner_reaches,
-            smoothing_factors: input.smoothing_factors,
-            superellipse_power: input.superellipse_power,
-        };
-
-        if quad.corner_smoothing > 0.0 {
-            if Edges::is_zero(quad.border_widths) {
-                let distance = prepared_corner_signed_distance(
-                    input.position.xy(),
-                    quad.bounds,
-                    quad.corner_radii,
-                    quad.corner_smoothing,
-                    prepared,
-                );
-
-                return blend_color(background_color, antialiased_coverage(distance));
-            }
-
-            let geometry = quad_geometry(quad, input.position.xy());
-            let rectangle_sample = figma_smooth_rectangle_sample(
-                input.position.xy(),
-                quad.bounds,
-                quad.corner_radii,
-                prepared.horizontal_reaches,
-                prepared.vertical_reaches,
-                prepared.smoothing_factors,
-            );
-            let mut border = vec2f(
-                select(
-                    quad.border_widths.right,
-                    quad.border_widths.left,
-                    geometry.center_to_point.x < 0.0,
-                ),
-                select(
-                    quad.border_widths.bottom,
-                    quad.border_widths.top,
-                    geometry.center_to_point.y < 0.0,
-                ),
-            );
-
-            match rectangle_sample.corner {
-                0u32 => {
-                    border = vec2f(quad.border_widths.left, quad.border_widths.top);
-                }
-                1u32 => {
-                    border = vec2f(quad.border_widths.right, quad.border_widths.top);
-                }
-                2u32 => {
-                    border = vec2f(quad.border_widths.right, quad.border_widths.bottom);
-                }
-                3u32 => {
-                    border = vec2f(quad.border_widths.left, quad.border_widths.bottom);
-                }
-                _ => {}
-            }
-
-            let reduced_border = vec2f(
-                select(border.x, -PIXEL_ANTIALIAS_RADIUS, border.x == 0.0),
-                select(border.y, -PIXEL_ANTIALIAS_RADIUS, border.y == 0.0),
-            );
-            let half_size = Bounds::half_size(quad.bounds);
-            let corner_to_point = abs(geometry.center_to_point) - half_size;
-            let straight_border_inner_corner_to_point = corner_to_point + reduced_border;
-            let near_curve = rectangle_sample.signed_distance.segment != FIGMA_SEGMENT_STRAIGHT;
-
-            if straight_border_inner_corner_to_point.x < -PIXEL_ANTIALIAS_RADIUS
-                && straight_border_inner_corner_to_point.y < -PIXEL_ANTIALIAS_RADIUS
-                && !near_curve
-            {
-                return blend_color(background_color, 1.0);
-            }
-
-            let outer = rectangle_sample.signed_distance.distance;
-            let mut inner = 0.0;
-
-            if near_curve {
-                let normal = abs(rectangle_sample.signed_distance.normal);
-                let active_sides = vec2f(
-                    select(0.0, 1.0, border.x > 0.0),
-                    select(0.0, 1.0, border.y > 0.0),
-                );
-                let effective_width = length(border * normal)
-                    - PIXEL_ANTIALIAS_RADIUS * (1.0 - length(active_sides * normal));
-                inner = -(outer + effective_width);
-            } else {
-                inner = -max(
-                    straight_border_inner_corner_to_point.x,
-                    straight_border_inner_corner_to_point.y,
-                );
-            }
-
-            let mut color = background_color;
-
-            if max(inner, outer) < PIXEL_ANTIALIAS_RADIUS {
-                let mut border_color = input.border_color;
-                if quad.border_style == BorderStyle::Dashed {
-                    border_color.w *= smoothed_dashed_border_alpha(
-                        quad,
-                        geometry,
-                        rectangle_sample,
-                        prepared,
-                        input.corner_lengths,
-                        border,
-                        straight_border_inner_corner_to_point,
-                    );
-                }
-
-                let blended_border = over(background_color, border_color);
-                let factor = antialiased_coverage(inner);
-
-                color = mix(
-                    background_color,
-                    blended_border,
-                    vec4f(factor, factor, factor, factor),
-                );
-            }
-
-            return blend_color(color, antialiased_coverage(outer));
-        }
         if Edges::is_zero(quad.border_widths) && Corners::is_zero(quad.corner_radii) {
             return blend_color(background_color, 1.0);
         }
@@ -736,5 +588,211 @@ pub mod quad {
             );
         }
         blend_color(color, antialiased_coverage(distances.outer))
+    }
+
+    #[derive(Wgsl)]
+    pub struct SmoothedQuadVarying {
+        #[builtin(position)]
+        pub position: Vec4f,
+        #[location(0)]
+        #[interpolate(flat)]
+        pub border_color: Vec4f,
+        #[location(1)]
+        #[interpolate(flat)]
+        pub quad_id: u32,
+        #[location(2)]
+        pub clip_distances: Vec4f,
+        #[location(3)]
+        #[interpolate(flat)]
+        pub background_solid: Vec4f,
+        #[location(4)]
+        #[interpolate(flat)]
+        pub background_color0: Vec4f,
+        #[location(5)]
+        #[interpolate(flat)]
+        pub background_color1: Vec4f,
+        #[location(6)]
+        #[interpolate(flat)]
+        pub horizontal_corner_reaches: Vec4f,
+        #[location(7)]
+        #[interpolate(flat)]
+        pub vertical_corner_reaches: Vec4f,
+        #[location(8)]
+        #[interpolate(flat)]
+        pub corner_lengths: Vec4f,
+        #[location(9)]
+        #[interpolate(flat)]
+        pub smoothing_factors: Vec4f,
+        #[location(10)]
+        #[interpolate(flat)]
+        pub superellipse_power: f32,
+    }
+
+    #[vertex]
+    pub fn vertex_smoothed_quad(
+        #[builtin(vertex_index)] vertex_id: u32,
+        #[builtin(instance_index)] instance_id: u32,
+    ) -> SmoothedQuadVarying {
+        let quad = get!(QUADS)[instance_id as usize];
+        let vertex = rectangle_vertex(vertex_id, quad.bounds);
+        let gradient = prepare_background(quad.background);
+        let prepared = prepare_corners(
+            quad.bounds.size,
+            quad.corner_radii,
+            quad.corner_smoothing,
+            quad.border_style == BorderStyle::Solid && Edges::is_zero(quad.border_widths),
+        );
+
+        SmoothedQuadVarying {
+            position: vertex.clip_position,
+            border_color: hsla_to_rgba(quad.border_color),
+            quad_id: instance_id,
+            clip_distances: clip_distances(vertex.viewport_position, quad.content_mask),
+            background_solid: gradient.solid,
+            background_color0: gradient.color0,
+            background_color1: gradient.color1,
+            horizontal_corner_reaches: prepared.horizontal_reaches,
+            vertical_corner_reaches: prepared.vertical_reaches,
+            corner_lengths: smoothed_corner_lengths(quad, prepared),
+            smoothing_factors: prepared.smoothing_factors,
+            superellipse_power: prepared.superellipse_power,
+        }
+    }
+
+    #[fragment]
+    pub fn fragment_smoothed_quad(input: SmoothedQuadVarying) -> Vec4f {
+        if is_clipped(input.clip_distances) {
+            return transparent();
+        }
+        let quad = get!(QUADS)[input.quad_id as usize];
+        let background_color = background_color(
+            quad.background,
+            input.position.xy(),
+            quad.bounds,
+            PreparedBackground {
+                solid: input.background_solid,
+                color0: input.background_color0,
+                color1: input.background_color1,
+            },
+        );
+        let prepared = PreparedCorners {
+            horizontal_reaches: input.horizontal_corner_reaches,
+            vertical_reaches: input.vertical_corner_reaches,
+            smoothing_factors: input.smoothing_factors,
+            superellipse_power: input.superellipse_power,
+        };
+
+        if Edges::is_zero(quad.border_widths) {
+            let distance = prepared_corner_signed_distance(
+                input.position.xy(),
+                quad.bounds,
+                quad.corner_radii,
+                quad.corner_smoothing,
+                prepared,
+            );
+
+            return blend_color(background_color, antialiased_coverage(distance));
+        }
+
+        let geometry = quad_geometry(quad, input.position.xy());
+        let rectangle_sample = figma_smooth_rectangle_sample(
+            input.position.xy(),
+            quad.bounds,
+            quad.corner_radii,
+            prepared.horizontal_reaches,
+            prepared.vertical_reaches,
+            prepared.smoothing_factors,
+        );
+        let mut border = vec2f(
+            select(
+                quad.border_widths.right,
+                quad.border_widths.left,
+                geometry.center_to_point.x < 0.0,
+            ),
+            select(
+                quad.border_widths.bottom,
+                quad.border_widths.top,
+                geometry.center_to_point.y < 0.0,
+            ),
+        );
+
+        match rectangle_sample.corner {
+            0u32 => {
+                border = vec2f(quad.border_widths.left, quad.border_widths.top);
+            }
+            1u32 => {
+                border = vec2f(quad.border_widths.right, quad.border_widths.top);
+            }
+            2u32 => {
+                border = vec2f(quad.border_widths.right, quad.border_widths.bottom);
+            }
+            3u32 => {
+                border = vec2f(quad.border_widths.left, quad.border_widths.bottom);
+            }
+            _ => {}
+        }
+
+        let reduced_border = vec2f(
+            select(border.x, -PIXEL_ANTIALIAS_RADIUS, border.x == 0.0),
+            select(border.y, -PIXEL_ANTIALIAS_RADIUS, border.y == 0.0),
+        );
+        let half_size = Bounds::half_size(quad.bounds);
+        let corner_to_point = abs(geometry.center_to_point) - half_size;
+        let straight_border_inner_corner_to_point = corner_to_point + reduced_border;
+        let near_curve = rectangle_sample.signed_distance.segment != FIGMA_SEGMENT_STRAIGHT;
+
+        if straight_border_inner_corner_to_point.x < -PIXEL_ANTIALIAS_RADIUS
+            && straight_border_inner_corner_to_point.y < -PIXEL_ANTIALIAS_RADIUS
+            && !near_curve
+        {
+            return blend_color(background_color, 1.0);
+        }
+
+        let outer = rectangle_sample.signed_distance.distance;
+        let mut inner = 0.0;
+
+        if near_curve {
+            let normal = abs(rectangle_sample.signed_distance.normal);
+            let active_sides = vec2f(
+                select(0.0, 1.0, border.x > 0.0),
+                select(0.0, 1.0, border.y > 0.0),
+            );
+            let effective_width = length(border * normal)
+                - PIXEL_ANTIALIAS_RADIUS * (1.0 - length(active_sides * normal));
+            inner = -(outer + effective_width);
+        } else {
+            inner = -max(
+                straight_border_inner_corner_to_point.x,
+                straight_border_inner_corner_to_point.y,
+            );
+        }
+
+        let mut color = background_color;
+
+        if max(inner, outer) < PIXEL_ANTIALIAS_RADIUS {
+            let mut border_color = input.border_color;
+            if quad.border_style == BorderStyle::Dashed {
+                border_color.w *= smoothed_dashed_border_alpha(
+                    quad,
+                    geometry,
+                    rectangle_sample,
+                    prepared,
+                    input.corner_lengths,
+                    border,
+                    straight_border_inner_corner_to_point,
+                );
+            }
+
+            let blended_border = over(background_color, border_color);
+            let factor = antialiased_coverage(inner);
+
+            color = mix(
+                background_color,
+                blended_border,
+                vec4f(factor, factor, factor, factor),
+            );
+        }
+
+        blend_color(color, antialiased_coverage(outer))
     }
 }

--- a/crates/gpui_render/src/shaders/quads.rs
+++ b/crates/gpui_render/src/shaders/quads.rs
@@ -505,6 +505,26 @@ pub mod quad {
         }
     }
 
+    #[derive(Clone, Copy, Wgsl)]
+    pub struct QuadVertexData {
+        pub position: Vec4f,
+        pub border_color: Vec4f,
+        pub quad_id: u32,
+        pub clip_distances: Vec4f,
+        pub background: PreparedBackground,
+    }
+
+    pub fn prepare_quad_vertex(vertex_id: u32, instance_id: u32, quad: Quad) -> QuadVertexData {
+        let vertex = rectangle_vertex(vertex_id, quad.bounds);
+        QuadVertexData {
+            position: vertex.clip_position,
+            border_color: hsla_to_rgba(quad.border_color),
+            quad_id: instance_id,
+            clip_distances: clip_distances(vertex.viewport_position, quad.content_mask),
+            background: prepare_background(quad.background),
+        }
+    }
+
     #[derive(Wgsl)]
     pub struct QuadVarying {
         #[builtin(position)]
@@ -534,16 +554,15 @@ pub mod quad {
         #[builtin(instance_index)] instance_id: u32,
     ) -> QuadVarying {
         let quad = get!(QUADS)[instance_id as usize];
-        let vertex = rectangle_vertex(vertex_id, quad.bounds);
-        let gradient = prepare_background(quad.background);
+        let vertex = prepare_quad_vertex(vertex_id, instance_id, quad);
         QuadVarying {
-            position: vertex.clip_position,
-            border_color: hsla_to_rgba(quad.border_color),
-            quad_id: instance_id,
-            clip_distances: clip_distances(vertex.viewport_position, quad.content_mask),
-            background_solid: gradient.solid,
-            background_color0: gradient.color0,
-            background_color1: gradient.color1,
+            position: vertex.position,
+            border_color: vertex.border_color,
+            quad_id: vertex.quad_id,
+            clip_distances: vertex.clip_distances,
+            background_solid: vertex.background.solid,
+            background_color0: vertex.background.color0,
+            background_color1: vertex.background.color1,
         }
     }
 
@@ -634,8 +653,7 @@ pub mod quad {
         #[builtin(instance_index)] instance_id: u32,
     ) -> SmoothedQuadVarying {
         let quad = get!(QUADS)[instance_id as usize];
-        let vertex = rectangle_vertex(vertex_id, quad.bounds);
-        let gradient = prepare_background(quad.background);
+        let vertex = prepare_quad_vertex(vertex_id, instance_id, quad);
         let prepared = prepare_corners(
             quad.bounds.size,
             quad.corner_radii,
@@ -644,13 +662,13 @@ pub mod quad {
         );
 
         SmoothedQuadVarying {
-            position: vertex.clip_position,
-            border_color: hsla_to_rgba(quad.border_color),
-            quad_id: instance_id,
-            clip_distances: clip_distances(vertex.viewport_position, quad.content_mask),
-            background_solid: gradient.solid,
-            background_color0: gradient.color0,
-            background_color1: gradient.color1,
+            position: vertex.position,
+            border_color: vertex.border_color,
+            quad_id: vertex.quad_id,
+            clip_distances: vertex.clip_distances,
+            background_solid: vertex.background.solid,
+            background_color0: vertex.background.color0,
+            background_color1: vertex.background.color1,
             horizontal_corner_reaches: prepared.horizontal_reaches,
             vertical_corner_reaches: prepared.vertical_reaches,
             corner_lengths: smoothed_corner_lengths(quad, prepared),

--- a/crates/gpui_render/src/shaders/quads.rs
+++ b/crates/gpui_render/src/shaders/quads.rs
@@ -1,6 +1,7 @@
 #[wgsl_rs::wgsl]
 pub mod quad {
     use super::super::common::*;
+    use super::super::corner_smoothing::*;
     use wgsl_rs::std::*;
 
     #[derive(Clone, Copy, Wgsl)]
@@ -13,6 +14,8 @@ pub mod quad {
         pub border_color: Hsla,
         pub corner_radii: Corners,
         pub border_widths: Edges,
+        pub corner_smoothing: f32,
+        pub padding: u32,
     }
     storage!(group(1), binding(0), QUADS: RuntimeArray<Quad>);
 
@@ -216,6 +219,198 @@ pub mod quad {
         }
     }
 
+    pub fn smoothed_corner_lengths(quad: Quad, prepared: PreparedCorners) -> Vec4f {
+        if quad.border_style != BorderStyle::Dashed || quad.corner_smoothing <= 0.0 {
+            return corner_values(quad.corner_radii) * (PI / 2.0);
+        }
+
+        let radii = corner_values(quad.corner_radii);
+        let top_left = figma_corner_length(figma_corner_params(
+            radii.x,
+            prepared.horizontal_reaches.x,
+            prepared.vertical_reaches.x,
+            prepared.smoothing_factors,
+        ));
+        let top_right = figma_corner_length(figma_corner_params(
+            radii.y,
+            prepared.horizontal_reaches.y,
+            prepared.vertical_reaches.y,
+            prepared.smoothing_factors,
+        ));
+        let bottom_right = figma_corner_length(figma_corner_params(
+            radii.z,
+            prepared.horizontal_reaches.z,
+            prepared.vertical_reaches.z,
+            prepared.smoothing_factors,
+        ));
+        let bottom_left = figma_corner_length(figma_corner_params(
+            radii.w,
+            prepared.horizontal_reaches.w,
+            prepared.vertical_reaches.w,
+            prepared.smoothing_factors,
+        ));
+
+        vec4f(top_left, top_right, bottom_right, bottom_left)
+    }
+
+    pub fn smoothed_dash_layout(
+        quad: Quad,
+        prepared: PreparedCorners,
+        corner_lengths: Vec4f,
+    ) -> RoundedDashLayout {
+        let side_velocities = side_dash_velocities(quad.border_widths);
+        let side_lengths = Edges {
+            top: (quad.bounds.size.x
+                - prepared.horizontal_reaches.x
+                - prepared.horizontal_reaches.y)
+                * side_velocities.top,
+            right: (quad.bounds.size.y - prepared.vertical_reaches.y - prepared.vertical_reaches.z)
+                * side_velocities.right,
+            bottom: (quad.bounds.size.x
+                - prepared.horizontal_reaches.z
+                - prepared.horizontal_reaches.w)
+                * side_velocities.bottom,
+            left: (quad.bounds.size.y - prepared.vertical_reaches.w - prepared.vertical_reaches.x)
+                * side_velocities.left,
+        };
+        let corner_velocities = corner_dash_velocities(side_velocities);
+        let top_left_length = corner_lengths.x * corner_velocities.top_left;
+        let top_right_length = corner_lengths.y * corner_velocities.top_right;
+        let bottom_right_length = corner_lengths.z * corner_velocities.bottom_right;
+        let bottom_left_length = corner_lengths.w * corner_velocities.bottom_left;
+        let right_start = side_lengths.top + top_right_length;
+        let bottom_right_start = right_start + side_lengths.right;
+        let bottom_left_start = bottom_right_start + bottom_right_length + side_lengths.bottom;
+        let left_start = bottom_left_start + bottom_left_length;
+        let top_left_start = left_start + side_lengths.left;
+
+        RoundedDashLayout {
+            side_velocities,
+            corner_velocities,
+            right_start,
+            bottom_right_start,
+            bottom_left_start,
+            left_start,
+            top_left_start,
+            perimeter: top_left_start + top_left_length,
+        }
+    }
+
+    pub fn smoothed_dashed_border_alpha(
+        quad: Quad,
+        geometry: QuadGeometry,
+        rectangle_sample: FigmaRectangleSample,
+        prepared: PreparedCorners,
+        corner_lengths: Vec4f,
+        border: Vec2f,
+        straight_border_inner_corner_to_point: Vec2f,
+    ) -> f32 {
+        let dash_layout = smoothed_dash_layout(quad, prepared, corner_lengths);
+        let mut dash_position = 0.0;
+        let mut dash_velocity = 0.0;
+
+        if rectangle_sample.corner != FIGMA_NO_CORNER
+            && rectangle_sample.signed_distance.segment != FIGMA_SEGMENT_STRAIGHT
+        {
+            let corner = rectangle_sample.corner;
+            let mut radius = quad.corner_radii.top_left;
+            let mut horizontal_reach = prepared.horizontal_reaches.x;
+            let mut vertical_reach = prepared.vertical_reaches.x;
+            let mut corner_length = corner_lengths.x;
+
+            match corner {
+                1u32 => {
+                    radius = quad.corner_radii.top_right;
+                    horizontal_reach = prepared.horizontal_reaches.y;
+                    vertical_reach = prepared.vertical_reaches.y;
+                    corner_length = corner_lengths.y;
+                }
+                2u32 => {
+                    radius = quad.corner_radii.bottom_right;
+                    horizontal_reach = prepared.horizontal_reaches.z;
+                    vertical_reach = prepared.vertical_reaches.z;
+                    corner_length = corner_lengths.z;
+                }
+                3u32 => {
+                    radius = quad.corner_radii.bottom_left;
+                    horizontal_reach = prepared.horizontal_reaches.w;
+                    vertical_reach = prepared.vertical_reaches.w;
+                    corner_length = corner_lengths.w;
+                }
+                _ => {}
+            }
+
+            let params = figma_corner_params(
+                radius,
+                horizontal_reach,
+                vertical_reach,
+                prepared.smoothing_factors,
+            );
+            let progress =
+                figma_corner_progress(params, rectangle_sample.signed_distance, corner_length);
+
+            match corner {
+                0u32 => {
+                    dash_velocity = dash_layout.corner_velocities.top_left;
+                    dash_position =
+                        dash_layout.top_left_start + (corner_length - progress) * dash_velocity;
+                }
+                1u32 => {
+                    dash_velocity = dash_layout.corner_velocities.top_right;
+                    dash_position = dash_layout.right_start + progress * dash_velocity;
+                }
+                2u32 => {
+                    dash_velocity = dash_layout.corner_velocities.bottom_right;
+                    dash_position =
+                        dash_layout.bottom_right_start + (corner_length - progress) * dash_velocity;
+                }
+                _ => {
+                    dash_velocity = dash_layout.corner_velocities.bottom_left;
+                    dash_position = dash_layout.bottom_left_start + progress * dash_velocity;
+                }
+            }
+        } else {
+            let mut horizontal =
+                straight_border_inner_corner_to_point.x < straight_border_inner_corner_to_point.y;
+
+            let mut straight_width = select(border.x, border.y, horizontal);
+            if straight_width <= 0.0 {
+                horizontal = !horizontal;
+                straight_width = select(border.x, border.y, horizontal);
+            }
+
+            if horizontal {
+                if geometry.center_to_point.y < 0.0 {
+                    dash_velocity = dash_layout.side_velocities.top;
+                    dash_position =
+                        (geometry.point.x - prepared.horizontal_reaches.x) * dash_velocity;
+                } else {
+                    dash_velocity = dash_layout.side_velocities.bottom;
+                    dash_position = dash_layout.bottom_left_start
+                        - (geometry.point.x - prepared.horizontal_reaches.w) * dash_velocity;
+                }
+            } else if geometry.center_to_point.x < 0.0 {
+                dash_velocity = dash_layout.side_velocities.left;
+                dash_position = dash_layout.top_left_start
+                    - (geometry.point.y - prepared.vertical_reaches.x) * dash_velocity;
+            } else {
+                dash_velocity = dash_layout.side_velocities.right;
+                dash_position = dash_layout.right_start
+                    + (geometry.point.y - prepared.vertical_reaches.y) * dash_velocity;
+            }
+        }
+
+        let dash_period_per_width = DASH_LENGTH_PER_BORDER_WIDTH + DASH_GAP_PER_BORDER_WIDTH;
+        let dash_length = DASH_LENGTH_PER_BORDER_WIDTH / dash_period_per_width;
+
+        if dash_layout.perimeter >= 1.0 {
+            let period = dash_layout.perimeter / floor(dash_layout.perimeter);
+            dash_coverage(dash_position, period, dash_length, dash_velocity)
+        } else {
+            1.0
+        }
+    }
+
     pub fn rounded_dash_position(quad: Quad, geometry: QuadGeometry) -> DashPosition {
         let radii = quad.corner_radii;
         let dash_layout = rounded_dash_layout(quad);
@@ -331,6 +526,21 @@ pub mod quad {
         #[location(5)]
         #[interpolate(flat)]
         pub background_color1: Vec4f,
+        #[location(6)]
+        #[interpolate(flat)]
+        pub horizontal_corner_reaches: Vec4f,
+        #[location(7)]
+        #[interpolate(flat)]
+        pub vertical_corner_reaches: Vec4f,
+        #[location(8)]
+        #[interpolate(flat)]
+        pub corner_lengths: Vec4f,
+        #[location(9)]
+        #[interpolate(flat)]
+        pub smoothing_factors: Vec4f,
+        #[location(10)]
+        #[interpolate(flat)]
+        pub superellipse_power: f32,
     }
 
     #[vertex]
@@ -341,6 +551,13 @@ pub mod quad {
         let quad = get!(QUADS)[instance_id as usize];
         let vertex = rectangle_vertex(vertex_id, quad.bounds);
         let gradient = prepare_background(quad.background);
+        let prepared = prepare_corners(
+            quad.bounds.size,
+            quad.corner_radii,
+            quad.corner_smoothing,
+            quad.border_style == BorderStyle::Solid && Edges::is_zero(quad.border_widths),
+        );
+
         QuadVarying {
             position: vertex.clip_position,
             border_color: hsla_to_rgba(quad.border_color),
@@ -349,6 +566,11 @@ pub mod quad {
             background_solid: gradient.solid,
             background_color0: gradient.color0,
             background_color1: gradient.color1,
+            horizontal_corner_reaches: prepared.horizontal_reaches,
+            vertical_corner_reaches: prepared.vertical_reaches,
+            corner_lengths: smoothed_corner_lengths(quad, prepared),
+            smoothing_factors: prepared.smoothing_factors,
+            superellipse_power: prepared.superellipse_power,
         }
     }
 
@@ -368,6 +590,127 @@ pub mod quad {
                 color1: input.background_color1,
             },
         );
+        let prepared = PreparedCorners {
+            horizontal_reaches: input.horizontal_corner_reaches,
+            vertical_reaches: input.vertical_corner_reaches,
+            smoothing_factors: input.smoothing_factors,
+            superellipse_power: input.superellipse_power,
+        };
+
+        if quad.corner_smoothing > 0.0 {
+            if Edges::is_zero(quad.border_widths) {
+                let distance = prepared_corner_signed_distance(
+                    input.position.xy(),
+                    quad.bounds,
+                    quad.corner_radii,
+                    quad.corner_smoothing,
+                    prepared,
+                );
+
+                return blend_color(background_color, antialiased_coverage(distance));
+            }
+
+            let geometry = quad_geometry(quad, input.position.xy());
+            let rectangle_sample = figma_smooth_rectangle_sample(
+                input.position.xy(),
+                quad.bounds,
+                quad.corner_radii,
+                prepared.horizontal_reaches,
+                prepared.vertical_reaches,
+                prepared.smoothing_factors,
+            );
+            let mut border = vec2f(
+                select(
+                    quad.border_widths.right,
+                    quad.border_widths.left,
+                    geometry.center_to_point.x < 0.0,
+                ),
+                select(
+                    quad.border_widths.bottom,
+                    quad.border_widths.top,
+                    geometry.center_to_point.y < 0.0,
+                ),
+            );
+
+            match rectangle_sample.corner {
+                0u32 => {
+                    border = vec2f(quad.border_widths.left, quad.border_widths.top);
+                }
+                1u32 => {
+                    border = vec2f(quad.border_widths.right, quad.border_widths.top);
+                }
+                2u32 => {
+                    border = vec2f(quad.border_widths.right, quad.border_widths.bottom);
+                }
+                3u32 => {
+                    border = vec2f(quad.border_widths.left, quad.border_widths.bottom);
+                }
+                _ => {}
+            }
+
+            let reduced_border = vec2f(
+                select(border.x, -PIXEL_ANTIALIAS_RADIUS, border.x == 0.0),
+                select(border.y, -PIXEL_ANTIALIAS_RADIUS, border.y == 0.0),
+            );
+            let half_size = Bounds::half_size(quad.bounds);
+            let corner_to_point = abs(geometry.center_to_point) - half_size;
+            let straight_border_inner_corner_to_point = corner_to_point + reduced_border;
+            let near_curve = rectangle_sample.signed_distance.segment != FIGMA_SEGMENT_STRAIGHT;
+
+            if straight_border_inner_corner_to_point.x < -PIXEL_ANTIALIAS_RADIUS
+                && straight_border_inner_corner_to_point.y < -PIXEL_ANTIALIAS_RADIUS
+                && !near_curve
+            {
+                return blend_color(background_color, 1.0);
+            }
+
+            let outer = rectangle_sample.signed_distance.distance;
+            let mut inner = 0.0;
+
+            if near_curve {
+                let normal = abs(rectangle_sample.signed_distance.normal);
+                let active_sides = vec2f(
+                    select(0.0, 1.0, border.x > 0.0),
+                    select(0.0, 1.0, border.y > 0.0),
+                );
+                let effective_width = length(border * normal)
+                    - PIXEL_ANTIALIAS_RADIUS * (1.0 - length(active_sides * normal));
+                inner = -(outer + effective_width);
+            } else {
+                inner = -max(
+                    straight_border_inner_corner_to_point.x,
+                    straight_border_inner_corner_to_point.y,
+                );
+            }
+
+            let mut color = background_color;
+
+            if max(inner, outer) < PIXEL_ANTIALIAS_RADIUS {
+                let mut border_color = input.border_color;
+                if quad.border_style == BorderStyle::Dashed {
+                    border_color.w *= smoothed_dashed_border_alpha(
+                        quad,
+                        geometry,
+                        rectangle_sample,
+                        prepared,
+                        input.corner_lengths,
+                        border,
+                        straight_border_inner_corner_to_point,
+                    );
+                }
+
+                let blended_border = over(background_color, border_color);
+                let factor = antialiased_coverage(inner);
+
+                color = mix(
+                    background_color,
+                    blended_border,
+                    vec4f(factor, factor, factor, factor),
+                );
+            }
+
+            return blend_color(color, antialiased_coverage(outer));
+        }
         if Edges::is_zero(quad.border_widths) && Corners::is_zero(quad.corner_radii) {
             return blend_color(background_color, 1.0);
         }

--- a/crates/gpui_render/src/shaders/shadows.rs
+++ b/crates/gpui_render/src/shaders/shadows.rs
@@ -153,6 +153,28 @@ pub mod shadow {
         coverage
     }
 
+    #[derive(Clone, Copy, Wgsl)]
+    pub struct ShadowVertexData {
+        pub position: Vec4f,
+        pub color: Vec4f,
+        pub shadow_id: u32,
+        pub clip_distances: Vec4f,
+    }
+
+    pub fn prepare_shadow_vertex(
+        vertex_id: u32,
+        instance_id: u32,
+        shadow: Shadow,
+    ) -> ShadowVertexData {
+        let vertex = rectangle_vertex(vertex_id, shadow_geometry(shadow));
+        ShadowVertexData {
+            position: vertex.clip_position,
+            color: hsla_to_rgba(shadow.color),
+            shadow_id: instance_id,
+            clip_distances: clip_distances(vertex.viewport_position, shadow.content_mask),
+        }
+    }
+
     #[derive(Wgsl)]
     pub struct ShadowVarying {
         #[builtin(position)]
@@ -173,13 +195,12 @@ pub mod shadow {
         #[builtin(instance_index)] instance_id: u32,
     ) -> ShadowVarying {
         let shadow = get!(SHADOWS)[instance_id as usize];
-        let geometry = shadow_geometry(shadow);
-        let vertex = rectangle_vertex(vertex_id, geometry);
+        let vertex = prepare_shadow_vertex(vertex_id, instance_id, shadow);
         ShadowVarying {
-            position: vertex.clip_position,
-            color: hsla_to_rgba(shadow.color),
-            shadow_id: instance_id,
-            clip_distances: clip_distances(vertex.viewport_position, shadow.content_mask),
+            position: vertex.position,
+            color: vertex.color,
+            shadow_id: vertex.shadow_id,
+            clip_distances: vertex.clip_distances,
         }
     }
 
@@ -227,8 +248,7 @@ pub mod shadow {
         #[builtin(instance_index)] instance_id: u32,
     ) -> SmoothedShadowVarying {
         let shadow = get!(SHADOWS)[instance_id as usize];
-        let geometry = shadow_geometry(shadow);
-        let vertex = rectangle_vertex(vertex_id, geometry);
+        let vertex = prepare_shadow_vertex(vertex_id, instance_id, shadow);
         let prepared = prepare_corners(
             shadow.bounds.size,
             shadow.corner_radii,
@@ -243,10 +263,10 @@ pub mod shadow {
         );
 
         SmoothedShadowVarying {
-            position: vertex.clip_position,
-            color: hsla_to_rgba(shadow.color),
-            shadow_id: instance_id,
-            clip_distances: clip_distances(vertex.viewport_position, shadow.content_mask),
+            position: vertex.position,
+            color: vertex.color,
+            shadow_id: vertex.shadow_id,
+            clip_distances: vertex.clip_distances,
             horizontal_corner_reaches: prepared.horizontal_reaches,
             vertical_corner_reaches: prepared.vertical_reaches,
             element_horizontal_corner_reaches: prepared_element.horizontal_reaches,

--- a/crates/gpui_render/src/shaders/shadows.rs
+++ b/crates/gpui_render/src/shaders/shadows.rs
@@ -222,7 +222,7 @@ pub mod shadow {
             return transparent();
         }
         let shadow = get!(SHADOWS)[input.shadow_id as usize];
-        let mut coverage = shadow_coverage(shadow, input.position.xy());
+        let mut coverage = 0.0;
         if shadow.corner_smoothing > 0.0 {
             coverage = smoothed_shadow_coverage(
                 shadow,
@@ -240,6 +240,8 @@ pub mod shadow {
                     superellipse_power: 0.0,
                 },
             );
+        } else {
+            coverage = shadow_coverage(shadow, input.position.xy());
         }
         blend_color(input.color, coverage)
     }

--- a/crates/gpui_render/src/shaders/shadows.rs
+++ b/crates/gpui_render/src/shaders/shadows.rs
@@ -165,6 +165,45 @@ pub mod shadow {
         pub shadow_id: u32,
         #[location(3)]
         pub clip_distances: Vec4f,
+    }
+
+    #[vertex]
+    pub fn vertex_shadow(
+        #[builtin(vertex_index)] vertex_id: u32,
+        #[builtin(instance_index)] instance_id: u32,
+    ) -> ShadowVarying {
+        let shadow = get!(SHADOWS)[instance_id as usize];
+        let geometry = shadow_geometry(shadow);
+        let vertex = rectangle_vertex(vertex_id, geometry);
+        ShadowVarying {
+            position: vertex.clip_position,
+            color: hsla_to_rgba(shadow.color),
+            shadow_id: instance_id,
+            clip_distances: clip_distances(vertex.viewport_position, shadow.content_mask),
+        }
+    }
+
+    #[fragment]
+    pub fn fragment_shadow(input: ShadowVarying) -> Vec4f {
+        if is_clipped(input.clip_distances) {
+            return transparent();
+        }
+        let shadow = get!(SHADOWS)[input.shadow_id as usize];
+        blend_color(input.color, shadow_coverage(shadow, input.position.xy()))
+    }
+
+    #[derive(Wgsl)]
+    pub struct SmoothedShadowVarying {
+        #[builtin(position)]
+        pub position: Vec4f,
+        #[location(0)]
+        #[interpolate(flat)]
+        pub color: Vec4f,
+        #[location(1)]
+        #[interpolate(flat)]
+        pub shadow_id: u32,
+        #[location(3)]
+        pub clip_distances: Vec4f,
         #[location(4)]
         #[interpolate(flat)]
         pub horizontal_corner_reaches: Vec4f,
@@ -183,10 +222,10 @@ pub mod shadow {
     }
 
     #[vertex]
-    pub fn vertex_shadow(
+    pub fn vertex_smoothed_shadow(
         #[builtin(vertex_index)] vertex_id: u32,
         #[builtin(instance_index)] instance_id: u32,
-    ) -> ShadowVarying {
+    ) -> SmoothedShadowVarying {
         let shadow = get!(SHADOWS)[instance_id as usize];
         let geometry = shadow_geometry(shadow);
         let vertex = rectangle_vertex(vertex_id, geometry);
@@ -203,7 +242,7 @@ pub mod shadow {
             false,
         );
 
-        ShadowVarying {
+        SmoothedShadowVarying {
             position: vertex.clip_position,
             color: hsla_to_rgba(shadow.color),
             shadow_id: instance_id,
@@ -217,32 +256,27 @@ pub mod shadow {
     }
 
     #[fragment]
-    pub fn fragment_shadow(input: ShadowVarying) -> Vec4f {
+    pub fn fragment_smoothed_shadow(input: SmoothedShadowVarying) -> Vec4f {
         if is_clipped(input.clip_distances) {
             return transparent();
         }
         let shadow = get!(SHADOWS)[input.shadow_id as usize];
-        let mut coverage = 0.0;
-        if shadow.corner_smoothing > 0.0 {
-            coverage = smoothed_shadow_coverage(
-                shadow,
-                input.position.xy(),
-                PreparedCorners {
-                    horizontal_reaches: input.horizontal_corner_reaches,
-                    vertical_reaches: input.vertical_corner_reaches,
-                    smoothing_factors: input.smoothing_factors,
-                    superellipse_power: 0.0,
-                },
-                PreparedCorners {
-                    horizontal_reaches: input.element_horizontal_corner_reaches,
-                    vertical_reaches: input.element_vertical_corner_reaches,
-                    smoothing_factors: input.smoothing_factors,
-                    superellipse_power: 0.0,
-                },
-            );
-        } else {
-            coverage = shadow_coverage(shadow, input.position.xy());
-        }
+        let coverage = smoothed_shadow_coverage(
+            shadow,
+            input.position.xy(),
+            PreparedCorners {
+                horizontal_reaches: input.horizontal_corner_reaches,
+                vertical_reaches: input.vertical_corner_reaches,
+                smoothing_factors: input.smoothing_factors,
+                superellipse_power: 0.0,
+            },
+            PreparedCorners {
+                horizontal_reaches: input.element_horizontal_corner_reaches,
+                vertical_reaches: input.element_vertical_corner_reaches,
+                smoothing_factors: input.smoothing_factors,
+                superellipse_power: 0.0,
+            },
+        );
         blend_color(input.color, coverage)
     }
 }

--- a/crates/gpui_render/src/shaders/shadows.rs
+++ b/crates/gpui_render/src/shaders/shadows.rs
@@ -1,6 +1,7 @@
 #[wgsl_rs::wgsl]
 pub mod shadow {
     use super::super::common::*;
+    use super::super::corner_smoothing::*;
     use wgsl_rs::std::*;
 
     #[derive(Clone, Copy, Wgsl)]
@@ -14,7 +15,7 @@ pub mod shadow {
         pub element_bounds: Bounds,
         pub element_corner_radii: Corners,
         pub inset: ShaderBool,
-        pub padding: u32,
+        pub corner_smoothing: f32,
     }
     storage!(group(1), binding(0), SHADOWS: RuntimeArray<Shadow>);
 
@@ -85,6 +86,73 @@ pub mod shadow {
         coverage
     }
 
+    pub fn smoothed_shadow_coverage(
+        shadow: Shadow,
+        position: Vec2f,
+        prepared: PreparedCorners,
+        prepared_element: PreparedCorners,
+    ) -> f32 {
+        let mut coverage = 0.0;
+
+        if shadow.blur_radius == 0.0 {
+            coverage = antialiased_coverage(prepared_corner_signed_distance(
+                position,
+                shadow.bounds,
+                shadow.corner_radii,
+                shadow.corner_smoothing,
+                prepared,
+            ));
+        } else if !Corners::is_zero(shadow.corner_radii) {
+            let blur_limit = GAUSSIAN_CUTOFF_STANDARD_DEVIATIONS * shadow.blur_radius;
+            let half_size = Bounds::half_size(shadow.bounds);
+            let center_to_point = position - Bounds::center(shadow.bounds);
+            let box_delta = abs(center_to_point) - half_size;
+            let outside_delta = max(box_delta, vec2f(0.0, 0.0));
+
+            if dot(outside_delta, outside_delta) <= blur_limit * blur_limit {
+                let local_point = position - shadow.bounds.origin;
+                let edge_depth = min(
+                    min(local_point.x, shadow.bounds.size.x - local_point.x),
+                    min(local_point.y, shadow.bounds.size.y - local_point.y),
+                );
+                let corner_candidate = figma_has_corner_candidate(
+                    local_point,
+                    shadow.bounds.size,
+                    prepared.horizontal_reaches,
+                    prepared.vertical_reaches,
+                );
+
+                if !corner_candidate && edge_depth >= blur_limit {
+                    coverage = 1.0;
+                } else {
+                    let distance = prepared_corner_signed_distance(
+                        position,
+                        shadow.bounds,
+                        shadow.corner_radii,
+                        shadow.corner_smoothing,
+                        prepared,
+                    );
+                    coverage = gaussian_signed_distance_coverage(distance, shadow.blur_radius);
+                }
+            }
+        } else {
+            coverage = blurred_shadow_coverage(shadow, position);
+        }
+
+        if is_enabled(shadow.inset) {
+            coverage = (1.0 - coverage)
+                * antialiased_coverage(prepared_corner_signed_distance(
+                    position,
+                    shadow.element_bounds,
+                    shadow.element_corner_radii,
+                    shadow.corner_smoothing,
+                    prepared_element,
+                ));
+        }
+
+        coverage
+    }
+
     #[derive(Wgsl)]
     pub struct ShadowVarying {
         #[builtin(position)]
@@ -97,6 +165,21 @@ pub mod shadow {
         pub shadow_id: u32,
         #[location(3)]
         pub clip_distances: Vec4f,
+        #[location(4)]
+        #[interpolate(flat)]
+        pub horizontal_corner_reaches: Vec4f,
+        #[location(5)]
+        #[interpolate(flat)]
+        pub vertical_corner_reaches: Vec4f,
+        #[location(6)]
+        #[interpolate(flat)]
+        pub element_horizontal_corner_reaches: Vec4f,
+        #[location(7)]
+        #[interpolate(flat)]
+        pub element_vertical_corner_reaches: Vec4f,
+        #[location(8)]
+        #[interpolate(flat)]
+        pub smoothing_factors: Vec4f,
     }
 
     #[vertex]
@@ -107,11 +190,29 @@ pub mod shadow {
         let shadow = get!(SHADOWS)[instance_id as usize];
         let geometry = shadow_geometry(shadow);
         let vertex = rectangle_vertex(vertex_id, geometry);
+        let prepared = prepare_corners(
+            shadow.bounds.size,
+            shadow.corner_radii,
+            shadow.corner_smoothing,
+            false,
+        );
+        let prepared_element = prepare_corners(
+            shadow.element_bounds.size,
+            shadow.element_corner_radii,
+            shadow.corner_smoothing,
+            false,
+        );
+
         ShadowVarying {
             position: vertex.clip_position,
             color: hsla_to_rgba(shadow.color),
             shadow_id: instance_id,
             clip_distances: clip_distances(vertex.viewport_position, shadow.content_mask),
+            horizontal_corner_reaches: prepared.horizontal_reaches,
+            vertical_corner_reaches: prepared.vertical_reaches,
+            element_horizontal_corner_reaches: prepared_element.horizontal_reaches,
+            element_vertical_corner_reaches: prepared_element.vertical_reaches,
+            smoothing_factors: prepared.smoothing_factors,
         }
     }
 
@@ -121,6 +222,25 @@ pub mod shadow {
             return transparent();
         }
         let shadow = get!(SHADOWS)[input.shadow_id as usize];
-        blend_color(input.color, shadow_coverage(shadow, input.position.xy()))
+        let mut coverage = shadow_coverage(shadow, input.position.xy());
+        if shadow.corner_smoothing > 0.0 {
+            coverage = smoothed_shadow_coverage(
+                shadow,
+                input.position.xy(),
+                PreparedCorners {
+                    horizontal_reaches: input.horizontal_corner_reaches,
+                    vertical_reaches: input.vertical_corner_reaches,
+                    smoothing_factors: input.smoothing_factors,
+                    superellipse_power: 0.0,
+                },
+                PreparedCorners {
+                    horizontal_reaches: input.element_horizontal_corner_reaches,
+                    vertical_reaches: input.element_vertical_corner_reaches,
+                    smoothing_factors: input.smoothing_factors,
+                    superellipse_power: 0.0,
+                },
+            );
+        }
+        blend_color(input.color, coverage)
     }
 }

--- a/crates/gpui_render/src/shaders/sprites.rs
+++ b/crates/gpui_render/src/shaders/sprites.rs
@@ -179,6 +179,67 @@ pub mod polychrome_sprite {
         #[location(1)]
         #[interpolate(flat)]
         pub sprite_id: u32,
+        #[location(3)]
+        pub clip_distances: Vec4f,
+    }
+
+    #[vertex]
+    pub fn vertex_polychrome_sprite(
+        #[builtin(vertex_index)] vertex_id: u32,
+        #[builtin(instance_index)] instance_id: u32,
+    ) -> PolychromeSpriteVarying {
+        let sprite = get!(POLYCHROME_SPRITES)[instance_id as usize];
+        let vertex = rectangle_vertex(vertex_id, sprite.bounds);
+        PolychromeSpriteVarying {
+            position: vertex.clip_position,
+            tile_position: atlas_texture_coordinates(
+                vertex.unit_position,
+                sprite.tile,
+                texture_dimensions(POLYCHROME_TEXTURE),
+            ),
+            sprite_id: instance_id,
+            clip_distances: clip_distances(vertex.viewport_position, sprite.content_mask),
+        }
+    }
+
+    #[fragment]
+    pub fn fragment_polychrome_sprite(input: PolychromeSpriteVarying) -> Vec4f {
+        if is_clipped(input.clip_distances) {
+            return transparent();
+        }
+        let sprite = get!(POLYCHROME_SPRITES)[input.sprite_id as usize];
+        let sample = texture_sample_level(
+            POLYCHROME_TEXTURE,
+            POLYCHROME_SAMPLER,
+            input.tile_position,
+            0.0,
+        );
+        let grayscale = dot(sample.rgb(), LINEAR_RGB_LUMA_WEIGHTS);
+        let color = select(
+            sample,
+            vec4f(grayscale, grayscale, grayscale, sample.w),
+            is_enabled(sprite.grayscale),
+        );
+        blend_color(
+            color,
+            sprite.opacity
+                * antialiased_coverage(rounded_rectangle_signed_distance(
+                    input.position.xy(),
+                    sprite.bounds,
+                    sprite.corner_radii,
+                )),
+        )
+    }
+
+    #[derive(Wgsl)]
+    pub struct SmoothedPolychromeSpriteVarying {
+        #[builtin(position)]
+        pub position: Vec4f,
+        #[location(0)]
+        pub tile_position: Vec2f,
+        #[location(1)]
+        #[interpolate(flat)]
+        pub sprite_id: u32,
         #[location(2)]
         #[interpolate(flat)]
         pub horizontal_corner_reaches: Vec4f,
@@ -196,10 +257,10 @@ pub mod polychrome_sprite {
     }
 
     #[vertex]
-    pub fn vertex_polychrome_sprite(
+    pub fn vertex_smoothed_polychrome_sprite(
         #[builtin(vertex_index)] vertex_id: u32,
         #[builtin(instance_index)] instance_id: u32,
-    ) -> PolychromeSpriteVarying {
+    ) -> SmoothedPolychromeSpriteVarying {
         let sprite = get!(POLYCHROME_SPRITES)[instance_id as usize];
         let vertex = rectangle_vertex(vertex_id, sprite.bounds);
         let prepared = prepare_corners(
@@ -209,7 +270,7 @@ pub mod polychrome_sprite {
             true,
         );
 
-        PolychromeSpriteVarying {
+        SmoothedPolychromeSpriteVarying {
             position: vertex.clip_position,
             tile_position: atlas_texture_coordinates(
                 vertex.unit_position,
@@ -226,7 +287,7 @@ pub mod polychrome_sprite {
     }
 
     #[fragment]
-    pub fn fragment_polychrome_sprite(input: PolychromeSpriteVarying) -> Vec4f {
+    pub fn fragment_smoothed_polychrome_sprite(input: SmoothedPolychromeSpriteVarying) -> Vec4f {
         if is_clipped(input.clip_distances) {
             return transparent();
         }

--- a/crates/gpui_render/src/shaders/sprites.rs
+++ b/crates/gpui_render/src/shaders/sprites.rs
@@ -170,6 +170,43 @@ pub mod polychrome_sprite {
     texture!(group(1), binding(1), POLYCHROME_TEXTURE: Texture2D<f32>);
     sampler!(group(1), binding(2), POLYCHROME_SAMPLER: Sampler);
 
+    #[derive(Clone, Copy, Wgsl)]
+    pub struct PolychromeVertexData {
+        pub position: Vec4f,
+        pub tile_position: Vec2f,
+        pub sprite_id: u32,
+        pub clip_distances: Vec4f,
+    }
+
+    pub fn prepare_polychrome_vertex(
+        vertex_id: u32,
+        instance_id: u32,
+        sprite: PolychromeSprite,
+    ) -> PolychromeVertexData {
+        let vertex = rectangle_vertex(vertex_id, sprite.bounds);
+        PolychromeVertexData {
+            position: vertex.clip_position,
+            tile_position: atlas_texture_coordinates(
+                vertex.unit_position,
+                sprite.tile,
+                texture_dimensions(POLYCHROME_TEXTURE),
+            ),
+            sprite_id: instance_id,
+            clip_distances: clip_distances(vertex.viewport_position, sprite.content_mask),
+        }
+    }
+
+    pub fn polychrome_color(sprite: PolychromeSprite, tile_position: Vec2f) -> Vec4f {
+        let sample =
+            texture_sample_level(POLYCHROME_TEXTURE, POLYCHROME_SAMPLER, tile_position, 0.0);
+        let grayscale = dot(sample.rgb(), LINEAR_RGB_LUMA_WEIGHTS);
+        select(
+            sample,
+            vec4f(grayscale, grayscale, grayscale, sample.w),
+            is_enabled(sprite.grayscale),
+        )
+    }
+
     #[derive(Wgsl)]
     pub struct PolychromeSpriteVarying {
         #[builtin(position)]
@@ -189,16 +226,12 @@ pub mod polychrome_sprite {
         #[builtin(instance_index)] instance_id: u32,
     ) -> PolychromeSpriteVarying {
         let sprite = get!(POLYCHROME_SPRITES)[instance_id as usize];
-        let vertex = rectangle_vertex(vertex_id, sprite.bounds);
+        let vertex = prepare_polychrome_vertex(vertex_id, instance_id, sprite);
         PolychromeSpriteVarying {
-            position: vertex.clip_position,
-            tile_position: atlas_texture_coordinates(
-                vertex.unit_position,
-                sprite.tile,
-                texture_dimensions(POLYCHROME_TEXTURE),
-            ),
-            sprite_id: instance_id,
-            clip_distances: clip_distances(vertex.viewport_position, sprite.content_mask),
+            position: vertex.position,
+            tile_position: vertex.tile_position,
+            sprite_id: vertex.sprite_id,
+            clip_distances: vertex.clip_distances,
         }
     }
 
@@ -208,18 +241,7 @@ pub mod polychrome_sprite {
             return transparent();
         }
         let sprite = get!(POLYCHROME_SPRITES)[input.sprite_id as usize];
-        let sample = texture_sample_level(
-            POLYCHROME_TEXTURE,
-            POLYCHROME_SAMPLER,
-            input.tile_position,
-            0.0,
-        );
-        let grayscale = dot(sample.rgb(), LINEAR_RGB_LUMA_WEIGHTS);
-        let color = select(
-            sample,
-            vec4f(grayscale, grayscale, grayscale, sample.w),
-            is_enabled(sprite.grayscale),
-        );
+        let color = polychrome_color(sprite, input.tile_position);
         blend_color(
             color,
             sprite.opacity
@@ -262,7 +284,7 @@ pub mod polychrome_sprite {
         #[builtin(instance_index)] instance_id: u32,
     ) -> SmoothedPolychromeSpriteVarying {
         let sprite = get!(POLYCHROME_SPRITES)[instance_id as usize];
-        let vertex = rectangle_vertex(vertex_id, sprite.bounds);
+        let vertex = prepare_polychrome_vertex(vertex_id, instance_id, sprite);
         let prepared = prepare_corners(
             sprite.bounds.size,
             sprite.corner_radii,
@@ -271,15 +293,11 @@ pub mod polychrome_sprite {
         );
 
         SmoothedPolychromeSpriteVarying {
-            position: vertex.clip_position,
-            tile_position: atlas_texture_coordinates(
-                vertex.unit_position,
-                sprite.tile,
-                texture_dimensions(POLYCHROME_TEXTURE),
-            ),
-            sprite_id: instance_id,
+            position: vertex.position,
+            tile_position: vertex.tile_position,
+            sprite_id: vertex.sprite_id,
             horizontal_corner_reaches: prepared.horizontal_reaches,
-            clip_distances: clip_distances(vertex.viewport_position, sprite.content_mask),
+            clip_distances: vertex.clip_distances,
             vertical_corner_reaches: prepared.vertical_reaches,
             smoothing_factors: prepared.smoothing_factors,
             superellipse_power: prepared.superellipse_power,
@@ -292,18 +310,7 @@ pub mod polychrome_sprite {
             return transparent();
         }
         let sprite = get!(POLYCHROME_SPRITES)[input.sprite_id as usize];
-        let sample = texture_sample_level(
-            POLYCHROME_TEXTURE,
-            POLYCHROME_SAMPLER,
-            input.tile_position,
-            0.0,
-        );
-        let grayscale = dot(sample.rgb(), LINEAR_RGB_LUMA_WEIGHTS);
-        let color = select(
-            sample,
-            vec4f(grayscale, grayscale, grayscale, sample.w),
-            is_enabled(sprite.grayscale),
-        );
+        let color = polychrome_color(sprite, input.tile_position);
         blend_color(
             color,
             sprite.opacity

--- a/crates/gpui_render/src/shaders/sprites.rs
+++ b/crates/gpui_render/src/shaders/sprites.rs
@@ -152,14 +152,15 @@ pub mod monochrome_sprite {
 #[wgsl_rs::wgsl]
 pub mod polychrome_sprite {
     use super::super::common::*;
+    use super::super::corner_smoothing::*;
     use wgsl_rs::std::*;
 
     #[derive(Clone, Copy, Wgsl)]
     pub struct PolychromeSprite {
         pub order: u32,
-        pub padding: u32,
         pub grayscale: ShaderBool,
         pub opacity: f32,
+        pub corner_smoothing: f32,
         pub bounds: Bounds,
         pub content_mask: Bounds,
         pub corner_radii: Corners,
@@ -178,8 +179,20 @@ pub mod polychrome_sprite {
         #[location(1)]
         #[interpolate(flat)]
         pub sprite_id: u32,
+        #[location(2)]
+        #[interpolate(flat)]
+        pub horizontal_corner_reaches: Vec4f,
         #[location(3)]
         pub clip_distances: Vec4f,
+        #[location(4)]
+        #[interpolate(flat)]
+        pub vertical_corner_reaches: Vec4f,
+        #[location(5)]
+        #[interpolate(flat)]
+        pub smoothing_factors: Vec4f,
+        #[location(6)]
+        #[interpolate(flat)]
+        pub superellipse_power: f32,
     }
 
     #[vertex]
@@ -189,6 +202,13 @@ pub mod polychrome_sprite {
     ) -> PolychromeSpriteVarying {
         let sprite = get!(POLYCHROME_SPRITES)[instance_id as usize];
         let vertex = rectangle_vertex(vertex_id, sprite.bounds);
+        let prepared = prepare_corners(
+            sprite.bounds.size,
+            sprite.corner_radii,
+            sprite.corner_smoothing,
+            true,
+        );
+
         PolychromeSpriteVarying {
             position: vertex.clip_position,
             tile_position: atlas_texture_coordinates(
@@ -197,7 +217,11 @@ pub mod polychrome_sprite {
                 texture_dimensions(POLYCHROME_TEXTURE),
             ),
             sprite_id: instance_id,
+            horizontal_corner_reaches: prepared.horizontal_reaches,
             clip_distances: clip_distances(vertex.viewport_position, sprite.content_mask),
+            vertical_corner_reaches: prepared.vertical_reaches,
+            smoothing_factors: prepared.smoothing_factors,
+            superellipse_power: prepared.superellipse_power,
         }
     }
 
@@ -222,10 +246,17 @@ pub mod polychrome_sprite {
         blend_color(
             color,
             sprite.opacity
-                * antialiased_coverage(rounded_rectangle_signed_distance(
+                * antialiased_coverage(prepared_corner_signed_distance(
                     input.position.xy(),
                     sprite.bounds,
                     sprite.corner_radii,
+                    sprite.corner_smoothing,
+                    PreparedCorners {
+                        horizontal_reaches: input.horizontal_corner_reaches,
+                        vertical_reaches: input.vertical_corner_reaches,
+                        smoothing_factors: input.smoothing_factors,
+                        superellipse_power: input.superellipse_power,
+                    },
                 )),
         )
     }

--- a/crates/gpui_render/src/shaders/tests.rs
+++ b/crates/gpui_render/src/shaders/tests.rs
@@ -1,29 +1,5 @@
 use super::*;
 
-fn braced_declaration<'a>(source: &'a str, declaration: &str) -> &'a str {
-    let start = source
-        .find(declaration)
-        .unwrap_or_else(|| panic!("missing shader declaration {declaration}"));
-    let body_start = source[start..]
-        .find('{')
-        .map(|offset| start + offset)
-        .unwrap_or_else(|| panic!("shader declaration {declaration} has no body"));
-    let mut depth = 0_u32;
-    for (offset, character) in source[body_start..].char_indices() {
-        match character {
-            '{' => depth += 1,
-            '}' => {
-                depth -= 1;
-                if depth == 0 {
-                    return &source[start..body_start + offset + 1];
-                }
-            }
-            _ => {}
-        }
-    }
-    panic!("shader declaration {declaration} has an unterminated body")
-}
-
 #[test]
 fn validates_subpixel_shader() {
     let generated = subpixel_sprite::WGSL_SOURCE.wgsl_source().unwrap();
@@ -79,51 +55,66 @@ fn shader_interface_matches_generated_sources() {
     assert_eq!(quad::QUADS.binding(), interface::DATA_BUFFER_BINDING);
 }
 
-#[test]
-fn ordinary_entry_points_keep_compact_corner_geometry() {
-    let source = base::WGSL_SOURCE.wgsl_source().unwrap();
-    for entry in [
-        "fn vertex_quad(",
-        "fn fragment_quad(",
-        "fn vertex_shadow(",
-        "fn fragment_shadow(",
-        "fn vertex_polychrome_sprite(",
-        "fn fragment_polychrome_sprite(",
-        "fn vertex_blur_composite(",
-        "fn fragment_blur_composite(",
-    ] {
-        let declaration = braced_declaration(&source, entry);
-        for expanded_operation in [
-            "prepare_corners",
-            "prepared_corner_signed_distance",
-            "figma_smooth_rectangle_sample",
-            "corner_smoothing",
-        ] {
-            assert!(
-                !declaration.contains(expanded_operation),
-                "ordinary shader {entry} contains {expanded_operation}"
-            );
-        }
-    }
+fn vertex_output_shape(module: &naga::Module, entry_name: &str) -> (usize, u32) {
+    let entry = module
+        .entry_points
+        .iter()
+        .find(|entry| entry.name == entry_name)
+        .unwrap_or_else(|| panic!("missing shader entry point {entry_name}"));
+    let result = entry
+        .function
+        .result
+        .as_ref()
+        .unwrap_or_else(|| panic!("shader entry point {entry_name} has no output"));
+    let naga::TypeInner::Struct { members, .. } = &module.types[result.ty].inner else {
+        panic!("shader entry point {entry_name} must return a struct");
+    };
 
-    for varying in [
-        "struct QuadVarying",
-        "struct ShadowVarying",
-        "struct PolychromeSpriteVarying",
-        "struct BlurVarying",
+    members
+        .iter()
+        .filter(|member| matches!(member.binding, Some(naga::Binding::Location { .. })))
+        .fold((0, 0), |(locations, components), member| {
+            let member_components = match module.types[member.ty].inner {
+                naga::TypeInner::Scalar(_) => 1,
+                naga::TypeInner::Vector { size, .. } => u32::from(size),
+                ref ty => panic!("unsupported stage output type {ty:?} in {entry_name}"),
+            };
+            (locations + 1, components + member_components)
+        })
+}
+
+#[test]
+fn ordinary_vertex_interfaces_stay_within_compact_budgets() {
+    let module = naga::front::wgsl::parse_str(&base::WGSL_SOURCE.wgsl_source().unwrap()).unwrap();
+    for (entry, maximum_shape) in [
+        ("vertex_quad", (6, 21)),
+        ("vertex_shadow", (3, 9)),
+        ("vertex_polychrome_sprite", (3, 7)),
+        ("vertex_blur_composite", (2, 6)),
     ] {
-        let declaration = braced_declaration(&source, varying);
-        for expanded_varying in [
-            "horizontal_corner_reaches",
-            "vertical_corner_reaches",
-            "smoothing_factors",
-            "superellipse_power",
-        ] {
-            assert!(
-                !declaration.contains(expanded_varying),
-                "ordinary shader {varying} contains {expanded_varying}"
-            );
-        }
+        let actual_shape = vertex_output_shape(&module, entry);
+        assert!(
+            actual_shape.0 <= maximum_shape.0 && actual_shape.1 <= maximum_shape.1,
+            "{entry} uses {actual_shape:?}, exceeding {maximum_shape:?} (locations, components)"
+        );
+    }
+}
+
+#[test]
+fn scene_instance_storage_sizes_are_bounded() {
+    for (name, actual, maximum) in [
+        ("Quad", std::mem::size_of::<gpui::Quad>(), 168),
+        ("Shadow", std::mem::size_of::<gpui::Shadow>(), 112),
+        (
+            "PolychromeSprite",
+            std::mem::size_of::<gpui::PolychromeSprite>(),
+            96,
+        ),
+    ] {
+        assert!(
+            actual <= maximum,
+            "{name} is {actual} bytes, exceeding its {maximum}-byte storage budget"
+        );
     }
 }
 

--- a/crates/gpui_render/src/shaders/tests.rs
+++ b/crates/gpui_render/src/shaders/tests.rs
@@ -1,5 +1,29 @@
 use super::*;
 
+fn braced_declaration<'a>(source: &'a str, declaration: &str) -> &'a str {
+    let start = source
+        .find(declaration)
+        .unwrap_or_else(|| panic!("missing shader declaration {declaration}"));
+    let body_start = source[start..]
+        .find('{')
+        .map(|offset| start + offset)
+        .unwrap_or_else(|| panic!("shader declaration {declaration} has no body"));
+    let mut depth = 0_u32;
+    for (offset, character) in source[body_start..].char_indices() {
+        match character {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return &source[start..body_start + offset + 1];
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!("shader declaration {declaration} has an unterminated body")
+}
+
 #[test]
 fn validates_subpixel_shader() {
     let generated = subpixel_sprite::WGSL_SOURCE.wgsl_source().unwrap();
@@ -53,6 +77,54 @@ fn shader_interface_matches_generated_sources() {
     );
     assert_eq!(quad::QUADS.group(), interface::DATA_BIND_GROUP);
     assert_eq!(quad::QUADS.binding(), interface::DATA_BUFFER_BINDING);
+}
+
+#[test]
+fn ordinary_entry_points_keep_compact_corner_geometry() {
+    let source = base::WGSL_SOURCE.wgsl_source().unwrap();
+    for entry in [
+        "fn vertex_quad(",
+        "fn fragment_quad(",
+        "fn vertex_shadow(",
+        "fn fragment_shadow(",
+        "fn vertex_polychrome_sprite(",
+        "fn fragment_polychrome_sprite(",
+        "fn vertex_blur_composite(",
+        "fn fragment_blur_composite(",
+    ] {
+        let declaration = braced_declaration(&source, entry);
+        for expanded_operation in [
+            "prepare_corners",
+            "prepared_corner_signed_distance",
+            "figma_smooth_rectangle_sample",
+            "corner_smoothing",
+        ] {
+            assert!(
+                !declaration.contains(expanded_operation),
+                "ordinary shader {entry} contains {expanded_operation}"
+            );
+        }
+    }
+
+    for varying in [
+        "struct QuadVarying",
+        "struct ShadowVarying",
+        "struct PolychromeSpriteVarying",
+        "struct BlurVarying",
+    ] {
+        let declaration = braced_declaration(&source, varying);
+        for expanded_varying in [
+            "horizontal_corner_reaches",
+            "vertical_corner_reaches",
+            "smoothing_factors",
+            "superellipse_power",
+        ] {
+            assert!(
+                !declaration.contains(expanded_varying),
+                "ordinary shader {varying} contains {expanded_varying}"
+            );
+        }
+    }
 }
 
 #[test]

--- a/crates/gpui_wgpu/benches/renderer.rs
+++ b/crates/gpui_wgpu/benches/renderer.rs
@@ -19,8 +19,18 @@ fn quad_scene(count: usize) -> Scene {
 fn smoothed_quad_scene(count: usize, corner_radii: Corners<ScaledPixels>) -> Scene {
     let mut scene = unplanned_quad_scene(count);
     for quad in &mut scene.quads {
-        quad.corner_radii = corner_radii.clone();
+        quad.corner_radii = corner_radii;
         quad.corner_smoothing = 1.0;
+    }
+    scene.finish();
+    scene
+}
+
+fn alternating_corner_modes_scene(count: usize) -> Scene {
+    let mut scene = unplanned_quad_scene(count);
+    for (index, quad) in scene.quads.iter_mut().enumerate() {
+        quad.corner_radii = Corners::all(ScaledPixels(8.0));
+        quad.corner_smoothing = if index % 2 == 0 { 0.0 } else { 1.0 };
     }
     scene.finish();
     scene
@@ -99,6 +109,7 @@ fn bench_renderer(c: &mut Criterion) {
             bottom_left: ScaledPixels(0.0),
         },
     );
+    let alternating_corner_modes = alternating_corner_modes_scene(512);
     let mut mixed_batches = unplanned_mixed_scene(512);
     mixed_batches.finish();
 
@@ -143,6 +154,13 @@ fn bench_renderer(c: &mut Criterion) {
             renderer
                 .render_scene_and_wait(&reach_aware_smoothed_quads, TARGET_SIZE)
                 .expect("reach-aware smoothed quad render must succeed")
+        })
+    });
+    group.bench_function("512_alternating_corner_modes_wait", |b| {
+        b.iter(|| {
+            renderer
+                .render_scene_and_wait(&alternating_corner_modes, TARGET_SIZE)
+                .expect("alternating corner modes must render successfully")
         })
     });
     group.bench_function("1024_mixed_batches_wait", |b| {

--- a/crates/gpui_wgpu/benches/renderer.rs
+++ b/crates/gpui_wgpu/benches/renderer.rs
@@ -1,7 +1,7 @@
 use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
 use gpui::{
-    Bounds, ContentMask, DevicePixels, PlatformHeadlessRenderer, Point, Quad, ScaledPixels, Scene,
-    ShaderBool, Size, Underline, solid_background, white,
+    Bounds, ContentMask, Corners, DevicePixels, PlatformHeadlessRenderer, Point, Quad,
+    ScaledPixels, Scene, ShaderBool, Size, Underline, solid_background, white,
 };
 use gpui_ce_wgpu::WgpuHeadlessRenderer;
 
@@ -12,6 +12,16 @@ const TARGET_SIZE: Size<DevicePixels> = Size {
 
 fn quad_scene(count: usize) -> Scene {
     let mut scene = unplanned_quad_scene(count);
+    scene.finish();
+    scene
+}
+
+fn smoothed_quad_scene(count: usize, corner_radii: Corners<ScaledPixels>) -> Scene {
+    let mut scene = unplanned_quad_scene(count);
+    for quad in &mut scene.quads {
+        quad.corner_radii = corner_radii.clone();
+        quad.corner_smoothing = 1.0;
+    }
     scene.finish();
     scene
 }
@@ -79,6 +89,16 @@ fn bench_renderer(c: &mut Criterion) {
     let mut renderer = WgpuHeadlessRenderer::new().expect("headless WGPU renderer must initialize");
     let single_quad = quad_scene(1);
     let dense_quads = quad_scene(512);
+    let compact_smoothed_quads = smoothed_quad_scene(512, Corners::all(ScaledPixels(8.0)));
+    let reach_aware_smoothed_quads = smoothed_quad_scene(
+        512,
+        Corners {
+            top_left: ScaledPixels(14.0),
+            top_right: ScaledPixels(0.0),
+            bottom_right: ScaledPixels(0.0),
+            bottom_left: ScaledPixels(0.0),
+        },
+    );
     let mut mixed_batches = unplanned_mixed_scene(512);
     mixed_batches.finish();
 
@@ -109,6 +129,20 @@ fn bench_renderer(c: &mut Criterion) {
             renderer
                 .render_scene_and_wait(&dense_quads, TARGET_SIZE)
                 .expect("dense quad render must succeed")
+        })
+    });
+    group.bench_function("512_compact_smoothed_quads_wait", |b| {
+        b.iter(|| {
+            renderer
+                .render_scene_and_wait(&compact_smoothed_quads, TARGET_SIZE)
+                .expect("compact smoothed quad render must succeed")
+        })
+    });
+    group.bench_function("512_reach_aware_smoothed_quads_wait", |b| {
+        b.iter(|| {
+            renderer
+                .render_scene_and_wait(&reach_aware_smoothed_quads, TARGET_SIZE)
+                .expect("reach-aware smoothed quad render must succeed")
         })
     });
     group.bench_function("1024_mixed_batches_wait", |b| {

--- a/crates/gpui_wgpu/src/wgpu_renderer/drawing.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/drawing.rs
@@ -16,24 +16,33 @@ impl WgpuRenderer {
     pub(super) fn draw_quads(
         &self,
         quads: &[Quad],
+        smoothed: bool,
         instances: &mut InstanceUpload,
         pass: &mut wgpu::RenderPass<'_>,
     ) -> frame::DrawResult {
-        self.draw_instances(quads, &self.resources().pipelines.quads, instances, pass)
+        let pipelines = &self.resources().pipelines;
+        let pipeline = if smoothed {
+            &pipelines.smoothed_quads
+        } else {
+            &pipelines.quads
+        };
+        self.draw_instances(quads, pipeline, instances, pass)
     }
 
     pub(super) fn draw_shadows(
         &self,
         shadows: &[Shadow],
+        smoothed: bool,
         instances: &mut InstanceUpload,
         pass: &mut wgpu::RenderPass<'_>,
     ) -> frame::DrawResult {
-        self.draw_instances(
-            shadows,
-            &self.resources().pipelines.shadows,
-            instances,
-            pass,
-        )
+        let pipelines = &self.resources().pipelines;
+        let pipeline = if smoothed {
+            &pipelines.smoothed_shadows
+        } else {
+            &pipelines.shadows
+        };
+        self.draw_instances(shadows, pipeline, instances, pass)
     }
 
     pub(super) fn draw_underlines(
@@ -89,18 +98,18 @@ impl WgpuRenderer {
         &self,
         sprites: &[PolychromeSprite],
         texture_id: AtlasTextureId,
+        smoothed: bool,
         instances: &mut InstanceUpload,
         pass: &mut wgpu::RenderPass<'_>,
     ) -> frame::DrawResult {
         let texture = self.atlas.get_texture_info(texture_id);
-        self.draw_instances_with_texture(
-            sprites,
-            texture_id,
-            &texture,
-            &self.resources().pipelines.polychrome_sprites,
-            instances,
-            pass,
-        )
+        let pipelines = &self.resources().pipelines;
+        let pipeline = if smoothed {
+            &pipelines.smoothed_polychrome_sprites
+        } else {
+            &pipelines.polychrome_sprites
+        };
+        self.draw_instances_with_texture(sprites, texture_id, &texture, pipeline, instances, pass)
     }
 
     fn draw_instances<T: BufferData>(

--- a/crates/gpui_wgpu/src/wgpu_renderer/filters.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/filters.rs
@@ -18,7 +18,7 @@ pub(super) struct FrameUniformRequirements {
     pub(super) surface_count: u64,
 }
 
-const _: () = assert!(std::mem::size_of::<BlurUniforms>() == 96);
+const _: () = assert!(std::mem::size_of::<BlurUniforms>() == 112);
 
 impl WgpuRenderer {
     fn make_blur_bind_group(
@@ -140,6 +140,7 @@ impl WgpuRenderer {
             composite_bounds,
             parameters.content_mask,
             parameters.corner_radii,
+            parameters.corner_smoothing,
             parameters.opacity,
             parameters.clip,
             blur_size,
@@ -180,6 +181,7 @@ impl WgpuRenderer {
                 bounds: filter.bounds,
                 content_mask: filter.content_mask.bounds,
                 corner_radii: filter.corner_radii,
+                corner_smoothing: filter.corner_smoothing,
                 blur_radius: filter.max_blur_radius(),
                 opacity: filter.opacity,
                 clip: FilterCompositeClip::RoundedBounds,

--- a/crates/gpui_wgpu/src/wgpu_renderer/filters.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/filters.rs
@@ -148,9 +148,14 @@ impl WgpuRenderer {
         );
         let (bind_group, uniform_offset) = self.make_blur_bind_group(uniforms, &horizontal_target);
         let resources = self.resources();
+        let pipeline = if uniforms.corner_smoothing > 0.0 {
+            &resources.pipelines.smoothed_blur_composite
+        } else {
+            &resources.pipelines.blur_composite
+        };
         let mut pass =
             begin_color_render_pass(encoder, "blur_composite", target, wgpu::LoadOp::Load);
-        pass.set_pipeline(&resources.pipelines.blur_composite);
+        pass.set_pipeline(pipeline);
         pass.set_bind_group(
             shader_interface::GLOBAL_BIND_GROUP,
             &resources.globals_bind_group,
@@ -161,10 +166,7 @@ impl WgpuRenderer {
             &bind_group,
             &[uniform_offset],
         );
-        pass.draw(
-            0..resources.pipelines.blur_composite.fixed_vertex_count(),
-            0..1,
-        );
+        pass.draw(0..pipeline.fixed_vertex_count(), 0..1);
     }
 
     pub(super) fn draw_backdrop_filter(

--- a/crates/gpui_wgpu/src/wgpu_renderer/frame.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/frame.rs
@@ -260,10 +260,12 @@ impl FrameRequirements {
                 continue;
             };
             match batch {
-                PrimitiveBatch::Shadows(range) => {
+                PrimitiveBatch::Shadows { range, .. } => {
                     reserve(std::mem::size_of::<Shadow>(), range.len())
                 }
-                PrimitiveBatch::Quads(range) => reserve(std::mem::size_of::<Quad>(), range.len()),
+                PrimitiveBatch::Quads { range, .. } => {
+                    reserve(std::mem::size_of::<Quad>(), range.len())
+                }
                 PrimitiveBatch::Paths {
                     rasterization_vertex_count,
                     sprite_count,
@@ -577,11 +579,11 @@ fn encode_inline_batch(
     pass: &mut wgpu::RenderPass<'_>,
 ) -> DrawResult {
     match batch {
-        PrimitiveBatch::Quads(range) => {
-            renderer.draw_quads(&scene.quads[range.clone()], instances, pass)
+        PrimitiveBatch::Quads { range, smoothed } => {
+            renderer.draw_quads(&scene.quads[range.clone()], *smoothed, instances, pass)
         }
-        PrimitiveBatch::Shadows(range) => {
-            renderer.draw_shadows(&scene.shadows[range.clone()], instances, pass)
+        PrimitiveBatch::Shadows { range, smoothed } => {
+            renderer.draw_shadows(&scene.shadows[range.clone()], *smoothed, instances, pass)
         }
         PrimitiveBatch::Underlines(range) => {
             renderer.draw_underlines(&scene.underlines[range.clone()], instances, pass)
@@ -599,13 +601,17 @@ fn encode_inline_batch(
             instances,
             pass,
         ),
-        PrimitiveBatch::PolychromeSprites { texture_id, range } => renderer
-            .draw_polychrome_sprites(
-                &scene.polychrome_sprites[range.clone()],
-                *texture_id,
-                instances,
-                pass,
-            ),
+        PrimitiveBatch::PolychromeSprites {
+            texture_id,
+            range,
+            smoothed,
+        } => renderer.draw_polychrome_sprites(
+            &scene.polychrome_sprites[range.clone()],
+            *texture_id,
+            *smoothed,
+            instances,
+            pass,
+        ),
         PrimitiveBatch::Surfaces(range) => {
             renderer.draw_surfaces(&scene.surfaces[range.clone()], pass)
         }

--- a/crates/gpui_wgpu/src/wgpu_renderer/frame.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/frame.rs
@@ -475,6 +475,7 @@ impl<'a> FrameEncoder<'a> {
                             bounds: boundary.bounds,
                             content_mask: boundary.content_mask.bounds,
                             corner_radii: boundary.corner_radii,
+                            corner_smoothing: boundary.corner_smoothing,
                             blur_radius: boundary.max_blur_radius(),
                             opacity: boundary.opacity,
                             clip: FilterCompositeClip::ContentShape,

--- a/crates/gpui_wgpu/src/wgpu_renderer/pipelines.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/pipelines.rs
@@ -50,13 +50,16 @@ fn instance_binding_entries(source: InstanceBindingSource<'_>) -> Vec<wgpu::Bind
 
 pub(super) struct WgpuPipelines {
     pub(super) quads: WgpuRenderPipeline,
+    pub(super) smoothed_quads: WgpuRenderPipeline,
     pub(super) shadows: WgpuRenderPipeline,
+    pub(super) smoothed_shadows: WgpuRenderPipeline,
     pub(super) path_rasterization: WgpuRenderPipeline,
     pub(super) paths: WgpuRenderPipeline,
     pub(super) underlines: WgpuRenderPipeline,
     pub(super) monochrome_sprites: WgpuRenderPipeline,
     pub(super) subpixel_sprites: Option<WgpuRenderPipeline>,
     pub(super) polychrome_sprites: WgpuRenderPipeline,
+    pub(super) smoothed_polychrome_sprites: WgpuRenderPipeline,
     #[cfg_attr(
         not(any(
             target_os = "macos",
@@ -70,6 +73,7 @@ pub(super) struct WgpuPipelines {
     pub(super) blur_downsample: WgpuRenderPipeline,
     pub(super) blur: WgpuRenderPipeline,
     pub(super) blur_composite: WgpuRenderPipeline,
+    pub(super) smoothed_blur_composite: WgpuRenderPipeline,
 }
 
 pub(super) struct WgpuRenderPipeline {
@@ -419,7 +423,9 @@ impl WgpuPipelines {
 
         Self {
             quads: create(shader::QUADS, &scene_target, 1, &shader_module),
+            smoothed_quads: create(shader::SMOOTHED_QUADS, &scene_target, 1, &shader_module),
             shadows: create(shader::SHADOWS, &scene_target, 1, &shader_module),
+            smoothed_shadows: create(shader::SMOOTHED_SHADOWS, &scene_target, 1, &shader_module),
             path_rasterization: create(
                 shader::PATH_RASTERIZATION,
                 &path_rasterization_target,
@@ -451,6 +457,12 @@ impl WgpuPipelines {
                 1,
                 &shader_module,
             ),
+            smoothed_polychrome_sprites: create(
+                shader::SMOOTHED_POLYCHROME_SPRITES,
+                &scene_target,
+                1,
+                &shader_module,
+            ),
             surfaces: create(shader::SURFACES, &scene_target, 1, &shader_module),
             blur_downsample: create(
                 shader::BLUR_DOWNSAMPLE,
@@ -460,6 +472,12 @@ impl WgpuPipelines {
             ),
             blur: create(shader::BLUR, &overwrite_target, 1, &shader_module),
             blur_composite: create(shader::BLUR_COMPOSITE, &composite_target, 1, &shader_module),
+            smoothed_blur_composite: create(
+                shader::SMOOTHED_BLUR_COMPOSITE,
+                &composite_target,
+                1,
+                &shader_module,
+            ),
         }
     }
 }

--- a/crates/gpui_wgpu/tests/headless_primitives.rs
+++ b/crates/gpui_wgpu/tests/headless_primitives.rs
@@ -249,7 +249,7 @@ fn smoothed_primitives_share_one_contour() {
         bounds: fill_bounds,
         content_mask,
         background: solid_background(green),
-        corner_radii: radii.clone(),
+        corner_radii: radii,
         corner_smoothing: 1.0,
         ..Default::default()
     });
@@ -265,7 +265,7 @@ fn smoothed_primitives_share_one_contour() {
             bottom: ScaledPixels(8.0),
             left: ScaledPixels(3.0),
         },
-        corner_radii: radii.clone(),
+        corner_radii: radii,
         corner_smoothing: 0.6,
         ..Default::default()
     });
@@ -295,7 +295,7 @@ fn smoothed_primitives_share_one_contour() {
         corner_smoothing: 1.0,
         bounds: image_bounds,
         content_mask,
-        corner_radii: radii.clone(),
+        corner_radii: radii,
         tile: image_tile,
     });
 

--- a/crates/gpui_wgpu/tests/headless_primitives.rs
+++ b/crates/gpui_wgpu/tests/headless_primitives.rs
@@ -171,7 +171,9 @@ fn every_primitive_kind_renders() {
         .render_commands()
         .iter()
         .filter_map(|command| match command {
-            gpui::RenderCommand::Batch(gpui::PrimitiveBatch::Quads(range)) => Some(range.clone()),
+            gpui::RenderCommand::Batch(gpui::PrimitiveBatch::Quads { range, .. }) => {
+                Some(range.clone())
+            }
             _ => None,
         })
         .collect();

--- a/crates/gpui_wgpu/tests/headless_primitives.rs
+++ b/crates/gpui_wgpu/tests/headless_primitives.rs
@@ -4,11 +4,13 @@
 #![cfg(feature = "test-support")]
 
 use gpui::{
-    AtlasKey, AtlasTile, Bounds, ContentMask, DevicePixels, Hsla, MonochromeSprite,
-    PlatformHeadlessRenderer, Point, PolychromeSprite, Quad, RenderImageParams, RenderSvgParams,
-    ScaledPixels, Scene, ShaderBool, Shadow, Size, Underline, solid_background,
+    AtlasKey, AtlasTile, BackdropFilter, BorderStyle, Bounds, ContentMask, Corners, DevicePixels,
+    Edges, Hsla, MonochromeSprite, PlatformHeadlessRenderer, Point, PolychromeSprite, Quad,
+    RenderImageParams, RenderSvgParams, ScaledFilter, ScaledPixels, Scene, ShaderBool, Shadow,
+    Size, Underline, checkerboard, solid_background,
 };
 use gpui_ce_wgpu::WgpuHeadlessRenderer;
+use smallvec::smallvec;
 use std::borrow::Cow;
 
 const TARGET: Size<DevicePixels> = Size {
@@ -32,6 +34,12 @@ fn bounds(x: f32, y: f32, w: f32, h: f32) -> Bounds<ScaledPixels> {
 fn full_mask() -> ContentMask<ScaledPixels> {
     ContentMask {
         bounds: bounds(0.0, 0.0, 200.0, 100.0),
+    }
+}
+
+fn mask(width: f32, height: f32) -> ContentMask<ScaledPixels> {
+    ContentMask {
+        bounds: bounds(0.0, 0.0, width, height),
     }
 }
 
@@ -111,7 +119,7 @@ fn every_primitive_kind_renders() {
         element_bounds: shadow_bounds,
         element_corner_radii: Default::default(),
         inset: ShaderBool::Disabled,
-        padding: 0,
+        corner_smoothing: 0.0,
     });
     // 4. Underline (white, solid).
     let underline_bounds = bounds(130.0, 20.0, 30.0, 4.0);
@@ -139,9 +147,9 @@ fn every_primitive_kind_renders() {
     let poly_bounds = bounds(50.0, 60.0, 30.0, 30.0);
     scene.insert_primitive(PolychromeSprite {
         order: 0,
-        padding: 0,
         grayscale: ShaderBool::Disabled,
         opacity: 1.0,
+        corner_smoothing: 0.0,
         bounds: poly_bounds,
         content_mask: full_mask(),
         corner_radii: Default::default(),
@@ -207,5 +215,239 @@ fn every_primitive_kind_renders() {
             failures.join("\n"),
             path.display()
         );
+    }
+}
+
+#[test]
+fn smoothed_primitives_share_one_contour() {
+    let mut renderer = WgpuHeadlessRenderer::new().expect("headless renderer");
+    let image_tile = tile(
+        &renderer,
+        AtlasKey::Image(RenderImageParams {
+            image_id: gpui::ImageId(2),
+            frame_index: 0,
+        }),
+        (0..64).flat_map(|_| [0u8, 0, 255, 255]).collect(),
+    );
+    let target = Size {
+        width: DevicePixels(360),
+        height: DevicePixels(170),
+    };
+    let content_mask = mask(360.0, 170.0);
+    let green: Hsla = gpui::rgb_to_hsla(gpui::rgb(0x19d36b));
+    let white: Hsla = gpui::rgb_to_hsla(gpui::rgb(0xffffff));
+    let blue: Hsla = gpui::rgb_to_hsla(gpui::rgb(0x287cff));
+    let black: Hsla = gpui::rgb_to_hsla(gpui::rgb(0x000000));
+    let radii = Corners::all(ScaledPixels(18.0));
+
+    let mut scene = Scene::default();
+
+    let fill_bounds = bounds(10.0, 10.0, 50.0, 50.0);
+    scene.insert_primitive(Quad {
+        bounds: fill_bounds,
+        content_mask,
+        background: solid_background(green),
+        corner_radii: radii.clone(),
+        corner_smoothing: 1.0,
+        ..Default::default()
+    });
+
+    let border_bounds = bounds(72.0, 10.0, 50.0, 50.0);
+    scene.insert_primitive(Quad {
+        bounds: border_bounds,
+        content_mask,
+        border_color: white.into(),
+        border_widths: Edges {
+            top: ScaledPixels(2.0),
+            right: ScaledPixels(5.0),
+            bottom: ScaledPixels(8.0),
+            left: ScaledPixels(3.0),
+        },
+        corner_radii: radii.clone(),
+        corner_smoothing: 0.6,
+        ..Default::default()
+    });
+
+    let dashed_bounds = bounds(134.0, 10.0, 58.0, 50.0);
+    scene.insert_primitive(Quad {
+        bounds: dashed_bounds,
+        content_mask,
+        border_style: BorderStyle::Dashed,
+        border_color: white.into(),
+        border_widths: Edges::all(ScaledPixels(3.0)),
+        corner_radii: Corners {
+            top_left: ScaledPixels(20.0),
+            top_right: ScaledPixels(8.0),
+            bottom_right: ScaledPixels(16.0),
+            bottom_left: ScaledPixels(3.0),
+        },
+        corner_smoothing: 1.0,
+        ..Default::default()
+    });
+
+    let image_bounds = bounds(204.0, 10.0, 50.0, 50.0);
+    scene.insert_primitive(PolychromeSprite {
+        order: 0,
+        grayscale: ShaderBool::Disabled,
+        opacity: 1.0,
+        corner_smoothing: 1.0,
+        bounds: image_bounds,
+        content_mask,
+        corner_radii: radii.clone(),
+        tile: image_tile,
+    });
+
+    let drop_element = bounds(20.0, 96.0, 50.0, 44.0);
+    scene.insert_primitive(Shadow {
+        order: 0,
+        blur_radius: ScaledPixels(5.0),
+        bounds: bounds(25.0, 101.0, 50.0, 44.0),
+        corner_radii: Corners::all(ScaledPixels(15.0)),
+        content_mask,
+        color: blue.into(),
+        element_bounds: drop_element,
+        element_corner_radii: Corners::all(ScaledPixels(15.0)),
+        inset: ShaderBool::Disabled,
+        corner_smoothing: 0.6,
+    });
+    scene.insert_primitive(Quad {
+        bounds: drop_element,
+        content_mask,
+        background: solid_background(green),
+        corner_radii: Corners::all(ScaledPixels(15.0)),
+        corner_smoothing: 0.6,
+        ..Default::default()
+    });
+
+    let inset_bounds = bounds(100.0, 94.0, 50.0, 48.0);
+    scene.insert_primitive(Quad {
+        bounds: inset_bounds,
+        content_mask,
+        background: solid_background(green),
+        corner_radii: Corners::all(ScaledPixels(16.0)),
+        corner_smoothing: 1.0,
+        ..Default::default()
+    });
+    scene.insert_primitive(Shadow {
+        order: 0,
+        blur_radius: ScaledPixels(4.0),
+        bounds: bounds(104.0, 98.0, 42.0, 40.0),
+        corner_radii: Corners::all(ScaledPixels(12.0)),
+        content_mask,
+        color: black.into(),
+        element_bounds: inset_bounds,
+        element_corner_radii: Corners::all(ScaledPixels(16.0)),
+        inset: ShaderBool::Enabled,
+        corner_smoothing: 1.0,
+    });
+
+    let filter_bounds = bounds(190.0, 92.0, 70.0, 52.0);
+    scene.insert_primitive(Quad {
+        bounds: filter_bounds,
+        content_mask,
+        background: checkerboard(white, 2.0),
+        ..Default::default()
+    });
+    scene.insert_primitive(BackdropFilter {
+        order: 0,
+        bounds: filter_bounds,
+        content_mask,
+        corner_radii: Corners::all(ScaledPixels(18.0)),
+        corner_smoothing: 1.0,
+        filters: smallvec![ScaledFilter::Blur(ScaledPixels(5.0))],
+        opacity: 1.0,
+    });
+
+    scene.finish();
+    let image = renderer
+        .render_scene_to_image(&scene, target)
+        .expect("render must succeed");
+    let mut unfiltered_scene = Scene::default();
+    unfiltered_scene.insert_primitive(Quad {
+        bounds: filter_bounds,
+        content_mask,
+        background: checkerboard(white, 2.0),
+        ..Default::default()
+    });
+    unfiltered_scene.finish();
+    let unfiltered = renderer
+        .render_scene_to_image(&unfiltered_scene, target)
+        .expect("reference render must succeed");
+    let pixel = |x: u32, y: u32| image.get_pixel(x, y).0;
+    let reference_pixel = |x: u32, y: u32| unfiltered.get_pixel(x, y).0;
+    let is_black = |x, y| pixel(x, y)[0..3].iter().all(|channel| *channel <= 12);
+    let is_white = |x, y| pixel(x, y)[0..3].iter().all(|channel| *channel >= 235);
+
+    assert!(is_black(10, 10), "smoothed fill must exclude its corner");
+    assert!(
+        pixel(35, 10)[1] > 180,
+        "fill shoulder must reach the top edge"
+    );
+    assert!(pixel(35, 35)[1] > 180, "fill center");
+
+    assert!(is_white(96, 10), "thin top border");
+    assert!(
+        is_black(96, 14),
+        "top border must not grow to the right width"
+    );
+    assert!(is_white(120, 35), "right border");
+    assert!(is_black(115, 35), "right border interior boundary");
+    assert!(is_white(96, 56), "thick bottom border");
+    assert!(is_black(96, 50), "bottom border interior boundary");
+
+    let dashed_pixels = (8..62)
+        .flat_map(|y| (132..194).map(move |x| (x, y)))
+        .filter(|&(x, y)| is_white(x, y))
+        .count();
+    assert!(
+        (150..420).contains(&dashed_pixels),
+        "dashed contour coverage: {dashed_pixels}"
+    );
+    assert!(is_black(163, 35), "dashed border interior");
+
+    assert!(is_black(204, 10), "smoothed image must exclude its corner");
+    assert!(
+        pixel(229, 10)[0] > 220,
+        "image shoulder must reach the top edge"
+    );
+    assert!(pixel(229, 35)[0] > 220, "image center");
+
+    assert!(
+        pixel(73, 132)[2] > 35,
+        "drop shadow must extend beyond the element"
+    );
+    assert!(
+        pixel(125, 96)[1] < pixel(125, 118)[1],
+        "inset shadow must darken the edge"
+    );
+    assert!(
+        pixel(125, 118)[1] > 120,
+        "inset shadow must preserve the center"
+    );
+
+    let blurred_midtones = (192..258)
+        .flat_map(|x| (94..142).map(move |y| pixel(x, y)[0]))
+        .filter(|channel| (30..225).contains(channel))
+        .count();
+    assert!(
+        blurred_midtones > 800,
+        "backdrop blur did not composite: {blurred_midtones}"
+    );
+    assert!(
+        pixel(190, 92)
+            .iter()
+            .zip(reference_pixel(190, 92))
+            .all(|(&actual, expected)| actual.abs_diff(expected) <= 1),
+        "the smoothed mask must exclude the backdrop corner"
+    );
+    assert!(
+        pixel(225, 92)[0].abs_diff(reference_pixel(225, 92)[0]) > 20,
+        "the smoothed mask must include the top shoulder"
+    );
+
+    if std::env::var_os("GPUI_SAVE_HEADLESS_TESTS").is_some() {
+        image
+            .save(std::env::temp_dir().join("gpui_smoothed_primitives.png"))
+            .expect("save diagnostic image");
     }
 }

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -247,6 +247,8 @@ struct DirectXRenderPipelines {
     blur_fragment: ID3D11PixelShader,
     blur_composite_vertex: ID3D11VertexShader,
     blur_composite_fragment: ID3D11PixelShader,
+    smoothed_blur_composite_vertex: ID3D11VertexShader,
+    smoothed_blur_composite_fragment: ID3D11PixelShader,
     blur_params_buffer: ID3D11Buffer,
     blur_blend_replace: ID3D11BlendState,
     blur_blend_composite: ID3D11BlendState,
@@ -635,11 +637,11 @@ impl DirectXRenderer {
                 .as_ref()
                 .map(|annotation| Annotation::new(annotation, HSTRING::from(command.label())));
             match command {
-                RenderCommand::Batch(PrimitiveBatch::Shadows(range)) => {
-                    self.draw_shadows(instance_range(range)?)
+                RenderCommand::Batch(PrimitiveBatch::Shadows { range, smoothed }) => {
+                    self.draw_shadows(instance_range(range)?, *smoothed)
                 }
-                RenderCommand::Batch(PrimitiveBatch::Quads(range)) => {
-                    self.draw_quads(instance_range(range)?)
+                RenderCommand::Batch(PrimitiveBatch::Quads { range, smoothed }) => {
+                    self.draw_quads(instance_range(range)?, *smoothed)
                 }
                 RenderCommand::Batch(PrimitiveBatch::Paths {
                     range,
@@ -667,7 +669,12 @@ impl DirectXRenderer {
                 RenderCommand::Batch(PrimitiveBatch::PolychromeSprites {
                     texture_id,
                     range,
-                }) => self.draw_polychrome_sprites(*texture_id, instance_range(range)?),
+                    smoothed,
+                }) => self.draw_polychrome_sprites(
+                    *texture_id,
+                    instance_range(range)?,
+                    *smoothed,
+                ),
                 RenderCommand::Batch(PrimitiveBatch::Surfaces(range)) => {
                     self.draw_surfaces(&scene.surfaces[range.clone()])
                 }
@@ -965,16 +972,22 @@ impl DirectXRenderer {
         })
     }
 
-    fn draw_shadows(&mut self, instances: InstanceRange) -> Result<()> {
-        self.pipelines
-            .shadow_pipeline
-            .draw_instances(&self.frame_bindings()?, None, instances)
+    fn draw_shadows(&mut self, instances: InstanceRange, smoothed: bool) -> Result<()> {
+        self.pipelines.shadow_pipeline.draw_instances_variant(
+            &self.frame_bindings()?,
+            None,
+            instances,
+            smoothed,
+        )
     }
 
-    fn draw_quads(&mut self, instances: InstanceRange) -> Result<()> {
-        self.pipelines
-            .quad_pipeline
-            .draw_instances(&self.frame_bindings()?, None, instances)
+    fn draw_quads(&mut self, instances: InstanceRange, smoothed: bool) -> Result<()> {
+        self.pipelines.quad_pipeline.draw_instances_variant(
+            &self.frame_bindings()?,
+            None,
+            instances,
+            smoothed,
+        )
     }
 
     fn draw_paths_to_intermediate(
@@ -1144,12 +1157,14 @@ impl DirectXRenderer {
         &mut self,
         texture_id: AtlasTextureId,
         instances: InstanceRange,
+        smoothed: bool,
     ) -> Result<()> {
         let texture_view = self.atlas.get_texture_view(texture_id);
-        self.pipelines.poly_sprites.draw_instances(
+        self.pipelines.poly_sprites.draw_instances_variant(
             &self.frame_bindings()?,
             Some(&texture_view),
             instances,
+            smoothed,
         )
     }
 
@@ -1374,23 +1389,35 @@ impl DirectXRenderer {
                 GAUSSIAN_CUTOFF_STANDARD_DEVIATIONS * blur_radius,
             ))
         };
+        let composite_uniforms = BlurUniforms::composite(
+            composite_bounds,
+            content_mask,
+            corner_radii,
+            corner_smoothing,
+            opacity,
+            clip,
+            blur_size,
+            [full_width as f32, full_height as f32],
+        );
+        let (composite_vertex, composite_fragment) = if composite_uniforms.corner_smoothing > 0.0 {
+            (
+                &self.pipelines.smoothed_blur_composite_vertex,
+                &self.pipelines.smoothed_blur_composite_fragment,
+            )
+        } else {
+            (
+                &self.pipelines.blur_composite_vertex,
+                &self.pipelines.blur_composite_fragment,
+            )
+        };
         // Composite the blurred result into the target (preserving its contents).
         self.dx_blur_pass(
-            &self.pipelines.blur_composite_vertex,
-            &self.pipelines.blur_composite_fragment,
+            composite_vertex,
+            composite_fragment,
             &self.pipelines.blur_blend_composite,
             target_rtv,
             &ping_srv,
-            BlurUniforms::composite(
-                composite_bounds,
-                content_mask,
-                corner_radii,
-                corner_smoothing,
-                opacity,
-                clip,
-                blur_size,
-                [full_width as f32, full_height as f32],
-            ),
+            composite_uniforms,
             &full_vp,
             D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP,
             4,
@@ -1585,14 +1612,16 @@ impl DirectXRenderPipelines {
             ShaderModule::Shadow,
             4,
             create_blend_state(device)?,
-        )?;
+        )?
+        .with_variant(device, ShaderModule::SmoothedShadow)?;
         let quad_pipeline = PipelineState::new(
             device,
             "quad_pipeline",
             ShaderModule::Quad,
             64,
             create_blend_state(device)?,
-        )?;
+        )?
+        .with_variant(device, ShaderModule::SmoothedQuad)?;
         let path_rasterization_pipeline = PipelineState::new(
             device,
             "path_rasterization_pipeline",
@@ -1634,7 +1663,8 @@ impl DirectXRenderPipelines {
             ShaderModule::PolychromeSprite,
             16,
             create_blend_state(device)?,
-        )?;
+        )?
+        .with_variant(device, ShaderModule::SmoothedPolychromeSprite)?;
 
         let blur_downsample = ShaderModule::BlurDownsample.bytecode()?;
         let blur_downsample_vertex = create_vertex_shader(device, blur_downsample.vertex)?;
@@ -1645,6 +1675,11 @@ impl DirectXRenderPipelines {
         let blur_composite = ShaderModule::BlurComposite.bytecode()?;
         let blur_composite_vertex = create_vertex_shader(device, blur_composite.vertex)?;
         let blur_composite_fragment = create_fragment_shader(device, blur_composite.fragment)?;
+        let smoothed_blur_composite = ShaderModule::SmoothedBlurComposite.bytecode()?;
+        let smoothed_blur_composite_vertex =
+            create_vertex_shader(device, smoothed_blur_composite.vertex)?;
+        let smoothed_blur_composite_fragment =
+            create_fragment_shader(device, smoothed_blur_composite.fragment)?;
         let blur_params_buffer =
             create_constant_buffer(device, std::mem::size_of::<BlurUniforms>())?;
         let blur_blend_replace = create_blend_state_no_blend(device)?;
@@ -1676,6 +1711,8 @@ impl DirectXRenderPipelines {
             blur_fragment,
             blur_composite_vertex,
             blur_composite_fragment,
+            smoothed_blur_composite_vertex,
+            smoothed_blur_composite_fragment,
             blur_params_buffer,
             blur_blend_replace,
             blur_blend_composite,
@@ -1753,12 +1790,19 @@ struct PipelineState<T> {
     specification: &'static shader_interface::Pipeline,
     vertex: ID3D11VertexShader,
     fragment: ID3D11PixelShader,
+    variant: Option<PipelineVariant>,
     draw_constants: Dx11DrawConstantsBinding,
     buffer: ID3D11Buffer,
     buffer_size: usize,
     view: Option<ID3D11ShaderResourceView>,
     blend_state: ID3D11BlendState,
     _marker: std::marker::PhantomData<T>,
+}
+
+struct PipelineVariant {
+    specification: &'static shader_interface::Pipeline,
+    vertex: ID3D11VertexShader,
+    fragment: ID3D11PixelShader,
 }
 
 impl<T> PipelineState<T> {
@@ -1784,6 +1828,7 @@ impl<T> PipelineState<T> {
             specification: shader.pipeline,
             vertex,
             fragment,
+            variant: None,
             draw_constants,
             buffer,
             buffer_size,
@@ -1791,6 +1836,35 @@ impl<T> PipelineState<T> {
             blend_state,
             _marker: std::marker::PhantomData,
         })
+    }
+
+    fn with_variant(mut self, device: &ID3D11Device, shader_module: ShaderModule) -> Result<Self> {
+        let shader = shader_module.shader();
+        let bytecode = shader_module.bytecode()?;
+        anyhow::ensure!(
+            shader.pipeline.data_layout == self.specification.data_layout
+                && shader.pipeline.topology == self.specification.topology
+                && shader.pipeline.vertex_count == self.specification.vertex_count,
+            "{} variant has an incompatible pipeline layout",
+            self.label,
+        );
+        let draw_constants = bytecode.draw_constants.with_context(|| {
+            format!(
+                "{} variant was generated without DX11 draw constants",
+                self.label
+            )
+        })?;
+        anyhow::ensure!(
+            draw_constants == self.draw_constants,
+            "{} variant uses a different DX11 draw-constants register",
+            self.label,
+        );
+        self.variant = Some(PipelineVariant {
+            specification: shader.pipeline,
+            vertex: create_vertex_shader(device, bytecode.vertex)?,
+            fragment: create_fragment_shader(device, bytecode.fragment)?,
+        });
+        Ok(self)
     }
 
     fn update_buffer(
@@ -1855,6 +1929,28 @@ impl<T> PipelineState<T> {
         self.draw(frame, texture, vertex_count, instances)
     }
 
+    fn draw_instances_variant(
+        &self,
+        frame: &FrameBindings<'_>,
+        texture: Option<&[Option<ID3D11ShaderResourceView>]>,
+        instances: InstanceRange,
+        use_variant: bool,
+    ) -> Result<()> {
+        let variant = use_variant.then(|| {
+            self.variant
+                .as_ref()
+                .unwrap_or_else(|| panic!("{} has no shader variant", self.label))
+        });
+        let specification = variant
+            .map(|variant| variant.specification)
+            .unwrap_or(self.specification);
+        let vertex_count = specification
+            .vertex_count
+            .fixed()
+            .with_context(|| format!("{} has no fixed vertex count", self.label))?;
+        self.draw_with_variant(frame, texture, vertex_count, instances, variant)
+    }
+
     /// Draws `vertex_count` vertex-pulled vertices as a single instance.
     fn draw_vertices(&self, frame: &FrameBindings<'_>, vertex_count: u32) -> Result<()> {
         anyhow::ensure!(
@@ -1871,6 +1967,17 @@ impl<T> PipelineState<T> {
         texture: Option<&[Option<ID3D11ShaderResourceView>]>,
         vertex_count: u32,
         instances: InstanceRange,
+    ) -> Result<()> {
+        self.draw_with_variant(frame, texture, vertex_count, instances, None)
+    }
+
+    fn draw_with_variant(
+        &self,
+        frame: &FrameBindings<'_>,
+        texture: Option<&[Option<ID3D11ShaderResourceView>]>,
+        vertex_count: u32,
+        instances: InstanceRange,
+        variant: Option<&PipelineVariant>,
     ) -> Result<()> {
         if instances.is_empty() || vertex_count == 0 {
             return Ok(());
@@ -1889,7 +1996,10 @@ impl<T> PipelineState<T> {
             &frame.globals.draw_constants_buffer,
             &[Dx11DrawConstants::for_instances(instances.first())],
         )?;
-        let topology = match self.specification.topology {
+        let specification = variant
+            .map(|variant| variant.specification)
+            .unwrap_or(self.specification);
+        let topology = match specification.topology {
             shader_interface::PrimitiveTopology::TriangleList => {
                 D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST
             }
@@ -1903,8 +2013,18 @@ impl<T> PipelineState<T> {
             ctx.PSSetShaderResources(DATA_REGISTER, Some(slice::from_ref(&self.view)));
             ctx.IASetPrimitiveTopology(topology);
             ctx.RSSetViewports(Some(slice::from_ref(frame.viewport)));
-            ctx.VSSetShader(&self.vertex, None);
-            ctx.PSSetShader(&self.fragment, None);
+            ctx.VSSetShader(
+                variant
+                    .map(|variant| &variant.vertex)
+                    .unwrap_or(&self.vertex),
+                None,
+            );
+            ctx.PSSetShader(
+                variant
+                    .map(|variant| &variant.fragment)
+                    .unwrap_or(&self.fragment),
+                None,
+            );
             ctx.VSSetConstantBuffers(0, Some(&frame.globals.cbuffers()));
             ctx.PSSetConstantBuffers(0, Some(&frame.globals.cbuffers()));
             ctx.VSSetConstantBuffers(self.draw_constants.register, Some(&draw_constants));
@@ -2390,53 +2510,65 @@ pub(crate) mod shader_resources {
     #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     pub(crate) enum ShaderModule {
         Quad,
+        SmoothedQuad,
         Shadow,
+        SmoothedShadow,
         Underline,
         PathRasterization,
         PathSprite,
         MonochromeSprite,
         SubpixelSprite,
         PolychromeSprite,
+        SmoothedPolychromeSprite,
         EmojiRasterization,
         Surface,
         BlurDownsample,
         Blur,
         BlurComposite,
+        SmoothedBlurComposite,
     }
 
     impl ShaderModule {
         #[cfg(test)]
-        const ALL: [Self; 13] = [
+        const ALL: [Self; 17] = [
             Self::Quad,
+            Self::SmoothedQuad,
             Self::Shadow,
+            Self::SmoothedShadow,
             Self::Underline,
             Self::PathRasterization,
             Self::PathSprite,
             Self::MonochromeSprite,
             Self::SubpixelSprite,
             Self::PolychromeSprite,
+            Self::SmoothedPolychromeSprite,
             Self::EmojiRasterization,
             Self::Surface,
             Self::BlurDownsample,
             Self::Blur,
             Self::BlurComposite,
+            Self::SmoothedBlurComposite,
         ];
 
         pub(crate) fn shader(self) -> &'static NativeShader {
             let label = match self {
                 Self::Quad => "quads",
+                Self::SmoothedQuad => "smoothed_quads",
                 Self::Shadow => "shadows",
+                Self::SmoothedShadow => "smoothed_shadows",
                 Self::Underline => "underlines",
                 Self::PathRasterization => "path_rasterization",
                 Self::PathSprite => "paths",
                 Self::MonochromeSprite => "monochrome_sprites",
                 Self::SubpixelSprite => "subpixel_sprites",
                 Self::PolychromeSprite => "polychrome_sprites",
+                Self::SmoothedPolychromeSprite => "smoothed_polychrome_sprites",
                 Self::EmojiRasterization => "emoji_rasterization",
                 Self::Surface => "surfaces",
                 Self::BlurDownsample => "blur_downsample",
                 Self::Blur => "blur",
                 Self::BlurComposite => "blur_composite",
+                Self::SmoothedBlurComposite => "smoothed_blur_composite",
             };
             NATIVE_SHADERS
                 .iter()
@@ -2851,7 +2983,7 @@ mod tests {
             .render_commands()
             .iter()
             .filter_map(|command| match command {
-                RenderCommand::Batch(PrimitiveBatch::Quads(range)) => Some(range.clone()),
+                RenderCommand::Batch(PrimitiveBatch::Quads { range, .. }) => Some(range.clone()),
                 _ => None,
             })
             .collect();

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -680,6 +680,7 @@ impl DirectXRenderer {
                                 filter.bounds,
                                 filter.content_mask.bounds,
                                 filter.corner_radii,
+                                filter.corner_smoothing,
                                 filter.max_blur_radius(),
                                 filter.opacity,
                                 true,
@@ -724,6 +725,7 @@ impl DirectXRenderer {
                         boundary.bounds,
                         boundary.content_mask.bounds,
                         boundary.corner_radii,
+                        boundary.corner_smoothing,
                         boundary.max_blur_radius(),
                         boundary.opacity,
                         false,
@@ -1283,6 +1285,7 @@ impl DirectXRenderer {
         bounds: Bounds<ScaledPixels>,
         content_mask: Bounds<ScaledPixels>,
         corner_radii: Corners<ScaledPixels>,
+        corner_smoothing: f32,
         blur_radius: f32,
         opacity: f32,
         // Backdrop clips to the rounded rect; content (`filter`) bleeds past its bounds.
@@ -1382,6 +1385,7 @@ impl DirectXRenderer {
                 composite_bounds,
                 content_mask,
                 corner_radii,
+                corner_smoothing,
                 opacity,
                 clip,
                 blur_size,
@@ -2825,9 +2829,9 @@ mod tests {
         });
         scene.insert_primitive(PolychromeSprite {
             order: 0,
-            padding: 0,
             grayscale: ShaderBool::Disabled,
             opacity: 1.0,
+            corner_smoothing: 0.0,
             bounds: scaled(50.0, 60.0, 30.0, 30.0),
             content_mask: full_mask(),
             corner_radii: Default::default(),


### PR DESCRIPTION
## Summary
Adds corner smoothing by extending the corner radii shaders to support a smoothing factor.

It uses [figma flavored corner smoothing](https://www.figma.com/blog/desperately-seeking-squircles/). To be specific its [phamfoo's implementation](https://github.com/phamfoo/figma-squircle) but translated into shaders.

I also improved phamfoo's smoothing preservation logic to fix an issue with smoothing breaking when 2 adjacent corners had a radii of half the width/height.

## Performance
Whilst a more simpler super-ellipse approach would've been faster, it wouldn't have allowed for smoothing preservation. 

Heres a comparison between a capsule shape with smoothing preservation (left), and one without (right):
<img width="776" height="201" alt="capsule" src="https://github.com/user-attachments/assets/b0d2932d-708c-4a85-b939-e3ef2b86a72c" />
Both shapes have a corner smoothing of 100%.

To make the difference more clear, heres both shapes overlapped:
<img width="404" height="201" alt="capsule_diff" src="https://github.com/user-attachments/assets/e702e249-93c0-4db8-a898-13e8d3fbef0c" />

## Showcase

<img width="472" height="600" alt="image" src="https://github.com/user-attachments/assets/e1054d6f-de78-4173-a9dd-0fb3209bf95d" />

## AI Disclosure
GPT 5.6-Sol helped me with this PR, particularly with the example, and translating the cpu-bound svg code into shaders for each platform. All code in this PR has been read and reviewed by me. 