### PR TITLE
gpui_web: Leave IME-owned keydowns to the browser

### DIFF
--- a/crates/gpui_web/src/events.rs
+++ b/crates/gpui_web/src/events.rs
@@ -713,6 +713,17 @@ impl WebWindowInner {
             let is_held = event.repeat();
             let key_char = compute_key_char(&event, &key, &modifiers);
 
+            // The first IME keydown can precede compositionstart, when both
+            // composing flags are still false. Leave it to the browser without
+            // dispatching editor actions or cancelling its default behavior.
+            if is_ime_keydown(
+                this.is_composing.get(),
+                event.is_composing(),
+                event.key_code(),
+            ) {
+                return;
+            }
+
             let keystroke = Keystroke {
                 modifiers,
                 key,
@@ -731,11 +742,6 @@ impl WebWindowInner {
                     this.schedule_ime_mirror_sync();
                     return;
                 }
-            }
-
-            if this.is_composing.get() || event.is_composing() {
-                event.prevent_default();
-                return;
             }
 
             if keystroke_inserts_text(&modifiers, this.is_mac)
@@ -1425,9 +1431,33 @@ fn mouse_position_in_element(event: &web_sys::MouseEvent) -> Point<Pixels> {
     point(px(event.offset_x() as f32), px(event.offset_y() as f32))
 }
 
+fn is_ime_keydown(is_composing: bool, event_is_composing: bool, key_code: u32) -> bool {
+    is_composing || event_is_composing || key_code == 229
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ime_keydowns_include_composition_boundaries() {
+        assert!(is_ime_keydown(true, false, 65));
+        assert!(is_ime_keydown(false, true, 65));
+        assert!(is_ime_keydown(true, true, 65));
+
+        // compositionstart can follow keydown, so both composing flags can still
+        // be false for the first IME-owned keydown.
+        assert!(is_ime_keydown(false, false, 229));
+
+        assert!(!is_ime_keydown(false, false, 65));
+    }
+
+    #[test]
+    fn ordinary_keys_are_not_owned_by_ime() {
+        for key_code in [0, 8, 13, 16, 17, 18, 27, 37, 65, 91] {
+            assert!(!is_ime_keydown(false, false, key_code));
+        }
+    }
 
     #[test]
     fn browser_pointer_id_reuse_gets_a_new_touch_id() {

--- a/crates/gpui_web/src/events.rs
+++ b/crates/gpui_web/src/events.rs
@@ -1431,6 +1431,15 @@ fn mouse_position_in_element(event: &web_sys::MouseEvent) -> Point<Pixels> {
     point(px(event.offset_x() as f32), px(event.offset_y() as f32))
 }
 
+/// 229 == Windows `VK_PROCESSKEY` (0xE5), reported while an IME
+/// owns the keystroke.
+/// W3C UI Events §7.3.1: "If an Input Method Editor is processing
+/// key input and the event is keydown, return 229."
+/// https://www.w3.org/TR/uievents/#determine-keydown-keyup-keyCode
+/// https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
+/// `key` is unreliable here ("Process" vs "Unidentified" per browser),
+/// so `keyCode` is the signal. First IME keydown can precede
+/// `compositionstart`, hence this fallback when both composing flags are false.
 fn is_ime_keydown(is_composing: bool, event_is_composing: bool, key_code: u32) -> bool {
     is_composing || event_is_composing || key_code == 229
 }


### PR DESCRIPTION
Typing `a` with a Japanese IME produced `aあ`. The raw `a` was inserted into the editor first, followed by the composed `あ`.

The first keydown event of composition fires before `compositionstart`, so both the internal `is_composing` flag and `event.isComposing` were still false. As a result, the keydown handler followed its normal path, dispatching `KeyDown` and inserting the key character through `replace_text_in_range`. The composition text was then inserted as well.

The browser reports `keyCode === 229` for IME-owned keydowns, including this initial event. This change checks that value as part of the composition guard and moves the guard before the `KeyDown` dispatch through `dispatch_input`. The handler returns without calling `preventDefault`, leaving the browser in control of composition.

Related Zed fix: https://github.com/zed-industries/zed/pull/63949