### PR TITLE
Add custom GPU rendering API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2660,13 +2660,16 @@ name = "gpui_ce_wgpu"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytemuck",
  "core-foundation",
  "core-video",
  "cosmic-text",
  "criterion",
+ "env_logger",
  "etagere",
  "gpui-ce",
  "gpui_ce_collections",
+ "gpui_ce_platform",
  "gpui_ce_render",
  "gpui_ce_util",
  "image",

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -18,8 +18,9 @@ workspace = true
 
 [features]
 default = ["font-kit", "wayland", "x11", "windows-manifest"]
-# Enables `SurfaceSource::Texture` and `gpu_context()` for standalone WGPU
-# surface integrations on Windows.
+# Enables the opt-in custom WGPU control API on platforms that support shared
+# texture surfaces.
+custom-gpu = []
 wgpu-surfaces = []
 test-support = [
   "leak-detection",

--- a/crates/gpui/src/elements/surface.rs
+++ b/crates/gpui/src/elements/surface.rs
@@ -16,10 +16,9 @@ pub enum SurfaceSource {
     Surface(CVPixelBuffer),
     /// A GPU texture handle (type-erased to avoid depending on wgpu)
     #[cfg(any(
-        target_family = "wasm",
         target_os = "linux",
         target_os = "freebsd",
-        all(target_os = "windows", feature = "wgpu-surfaces")
+        all(target_family = "wasm", feature = "custom-gpu")
     ))]
     Texture {
         /// The GPU texture, type-erased (expected to be `Arc<wgpu::Texture>`)
@@ -47,10 +46,9 @@ impl std::fmt::Debug for SurfaceSource {
             #[cfg(target_os = "macos")]
             SurfaceSource::Surface(ref buf) => _f.debug_tuple("Surface").field(buf).finish(),
             #[cfg(any(
-                target_family = "wasm",
                 target_os = "linux",
                 target_os = "freebsd",
-                all(target_os = "windows", feature = "wgpu-surfaces")
+                all(target_family = "wasm", feature = "custom-gpu")
             ))]
             SurfaceSource::Texture { size, .. } => _f
                 .debug_struct("Texture")
@@ -71,10 +69,9 @@ impl SurfaceSource {
                 crate::size(buffer.get_width().into(), buffer.get_height().into())
             }
             #[cfg(any(
-                target_family = "wasm",
                 target_os = "linux",
                 target_os = "freebsd",
-                all(target_os = "windows", feature = "wgpu-surfaces")
+                all(target_family = "wasm", feature = "custom-gpu")
             ))]
             SurfaceSource::Texture { size, .. } => *size,
             #[cfg(target_os = "windows")]

--- a/crates/gpui/src/elements/surface.rs
+++ b/crates/gpui/src/elements/surface.rs
@@ -15,7 +15,11 @@ pub enum SurfaceSource {
     #[cfg(target_os = "macos")]
     Surface(CVPixelBuffer),
     /// A GPU texture handle (type-erased to avoid depending on wgpu)
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        all(target_os = "windows", feature = "wgpu-surfaces")
+    ))]
     Texture {
         /// The GPU texture, type-erased (expected to be `Arc<wgpu::Texture>`)
         texture: std::sync::Arc<dyn std::any::Any + Send + Sync>,
@@ -35,7 +39,11 @@ impl std::fmt::Debug for SurfaceSource {
         match *self {
             #[cfg(target_os = "macos")]
             SurfaceSource::Surface(ref buf) => _f.debug_tuple("Surface").field(buf).finish(),
-            #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "freebsd",
+                all(target_os = "windows", feature = "wgpu-surfaces")
+            ))]
             SurfaceSource::Texture { size, .. } => _f
                 .debug_struct("Texture")
                 .field("size", &size)
@@ -54,7 +62,11 @@ impl SurfaceSource {
             SurfaceSource::Surface(buffer) => {
                 crate::size(buffer.get_width().into(), buffer.get_height().into())
             }
-            #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "freebsd",
+                all(target_os = "windows", feature = "wgpu-surfaces")
+            ))]
             SurfaceSource::Texture { size, .. } => *size,
             #[cfg(target_os = "windows")]
             SurfaceSource::WindowsCapture(frame) => frame.size(),
@@ -156,7 +168,11 @@ impl Element for Surface {
     ) {
         let new_bounds = self.object_fit.get_bounds(_bounds, self.source.size());
         // TODO: Add support for corner_radii.
-        _window.paint_surface(new_bounds, self.source.clone());
+        let mut style = Style::default();
+        style.refine(&self.style);
+        _window.with_element_opacity(style.opacity, |window| {
+            window.paint_surface(new_bounds, self.source.clone());
+        });
     }
 }
 

--- a/crates/gpui/src/elements/surface.rs
+++ b/crates/gpui/src/elements/surface.rs
@@ -16,13 +16,20 @@ pub enum SurfaceSource {
     Surface(CVPixelBuffer),
     /// A GPU texture handle (type-erased to avoid depending on wgpu)
     #[cfg(any(
+        target_family = "wasm",
         target_os = "linux",
         target_os = "freebsd",
         all(target_os = "windows", feature = "wgpu-surfaces")
     ))]
     Texture {
         /// The GPU texture, type-erased (expected to be `Arc<wgpu::Texture>`)
+        #[cfg(not(target_family = "wasm"))]
         texture: std::sync::Arc<dyn std::any::Any + Send + Sync>,
+        /// The GPU texture, type-erased (expected to be `Arc<wgpu::Texture>`).
+        ///
+        /// WGPU handles are intentionally thread-local in browser builds.
+        #[cfg(target_family = "wasm")]
+        texture: std::sync::Arc<dyn std::any::Any>,
         /// Dimensions of the texture in device pixels
         size: Size<DevicePixels>,
     },
@@ -40,6 +47,7 @@ impl std::fmt::Debug for SurfaceSource {
             #[cfg(target_os = "macos")]
             SurfaceSource::Surface(ref buf) => _f.debug_tuple("Surface").field(buf).finish(),
             #[cfg(any(
+                target_family = "wasm",
                 target_os = "linux",
                 target_os = "freebsd",
                 all(target_os = "windows", feature = "wgpu-surfaces")
@@ -63,6 +71,7 @@ impl SurfaceSource {
                 crate::size(buffer.get_width().into(), buffer.get_height().into())
             }
             #[cfg(any(
+                target_family = "wasm",
                 target_os = "linux",
                 target_os = "freebsd",
                 all(target_os = "windows", feature = "wgpu-surfaces")

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -997,12 +997,7 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     /// Returns typed backend-specific GPU context information for custom
     /// controls. The value is intentionally type-erased in this crate so the
     /// core UI crate does not depend on a rendering backend.
-    #[cfg(any(
-        target_family = "wasm",
-        target_os = "linux",
-        target_os = "freebsd",
-        all(target_os = "windows", feature = "wgpu-surfaces")
-    ))]
+    #[cfg(any(target_family = "wasm", target_os = "linux", target_os = "freebsd"))]
     fn gpu_context_info(&self) -> Option<Box<dyn std::any::Any>> {
         None
     }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -994,6 +994,18 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
         None
     }
 
+    /// Returns typed backend-specific GPU context information for custom
+    /// controls. The value is intentionally type-erased in this crate so the
+    /// core UI crate does not depend on a rendering backend.
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        all(target_os = "windows", feature = "wgpu-surfaces")
+    ))]
+    fn gpu_context_info(&self) -> Option<Box<dyn std::any::Any>> {
+        None
+    }
+
     /// Whether this window's GPU device has been lost (the platform renderer
     /// recovers it on a subsequent draw). `None` when the backend cannot
     /// know. Safe to call mid-recovery, unlike `gpu_context`. Embedders that

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -998,6 +998,7 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     /// controls. The value is intentionally type-erased in this crate so the
     /// core UI crate does not depend on a rendering backend.
     #[cfg(any(
+        target_family = "wasm",
         target_os = "linux",
         target_os = "freebsd",
         all(target_os = "windows", feature = "wgpu-surfaces")

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -68,6 +68,7 @@ pub struct Scene {
     pub subpixel_sprites: Vec<SubpixelSprite>,
     pub polychrome_sprites: Vec<PolychromeSprite>,
     pub surfaces: Vec<PaintSurface>,
+    surface_opacities: Vec<f32>,
     pub backdrop_filters: Vec<BackdropFilter>,
     pub filter_boundaries: Vec<FilterBoundary>,
     render_plan: ScenePlan,
@@ -88,6 +89,7 @@ impl Scene {
         self.subpixel_sprites.clear();
         self.polychrome_sprites.clear();
         self.surfaces.clear();
+        self.surface_opacities.clear();
         self.backdrop_filters.clear();
         self.filter_boundaries.clear();
         self.render_plan.clear();
@@ -123,8 +125,19 @@ impl Scene {
     }
 
     pub fn insert_primitive(&mut self, primitive: impl Into<Primitive>) {
+        self.insert_primitive_with_surface_opacity(primitive.into(), None);
+    }
+
+    pub(crate) fn insert_surface(&mut self, surface: PaintSurface, opacity: f32) {
+        self.insert_primitive_with_surface_opacity(Primitive::Surface(surface), Some(opacity));
+    }
+
+    fn insert_primitive_with_surface_opacity(
+        &mut self,
+        mut primitive: Primitive,
+        surface_opacity: Option<f32>,
+    ) {
         self.is_finished = false;
-        let mut primitive = primitive.into();
         let clipped_bounds = primitive
             .bounds()
             .intersect(&primitive.content_mask().bounds);
@@ -191,6 +204,7 @@ impl Scene {
             Primitive::Surface(surface) => {
                 surface.order = order;
                 self.surfaces.push(surface.clone());
+                self.surface_opacities.push(surface_opacity.unwrap_or(1.0));
             }
             Primitive::BackdropFilter(filter) => {
                 filter.order = order;
@@ -209,14 +223,24 @@ impl Scene {
                 self.filter_boundaries.push(boundary.clone());
             }
         }
-        self.paint_operations
-            .push(PaintOperation::Primitive(primitive));
+        if let (Primitive::Surface(surface), Some(opacity)) = (&primitive, surface_opacity) {
+            self.paint_operations.push(PaintOperation::Surface {
+                surface: surface.clone(),
+                opacity,
+            });
+        } else {
+            self.paint_operations
+                .push(PaintOperation::Primitive(primitive));
+        }
     }
 
     pub fn replay(&mut self, range: Range<usize>, prev_scene: &Scene) {
         for operation in &prev_scene.paint_operations[range] {
             match operation {
                 PaintOperation::Primitive(primitive) => self.insert_primitive(primitive.clone()),
+                PaintOperation::Surface { surface, opacity } => {
+                    self.insert_surface(surface.clone(), *opacity)
+                }
                 PaintOperation::StartLayer(bounds) => self.push_layer(*bounds),
                 PaintOperation::EndLayer => self.pop_layer(),
             }
@@ -234,7 +258,19 @@ impl Scene {
             .sort_by_key(|sprite| (sprite.order, sprite.tile.tile_id));
         self.polychrome_sprites
             .sort_by_key(|sprite| (sprite.order, sprite.tile.tile_id));
-        self.surfaces.sort_by_key(|surface| surface.order);
+        let surfaces = std::mem::take(&mut self.surfaces);
+        let mut surface_opacities = std::mem::take(&mut self.surface_opacities);
+        surface_opacities.resize(surfaces.len(), 1.0);
+        surface_opacities.truncate(surfaces.len());
+        let mut surfaces_with_opacity = surfaces
+            .into_iter()
+            .zip(surface_opacities)
+            .collect::<Vec<_>>();
+        surfaces_with_opacity.sort_by_key(|(surface, _)| surface.order);
+        let (surfaces, surface_opacities): (Vec<_>, Vec<_>) =
+            surfaces_with_opacity.into_iter().unzip();
+        self.surfaces = surfaces;
+        self.surface_opacities = surface_opacities;
         self.backdrop_filters.sort_by_key(|filter| filter.order);
         // Markers normally get distinct, monotonically-increasing orders (children overlap
         // their group bounds and so sort strictly between the start and end). The `!is_start`
@@ -284,6 +320,13 @@ impl Scene {
         );
         self.render_plan.assert_matches(self);
         &self.render_plan
+    }
+
+    /// Returns the opacity associated with each surface in [`Self::surfaces`].
+    ///
+    /// Entries created through [`Self::insert_primitive`] default to fully opaque.
+    pub fn surface_opacities(&self) -> &[f32] {
+        &self.surface_opacities
     }
 
     /// Whether rendering needs an offscreen scene target for backdrop or content filters.
@@ -350,6 +393,7 @@ pub(crate) enum PrimitiveKind {
 
 pub(crate) enum PaintOperation {
     Primitive(Primitive),
+    Surface { surface: PaintSurface, opacity: f32 },
     StartLayer(Bounds<ScaledPixels>),
     EndLayer,
 }
@@ -1031,7 +1075,6 @@ pub struct PaintSurface {
     pub order: DrawOrder,
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
-    pub opacity: f32,
     pub source: crate::SurfaceSource,
 }
 
@@ -1213,7 +1256,7 @@ impl PathVertex<Pixels> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Point, Size};
+    use crate::{Point, Size, SurfaceSource};
 
     fn sp(value: f32) -> ScaledPixels {
         ScaledPixels(value)
@@ -1291,6 +1334,15 @@ mod tests {
         }
     }
 
+    fn surface() -> PaintSurface {
+        PaintSurface {
+            order: 0,
+            bounds: full_bounds(),
+            content_mask: mask(),
+            source: SurfaceSource::Unsupported(Size::default()),
+        }
+    }
+
     fn batch_kinds(scene: &mut Scene) -> Vec<&'static str> {
         scene.finish();
         scene
@@ -1326,6 +1378,21 @@ mod tests {
             batch_kinds(&mut scene),
             vec!["quad", "start", "quad", "end"]
         );
+    }
+
+    #[test]
+    fn surface_opacity_is_preserved_without_changing_paint_surface_layout() {
+        let mut scene = Scene::default();
+        scene.insert_surface(surface(), 0.25);
+        scene.insert_primitive(surface());
+        scene.finish();
+
+        assert_eq!(scene.surface_opacities(), &[0.25, 1.0]);
+
+        let mut replay = Scene::default();
+        replay.replay(0..scene.paint_operations.len(), &scene);
+        replay.finish();
+        assert_eq!(replay.surface_opacities(), &[0.25, 1.0]);
     }
 
     // Note: this validates only the *scene ordering* of nested filter boundaries (start/child/

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -1031,6 +1031,7 @@ pub struct PaintSurface {
     pub order: DrawOrder,
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
+    pub opacity: f32,
     pub source: crate::SurfaceSource,
 }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4792,13 +4792,15 @@ impl Window {
 
         let bounds = self.snap_bounds(bounds);
         let content_mask = self.snapped_content_mask();
-        self.next_frame.scene.insert_primitive(PaintSurface {
-            order: 0,
-            bounds,
-            content_mask,
-            opacity: self.element_opacity(),
-            source: source.into(),
-        });
+        self.next_frame.scene.insert_surface(
+            PaintSurface {
+                order: 0,
+                bounds,
+                content_mask,
+                source: source.into(),
+            },
+            self.element_opacity(),
+        );
     }
 
     /// Removes an image from the sprite atlas.
@@ -6420,12 +6422,7 @@ impl Window {
     /// Returns backend-specific typed GPU context information for custom
     /// controls. Use the rendering backend's context type to downcast the
     /// returned value.
-    #[cfg(any(
-        target_family = "wasm",
-        target_os = "linux",
-        target_os = "freebsd",
-        all(target_os = "windows", feature = "wgpu-surfaces")
-    ))]
+    #[cfg(any(target_family = "wasm", target_os = "linux", target_os = "freebsd"))]
     pub fn gpu_context_info(&self) -> Option<Box<dyn std::any::Any>> {
         self.platform_window.gpu_context_info()
     }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4796,6 +4796,7 @@ impl Window {
             order: 0,
             bounds,
             content_mask,
+            opacity: self.element_opacity(),
             source: source.into(),
         });
     }
@@ -6414,6 +6415,18 @@ impl Window {
     #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "windows"))]
     pub fn gpu_context(&self) -> Option<Box<dyn std::any::Any>> {
         self.platform_window.gpu_context()
+    }
+
+    /// Returns backend-specific typed GPU context information for custom
+    /// controls. Use the rendering backend's context type to downcast the
+    /// returned value.
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        all(target_os = "windows", feature = "wgpu-surfaces")
+    ))]
+    pub fn gpu_context_info(&self) -> Option<Box<dyn std::any::Any>> {
+        self.platform_window.gpu_context_info()
     }
 
     /// Whether the GPU device backing this window has been lost (recovery

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -6421,6 +6421,7 @@ impl Window {
     /// controls. Use the rendering backend's context type to downcast the
     /// returned value.
     #[cfg(any(
+        target_family = "wasm",
         target_os = "linux",
         target_os = "freebsd",
         all(target_os = "windows", feature = "wgpu-surfaces")

--- a/crates/gpui_apple/src/metal_renderer.rs
+++ b/crates/gpui_apple/src/metal_renderer.rs
@@ -977,6 +977,7 @@ impl MetalRenderer {
                 }
                 RenderCommand::Batch(PrimitiveBatch::Surfaces(range)) => self.draw_surfaces(
                     &scene.surfaces[range.clone()],
+                    &scene.surface_opacities()[range.clone()],
                     &scene_uniforms,
                     command_encoder,
                 ),
@@ -1717,6 +1718,7 @@ impl MetalRenderer {
     fn draw_surfaces(
         &mut self,
         surfaces: &[PaintSurface],
+        opacities: &[f32],
         scene_uniforms: &SceneUniforms,
         command_encoder: &metal::RenderCommandEncoderRef,
     ) -> bool {
@@ -1724,7 +1726,7 @@ impl MetalRenderer {
         bind_scene_uniforms(command_encoder, scene_uniforms);
         command_encoder.set_fragment_sampler_state(SAMPLER_SLOT, Some(&self.sampler));
 
-        for surface in surfaces {
+        for (index, surface) in surfaces.iter().enumerate() {
             let image_buffer = match &surface.source {
                 SurfaceSource::Surface(image_buffer) => image_buffer,
                 SurfaceSource::Unsupported(size) => {
@@ -1765,7 +1767,7 @@ impl MetalRenderer {
                 bounds: surface.bounds.into(),
                 content_mask: surface.content_mask.bounds.into(),
                 color_format: SurfaceColorFormat::Yuv,
-                opacity: surface.opacity,
+                opacity: opacities.get(index).copied().unwrap_or(1.0),
                 padding0: 0,
                 padding1: 0,
                 padding2: 0,

--- a/crates/gpui_apple/src/metal_renderer.rs
+++ b/crates/gpui_apple/src/metal_renderer.rs
@@ -1769,6 +1769,7 @@ impl MetalRenderer {
                 padding0: 0,
                 padding1: 0,
                 padding2: 0,
+                padding3: 0,
             };
             command_encoder.set_vertex_bytes(
                 DATA_SLOT,

--- a/crates/gpui_apple/src/metal_renderer.rs
+++ b/crates/gpui_apple/src/metal_renderer.rs
@@ -1765,6 +1765,7 @@ impl MetalRenderer {
                 bounds: surface.bounds.into(),
                 content_mask: surface.content_mask.bounds.into(),
                 color_format: SurfaceColorFormat::Yuv,
+                opacity: surface.opacity,
                 padding0: 0,
                 padding1: 0,
                 padding2: 0,

--- a/crates/gpui_apple/src/metal_renderer.rs
+++ b/crates/gpui_apple/src/metal_renderer.rs
@@ -1770,6 +1770,8 @@ impl MetalRenderer {
                 padding1: 0,
                 padding2: 0,
                 padding3: 0,
+                padding4: 0,
+                padding5: 0,
             };
             command_encoder.set_vertex_bytes(
                 DATA_SLOT,

--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -2206,6 +2206,13 @@ impl PlatformWindow for WaylandWindow {
         Some(Box::new((device, queue)))
     }
 
+    fn gpu_context_info(&self) -> Option<Box<dyn std::any::Any>> {
+        self.borrow()
+            .renderer
+            .gpu_context_info()
+            .map(|context| Box::new(context) as Box<dyn std::any::Any>)
+    }
+
     fn gpu_device_lost(&self) -> Option<bool> {
         // Only loads an atomic flag — safe even mid-recovery, when
         // `gpu_context` would panic on the torn-down resources.

--- a/crates/gpui_linux/src/linux/x11/window.rs
+++ b/crates/gpui_linux/src/linux/x11/window.rs
@@ -1952,6 +1952,15 @@ impl PlatformWindow for X11Window {
         Some(Box::new((device, queue)))
     }
 
+    fn gpu_context_info(&self) -> Option<Box<dyn std::any::Any>> {
+        self.0
+            .state
+            .borrow()
+            .renderer
+            .gpu_context_info()
+            .map(|context| Box::new(context) as Box<dyn std::any::Any>)
+    }
+
     fn gpu_device_lost(&self) -> Option<bool> {
         // Only loads an atomic flag — safe even mid-recovery, when
         // `gpu_context` would panic on the torn-down resources.

--- a/crates/gpui_render/build.rs
+++ b/crates/gpui_render/build.rs
@@ -350,7 +350,13 @@ fn emit_downlevel_runtime(name: &str, base_source: &str, arrays: &[StorageArray]
     .unwrap();
     writeln!(
         runtime,
-        "@group(1) @binding({DOWNLEVEL_RANGE_BINDING}) var<uniform> DATA_RANGE: vec2<u32>;"
+        "struct DataRange {{
+    base_texel: u32,
+    element_count: u32,
+    padding0: u32,
+    padding1: u32,
+}}
+@group(1) @binding({DOWNLEVEL_RANGE_BINDING}) var<uniform> DATA_RANGE: DataRange;"
     )
     .unwrap();
     writeln!(
@@ -380,7 +386,7 @@ fn emit_downlevel_runtime(name: &str, base_source: &str, arrays: &[StorageArray]
         writeln!(
             runtime,
             "fn dl_load_{array_name}(i: u32) -> {type_name} {{
-    return dl_load_{type_name}_impl({array_name}_DATA, DATA_RANGE.x * 4u + i * {words}u);
+    return dl_load_{type_name}_impl({array_name}_DATA, DATA_RANGE.base_texel * 4u + i * {words}u);
 }}",
             array_name = array.name,
             type_name = array.element_type,

--- a/crates/gpui_render/src/shaders/filters.rs
+++ b/crates/gpui_render/src/shaders/filters.rs
@@ -9,6 +9,7 @@ pub mod surface {
         pub bounds: Bounds,
         pub content_mask: Bounds,
         pub color_format: SurfaceColorFormat,
+        pub opacity: f32,
         pub padding0: u32,
         pub padding1: u32,
         pub padding2: u32,
@@ -66,14 +67,14 @@ pub mod surface {
             return transparent();
         }
         if get!(SURFACE_LOCALS).color_format == SurfaceColorFormat::Yuv {
-            return sample_yuv_surface(input.texture_position);
+            return sample_yuv_surface(input.texture_position) * get!(SURFACE_LOCALS).opacity;
         }
         texture_sample_level(
             SURFACE_TEXTURE,
             SURFACE_SAMPLER,
             input.texture_position,
             0.0,
-        )
+        ) * get!(SURFACE_LOCALS).opacity
     }
 }
 

--- a/crates/gpui_render/src/shaders/filters.rs
+++ b/crates/gpui_render/src/shaders/filters.rs
@@ -13,6 +13,7 @@ pub mod surface {
         pub padding0: u32,
         pub padding1: u32,
         pub padding2: u32,
+        pub padding3: u32,
     }
     uniform!(group(1), binding(0), SURFACE_LOCALS: SurfaceUniforms);
     texture!(group(1), binding(1), SURFACE_TEXTURE: Texture2D<f32>);

--- a/crates/gpui_render/src/shaders/filters.rs
+++ b/crates/gpui_render/src/shaders/filters.rs
@@ -14,6 +14,8 @@ pub mod surface {
         pub padding1: u32,
         pub padding2: u32,
         pub padding3: u32,
+        pub padding4: u32,
+        pub padding5: u32,
     }
     uniform!(group(1), binding(0), SURFACE_LOCALS: SurfaceUniforms);
     texture!(group(1), binding(1), SURFACE_TEXTURE: Texture2D<f32>);

--- a/crates/gpui_render/src/shaders/interface.rs
+++ b/crates/gpui_render/src/shaders/interface.rs
@@ -200,9 +200,11 @@ pub const RENDER_BUFFER_LAYOUTS: &[gpui::SceneBufferLayout] = &[
         bounds,
         content_mask,
         color_format,
+        opacity,
         padding0,
         padding1,
-        padding2
+        padding2,
+        padding3
     ),
     render_layout!(
         super::blur::BlurUniforms,

--- a/crates/gpui_render/src/shaders/interface.rs
+++ b/crates/gpui_render/src/shaders/interface.rs
@@ -204,7 +204,9 @@ pub const RENDER_BUFFER_LAYOUTS: &[gpui::SceneBufferLayout] = &[
         padding0,
         padding1,
         padding2,
-        padding3
+        padding3,
+        padding4,
+        padding5
     ),
     render_layout!(
         super::blur::BlurUniforms,

--- a/crates/gpui_web/src/window.rs
+++ b/crates/gpui_web/src/window.rs
@@ -850,6 +850,15 @@ impl PlatformWindow for WebWindow {
         Some(self.inner.state.borrow().renderer.gpu_specs())
     }
 
+    fn gpu_context_info(&self) -> Option<Box<dyn std::any::Any>> {
+        self.inner
+            .state
+            .borrow()
+            .renderer
+            .gpu_context_info()
+            .map(|context| Box::new(context) as Box<dyn std::any::Any>)
+    }
+
     fn update_ime_position(&self, _bounds: Bounds<Pixels>) {}
 
     fn request_decorations(&self, _decorations: WindowDecorations) {}

--- a/crates/gpui_wgpu/Cargo.toml
+++ b/crates/gpui_wgpu/Cargo.toml
@@ -74,7 +74,10 @@ web-sys = { version = "0.3", features = ["HtmlCanvasElement"] }
 js-sys.workspace = true
 
 [dev-dependencies]
+bytemuck = { version = "1", features = ["derive"] }
 criterion.workspace = true
+env_logger.workspace = true
+gpui_platform = { workspace = true, features = ["font-kit", "wayland", "x11"] }
 naga = { version = "29.0.4", features = ["wgsl-in"] }
 
 [[bench]]

--- a/crates/gpui_wgpu/Cargo.toml
+++ b/crates/gpui_wgpu/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/gpui_wgpu.rs"
 default = []
 font-kit = ["dep:font-kit"]
 test-support = ["gpui/test-support", "dep:image"]
+custom-gpu = ["gpui/custom-gpu"]
 wgpu-surfaces = ["gpui/wgpu-surfaces"]
 
 [dependencies]
@@ -79,6 +80,10 @@ criterion.workspace = true
 env_logger.workspace = true
 gpui_platform = { workspace = true, features = ["font-kit", "wayland", "x11"] }
 naga = { version = "29.0.4", features = ["wgsl-in"] }
+
+[[example]]
+name = "custom_gpu"
+required-features = ["custom-gpu"]
 
 [[bench]]
 name = "layout_line"

--- a/crates/gpui_wgpu/examples/custom_gpu.rs
+++ b/crates/gpui_wgpu/examples/custom_gpu.rs
@@ -1,0 +1,331 @@
+//! A minimal custom GPU control.
+//!
+//! The control owns its buffers, pipeline, and offscreen target. GPUI owns the
+//! device and queue, so those resources are recreated after device loss.
+
+use std::borrow::Cow;
+
+use gpui::{
+    App, AppContext, Bounds, Context, ParentElement, Render, Styled, TitlebarOptions, Window,
+    WindowBounds, WindowOptions, div, px, size,
+};
+use gpui_ce_wgpu::{WgpuContextHandle, WgpuRenderTarget};
+use gpui_platform::application;
+use wgpu::util::DeviceExt;
+
+const SHADER: &str = r#"
+struct Uniforms {
+    time: f32,
+    aspect: f32,
+    pad: vec2<f32>,
+};
+
+@group(0) @binding(0)
+var<uniform> uniforms: Uniforms;
+
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+    @location(1) color: vec3<f32>,
+};
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) color: vec3<f32>,
+};
+
+@vertex
+fn vs_main(input: VertexInput) -> VertexOutput {
+    let angle = uniforms.time;
+    let rotation = mat2x2<f32>(
+        cos(angle), -sin(angle),
+        sin(angle), cos(angle),
+    );
+    let position = rotation * vec2<f32>(input.position.x / uniforms.aspect, input.position.y);
+
+    var output: VertexOutput;
+    output.position = vec4<f32>(position, 0.0, 1.0);
+    output.color = input.color;
+    return output;
+}
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    return vec4<f32>(input.color, 1.0);
+}
+"#;
+
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct Uniforms {
+    time: f32,
+    aspect: f32,
+    _pad: [f32; 2],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct Vertex {
+    position: [f32; 2],
+    color: [f32; 3],
+}
+
+const VERTICES: &[Vertex] = &[
+    Vertex {
+        position: [0.0, 0.75],
+        color: [1.0, 0.2, 0.2],
+    },
+    Vertex {
+        position: [-0.75, -0.5],
+        color: [0.2, 1.0, 0.2],
+    },
+    Vertex {
+        position: [0.75, -0.5],
+        color: [0.2, 0.4, 1.0],
+    },
+];
+
+struct CustomGpuControl {
+    context: Option<WgpuContextHandle>,
+    target: Option<WgpuRenderTarget>,
+    pipeline: Option<wgpu::RenderPipeline>,
+    bind_group: Option<wgpu::BindGroup>,
+    uniform_buffer: Option<wgpu::Buffer>,
+    vertex_buffer: Option<wgpu::Buffer>,
+    time: f32,
+}
+
+impl CustomGpuControl {
+    fn new(_window: &mut Window, _cx: &mut Context<Self>) -> Self {
+        Self {
+            context: None,
+            target: None,
+            pipeline: None,
+            bind_group: None,
+            uniform_buffer: None,
+            vertex_buffer: None,
+            time: 0.0,
+        }
+    }
+
+    fn clear_gpu_resources(&mut self) {
+        self.context = None;
+        self.target = None;
+        self.pipeline = None;
+        self.bind_group = None;
+        self.uniform_buffer = None;
+        self.vertex_buffer = None;
+    }
+
+    fn ensure_gpu_resources(&mut self, window: &Window, context: &WgpuContextHandle) {
+        let viewport = window.viewport_size();
+        let scale_factor = window.scale_factor();
+        let target_size = size(
+            gpui::DevicePixels((f32::from(viewport.width) * scale_factor).round() as i32),
+            gpui::DevicePixels((f32::from(viewport.height) * scale_factor).round() as i32),
+        );
+        let target_size = size(
+            target_size.width.max(gpui::DevicePixels(1)),
+            target_size.height.max(gpui::DevicePixels(1)),
+        );
+
+        if self
+            .target
+            .as_ref()
+            .is_none_or(|target| target.size() != target_size)
+        {
+            self.target = Some(WgpuRenderTarget::new(context, target_size));
+        }
+
+        if self.pipeline.is_some() {
+            return;
+        }
+
+        let device = context.device();
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("custom-gpu-shader"),
+            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(SHADER)),
+        });
+        let uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("custom-gpu-uniforms"),
+            size: std::mem::size_of::<Uniforms>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("custom-gpu-bind-group-layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+        });
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("custom-gpu-bind-group"),
+            layout: &bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniform_buffer.as_entire_binding(),
+            }],
+        });
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("custom-gpu-pipeline-layout"),
+            bind_group_layouts: &[Some(&bind_group_layout)],
+            immediate_size: 0,
+        });
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("custom-gpu-pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                compilation_options: Default::default(),
+                buffers: &[wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<Vertex>() as u64,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &[
+                        wgpu::VertexAttribute {
+                            format: wgpu::VertexFormat::Float32x2,
+                            offset: 0,
+                            shader_location: 0,
+                        },
+                        wgpu::VertexAttribute {
+                            format: wgpu::VertexFormat::Float32x3,
+                            offset: std::mem::size_of::<[f32; 2]>() as u64,
+                            shader_location: 1,
+                        },
+                    ],
+                }],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                compilation_options: Default::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: context.texture_format(),
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: Default::default(),
+            depth_stencil: None,
+            multisample: Default::default(),
+            multiview_mask: None,
+            cache: None,
+        });
+        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("custom-gpu-vertices"),
+            contents: bytemuck::cast_slice(VERTICES),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+
+        self.pipeline = Some(pipeline);
+        self.bind_group = Some(bind_group);
+        self.uniform_buffer = Some(uniform_buffer);
+        self.vertex_buffer = Some(vertex_buffer);
+    }
+
+    fn render_gpu(&mut self, window: &mut Window) {
+        let Some(context) = WgpuContextHandle::from_window(window) else {
+            self.clear_gpu_resources();
+            return;
+        };
+        if self
+            .context
+            .as_ref()
+            .is_some_and(|previous| !context.is_same_device(previous))
+        {
+            self.clear_gpu_resources();
+        }
+        if context.device_lost() {
+            self.clear_gpu_resources();
+            return;
+        }
+        self.context = Some(context.clone());
+
+        self.ensure_gpu_resources(window, &context);
+        self.time += 0.02;
+        let target = self.target.as_ref().unwrap();
+        let uniform_buffer = self.uniform_buffer.as_ref().unwrap();
+        let pipeline = self.pipeline.as_ref().unwrap();
+        let bind_group = self.bind_group.as_ref().unwrap();
+        let vertex_buffer = self.vertex_buffer.as_ref().unwrap();
+        let aspect = target.size().width.0 as f32 / target.size().height.0 as f32;
+        context.queue().write_buffer(
+            uniform_buffer,
+            0,
+            bytemuck::bytes_of(&Uniforms {
+                time: self.time,
+                aspect,
+                _pad: [0.0; 2],
+            }),
+        );
+
+        let mut encoder =
+            context
+                .device()
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("custom-gpu-encoder"),
+                });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("custom-gpu-pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: target.view(),
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                    depth_slice: None,
+                })],
+                depth_stencil_attachment: None,
+                ..Default::default()
+            });
+            pass.set_pipeline(pipeline);
+            pass.set_bind_group(0, bind_group, &[]);
+            pass.set_vertex_buffer(0, vertex_buffer.slice(..));
+            pass.draw(0..VERTICES.len() as u32, 0..1);
+        }
+        context.queue().submit([encoder.finish()]);
+    }
+}
+
+impl Render for CustomGpuControl {
+    fn render(&mut self, window: &mut Window, _cx: &mut Context<Self>) -> impl gpui::IntoElement {
+        window.request_animation_frame();
+        self.render_gpu(window);
+        let mut root = div().size_full();
+        if let Some(target) = self.target.as_ref() {
+            root = root.child(target.surface());
+        }
+        root
+    }
+}
+
+fn main() {
+    env_logger::init();
+    application().run(|cx: &mut App| {
+        cx.open_window(
+            WindowOptions {
+                titlebar: Some(TitlebarOptions {
+                    title: Some("Custom GPU rendering".into()),
+                    ..Default::default()
+                }),
+                window_bounds: Some(WindowBounds::Windowed(Bounds::centered(
+                    None,
+                    size(px(800.0), px(600.0)),
+                    cx,
+                ))),
+                ..Default::default()
+            },
+            |window, cx| cx.new(|cx| CustomGpuControl::new(window, cx)),
+        )
+        .unwrap();
+        cx.activate(true);
+    });
+}

--- a/crates/gpui_wgpu/examples/custom_gpu.rs
+++ b/crates/gpui_wgpu/examples/custom_gpu.rs
@@ -2,18 +2,22 @@
 //!
 //! The control owns its buffers, pipeline, and offscreen target. GPUI owns the
 //! device and queue, so those resources are recreated after device loss.
+//!
+//! Run with `--features custom-gpu` on supported targets.
 
-use std::borrow::Cow;
+#[cfg(any(target_family = "wasm", target_os = "linux", target_os = "freebsd"))]
+mod custom_gpu {
+    use std::borrow::Cow;
 
-use gpui::{
-    App, AppContext, Bounds, Context, ParentElement, Render, Styled, TitlebarOptions, Window,
-    WindowBounds, WindowOptions, div, px, size,
-};
-use gpui_ce_wgpu::{WgpuContextHandle, WgpuRenderTarget};
-use gpui_platform::application;
-use wgpu::util::DeviceExt;
+    use gpui::{
+        App, AppContext, Bounds, Context, ParentElement, Render, Styled, TitlebarOptions, Window,
+        WindowBounds, WindowOptions, div, px, size,
+    };
+    use gpui_ce_wgpu::{WgpuContextHandle, WgpuRenderTarget};
+    use gpui_platform::application;
+    use wgpu::util::DeviceExt;
 
-const SHADER: &str = r#"
+    const SHADER: &str = r#"
 struct Uniforms {
     time: f32,
     aspect: f32,
@@ -54,278 +58,294 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
 }
 "#;
 
-#[repr(C)]
-#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
-struct Uniforms {
-    time: f32,
-    aspect: f32,
-    _pad: [f32; 2],
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
-struct Vertex {
-    position: [f32; 2],
-    color: [f32; 3],
-}
-
-const VERTICES: &[Vertex] = &[
-    Vertex {
-        position: [0.0, 0.75],
-        color: [1.0, 0.2, 0.2],
-    },
-    Vertex {
-        position: [-0.75, -0.5],
-        color: [0.2, 1.0, 0.2],
-    },
-    Vertex {
-        position: [0.75, -0.5],
-        color: [0.2, 0.4, 1.0],
-    },
-];
-
-struct CustomGpuControl {
-    context: Option<WgpuContextHandle>,
-    target: Option<WgpuRenderTarget>,
-    pipeline: Option<wgpu::RenderPipeline>,
-    bind_group: Option<wgpu::BindGroup>,
-    uniform_buffer: Option<wgpu::Buffer>,
-    vertex_buffer: Option<wgpu::Buffer>,
-    time: f32,
-}
-
-impl CustomGpuControl {
-    fn new(_window: &mut Window, _cx: &mut Context<Self>) -> Self {
-        Self {
-            context: None,
-            target: None,
-            pipeline: None,
-            bind_group: None,
-            uniform_buffer: None,
-            vertex_buffer: None,
-            time: 0.0,
-        }
+    #[repr(C)]
+    #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+    struct Uniforms {
+        time: f32,
+        aspect: f32,
+        _pad: [f32; 2],
     }
 
-    fn clear_gpu_resources(&mut self) {
-        self.context = None;
-        self.target = None;
-        self.pipeline = None;
-        self.bind_group = None;
-        self.uniform_buffer = None;
-        self.vertex_buffer = None;
+    #[repr(C)]
+    #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+    struct Vertex {
+        position: [f32; 2],
+        color: [f32; 3],
     }
 
-    fn ensure_gpu_resources(&mut self, window: &Window, context: &WgpuContextHandle) {
-        let viewport = window.viewport_size();
-        let scale_factor = window.scale_factor();
-        let target_size = size(
-            gpui::DevicePixels((f32::from(viewport.width) * scale_factor).round() as i32),
-            gpui::DevicePixels((f32::from(viewport.height) * scale_factor).round() as i32),
-        );
-        let target_size = size(
-            target_size.width.max(gpui::DevicePixels(1)),
-            target_size.height.max(gpui::DevicePixels(1)),
-        );
+    const VERTICES: &[Vertex] = &[
+        Vertex {
+            position: [0.0, 0.75],
+            color: [1.0, 0.2, 0.2],
+        },
+        Vertex {
+            position: [-0.75, -0.5],
+            color: [0.2, 1.0, 0.2],
+        },
+        Vertex {
+            position: [0.75, -0.5],
+            color: [0.2, 0.4, 1.0],
+        },
+    ];
 
-        if self
-            .target
-            .as_ref()
-            .is_none_or(|target| target.size() != target_size)
-        {
-            self.target = Some(WgpuRenderTarget::new(context, target_size));
-        }
-
-        if self.pipeline.is_some() {
-            return;
-        }
-
-        let device = context.device();
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("custom-gpu-shader"),
-            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(SHADER)),
-        });
-        let uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("custom-gpu-uniforms"),
-            size: std::mem::size_of::<Uniforms>() as u64,
-            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("custom-gpu-bind-group-layout"),
-            entries: &[wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: false,
-                    min_binding_size: None,
-                },
-                count: None,
-            }],
-        });
-        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("custom-gpu-bind-group"),
-            layout: &bind_group_layout,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: uniform_buffer.as_entire_binding(),
-            }],
-        });
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("custom-gpu-pipeline-layout"),
-            bind_group_layouts: &[Some(&bind_group_layout)],
-            immediate_size: 0,
-        });
-        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("custom-gpu-pipeline"),
-            layout: Some(&pipeline_layout),
-            vertex: wgpu::VertexState {
-                module: &shader,
-                entry_point: Some("vs_main"),
-                compilation_options: Default::default(),
-                buffers: &[wgpu::VertexBufferLayout {
-                    array_stride: std::mem::size_of::<Vertex>() as u64,
-                    step_mode: wgpu::VertexStepMode::Vertex,
-                    attributes: &[
-                        wgpu::VertexAttribute {
-                            format: wgpu::VertexFormat::Float32x2,
-                            offset: 0,
-                            shader_location: 0,
-                        },
-                        wgpu::VertexAttribute {
-                            format: wgpu::VertexFormat::Float32x3,
-                            offset: std::mem::size_of::<[f32; 2]>() as u64,
-                            shader_location: 1,
-                        },
-                    ],
-                }],
-            },
-            fragment: Some(wgpu::FragmentState {
-                module: &shader,
-                entry_point: Some("fs_main"),
-                compilation_options: Default::default(),
-                targets: &[Some(wgpu::ColorTargetState {
-                    format: context.texture_format(),
-                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
-                    write_mask: wgpu::ColorWrites::ALL,
-                })],
-            }),
-            primitive: Default::default(),
-            depth_stencil: None,
-            multisample: Default::default(),
-            multiview_mask: None,
-            cache: None,
-        });
-        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("custom-gpu-vertices"),
-            contents: bytemuck::cast_slice(VERTICES),
-            usage: wgpu::BufferUsages::VERTEX,
-        });
-
-        self.pipeline = Some(pipeline);
-        self.bind_group = Some(bind_group);
-        self.uniform_buffer = Some(uniform_buffer);
-        self.vertex_buffer = Some(vertex_buffer);
+    struct CustomGpuControl {
+        context: Option<WgpuContextHandle>,
+        target: Option<WgpuRenderTarget>,
+        pipeline: Option<wgpu::RenderPipeline>,
+        bind_group: Option<wgpu::BindGroup>,
+        uniform_buffer: Option<wgpu::Buffer>,
+        vertex_buffer: Option<wgpu::Buffer>,
+        time: f32,
     }
 
-    fn render_gpu(&mut self, window: &mut Window) {
-        let Some(context) = WgpuContextHandle::from_window(window) else {
-            self.clear_gpu_resources();
-            return;
-        };
-        if self
-            .context
-            .as_ref()
-            .is_some_and(|previous| !context.is_same_device(previous))
-        {
-            self.clear_gpu_resources();
+    impl CustomGpuControl {
+        fn new(_window: &mut Window, _cx: &mut Context<Self>) -> Self {
+            Self {
+                context: None,
+                target: None,
+                pipeline: None,
+                bind_group: None,
+                uniform_buffer: None,
+                vertex_buffer: None,
+                time: 0.0,
+            }
         }
-        if context.device_lost() {
-            self.clear_gpu_resources();
-            return;
+
+        fn clear_gpu_resources(&mut self) {
+            self.context = None;
+            self.target = None;
+            self.pipeline = None;
+            self.bind_group = None;
+            self.uniform_buffer = None;
+            self.vertex_buffer = None;
         }
-        self.context = Some(context.clone());
 
-        self.ensure_gpu_resources(window, &context);
-        self.time += 0.02;
-        let target = self.target.as_ref().unwrap();
-        let uniform_buffer = self.uniform_buffer.as_ref().unwrap();
-        let pipeline = self.pipeline.as_ref().unwrap();
-        let bind_group = self.bind_group.as_ref().unwrap();
-        let vertex_buffer = self.vertex_buffer.as_ref().unwrap();
-        let aspect = target.size().width.0 as f32 / target.size().height.0 as f32;
-        context.queue().write_buffer(
-            uniform_buffer,
-            0,
-            bytemuck::bytes_of(&Uniforms {
-                time: self.time,
-                aspect,
-                _pad: [0.0; 2],
-            }),
-        );
+        fn ensure_gpu_resources(&mut self, window: &Window, context: &WgpuContextHandle) {
+            let viewport = window.viewport_size();
+            let scale_factor = window.scale_factor();
+            let target_size = size(
+                gpui::DevicePixels((f32::from(viewport.width) * scale_factor).round() as i32),
+                gpui::DevicePixels((f32::from(viewport.height) * scale_factor).round() as i32),
+            );
+            let target_size = size(
+                target_size.width.max(gpui::DevicePixels(1)),
+                target_size.height.max(gpui::DevicePixels(1)),
+            );
 
-        let mut encoder =
-            context
-                .device()
-                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                    label: Some("custom-gpu-encoder"),
-                });
-        {
-            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: Some("custom-gpu-pass"),
-                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: target.view(),
-                    resolve_target: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
-                        store: wgpu::StoreOp::Store,
-                    },
-                    depth_slice: None,
-                })],
-                depth_stencil_attachment: None,
-                ..Default::default()
+            if self
+                .target
+                .as_ref()
+                .is_none_or(|target| target.size() != target_size)
+            {
+                self.target = Some(WgpuRenderTarget::new(context, target_size));
+            }
+
+            if self.pipeline.is_some() {
+                return;
+            }
+
+            let device = context.device();
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("custom-gpu-shader"),
+                source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(SHADER)),
             });
-            pass.set_pipeline(pipeline);
-            pass.set_bind_group(0, bind_group, &[]);
-            pass.set_vertex_buffer(0, vertex_buffer.slice(..));
-            pass.draw(0..VERTICES.len() as u32, 0..1);
-        }
-        context.queue().submit([encoder.finish()]);
-    }
-}
-
-impl Render for CustomGpuControl {
-    fn render(&mut self, window: &mut Window, _cx: &mut Context<Self>) -> impl gpui::IntoElement {
-        window.request_animation_frame();
-        self.render_gpu(window);
-        let mut root = div().size_full();
-        if let Some(target) = self.target.as_ref() {
-            root = root.child(target.surface());
-        }
-        root
-    }
-}
-
-fn main() {
-    env_logger::init();
-    application().run(|cx: &mut App| {
-        cx.open_window(
-            WindowOptions {
-                titlebar: Some(TitlebarOptions {
-                    title: Some("Custom GPU rendering".into()),
-                    ..Default::default()
+            let uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("custom-gpu-uniforms"),
+                size: std::mem::size_of::<Uniforms>() as u64,
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+            let bind_group_layout =
+                device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("custom-gpu-bind-group-layout"),
+                    entries: &[wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::VERTEX,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    }],
+                });
+            let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("custom-gpu-bind-group"),
+                layout: &bind_group_layout,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: uniform_buffer.as_entire_binding(),
+                }],
+            });
+            let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("custom-gpu-pipeline-layout"),
+                bind_group_layouts: &[Some(&bind_group_layout)],
+                immediate_size: 0,
+            });
+            let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("custom-gpu-pipeline"),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: Some("vs_main"),
+                    compilation_options: Default::default(),
+                    buffers: &[wgpu::VertexBufferLayout {
+                        array_stride: std::mem::size_of::<Vertex>() as u64,
+                        step_mode: wgpu::VertexStepMode::Vertex,
+                        attributes: &[
+                            wgpu::VertexAttribute {
+                                format: wgpu::VertexFormat::Float32x2,
+                                offset: 0,
+                                shader_location: 0,
+                            },
+                            wgpu::VertexAttribute {
+                                format: wgpu::VertexFormat::Float32x3,
+                                offset: std::mem::size_of::<[f32; 2]>() as u64,
+                                shader_location: 1,
+                            },
+                        ],
+                    }],
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: Some("fs_main"),
+                    compilation_options: Default::default(),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: context.texture_format(),
+                        blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
                 }),
-                window_bounds: Some(WindowBounds::Windowed(Bounds::centered(
-                    None,
-                    size(px(800.0), px(600.0)),
-                    cx,
-                ))),
-                ..Default::default()
-            },
-            |window, cx| cx.new(|cx| CustomGpuControl::new(window, cx)),
-        )
-        .unwrap();
-        cx.activate(true);
-    });
+                primitive: Default::default(),
+                depth_stencil: None,
+                multisample: Default::default(),
+                multiview_mask: None,
+                cache: None,
+            });
+            let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("custom-gpu-vertices"),
+                contents: bytemuck::cast_slice(VERTICES),
+                usage: wgpu::BufferUsages::VERTEX,
+            });
+
+            self.pipeline = Some(pipeline);
+            self.bind_group = Some(bind_group);
+            self.uniform_buffer = Some(uniform_buffer);
+            self.vertex_buffer = Some(vertex_buffer);
+        }
+
+        fn render_gpu(&mut self, window: &mut Window) {
+            let Some(context) = WgpuContextHandle::from_window(window) else {
+                self.clear_gpu_resources();
+                return;
+            };
+            if self
+                .context
+                .as_ref()
+                .is_some_and(|previous| !context.is_same_device(previous))
+            {
+                self.clear_gpu_resources();
+            }
+            if context.device_lost() {
+                self.clear_gpu_resources();
+                return;
+            }
+            self.context = Some(context.clone());
+
+            self.ensure_gpu_resources(window, &context);
+            self.time += 0.02;
+            let target = self.target.as_ref().unwrap();
+            let uniform_buffer = self.uniform_buffer.as_ref().unwrap();
+            let pipeline = self.pipeline.as_ref().unwrap();
+            let bind_group = self.bind_group.as_ref().unwrap();
+            let vertex_buffer = self.vertex_buffer.as_ref().unwrap();
+            let aspect = target.size().width.0 as f32 / target.size().height.0 as f32;
+            context.queue().write_buffer(
+                uniform_buffer,
+                0,
+                bytemuck::bytes_of(&Uniforms {
+                    time: self.time,
+                    aspect,
+                    _pad: [0.0; 2],
+                }),
+            );
+
+            let mut encoder =
+                context
+                    .device()
+                    .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                        label: Some("custom-gpu-encoder"),
+                    });
+            {
+                let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("custom-gpu-pass"),
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: target.view(),
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                            store: wgpu::StoreOp::Store,
+                        },
+                        depth_slice: None,
+                    })],
+                    depth_stencil_attachment: None,
+                    ..Default::default()
+                });
+                pass.set_pipeline(pipeline);
+                pass.set_bind_group(0, bind_group, &[]);
+                pass.set_vertex_buffer(0, vertex_buffer.slice(..));
+                pass.draw(0..VERTICES.len() as u32, 0..1);
+            }
+            context.queue().submit([encoder.finish()]);
+        }
+    }
+
+    impl Render for CustomGpuControl {
+        fn render(
+            &mut self,
+            window: &mut Window,
+            _cx: &mut Context<Self>,
+        ) -> impl gpui::IntoElement {
+            window.request_animation_frame();
+            self.render_gpu(window);
+            let mut root = div().size_full();
+            if let Some(target) = self.target.as_ref() {
+                root = root.child(target.surface());
+            }
+            root
+        }
+    }
+
+    pub fn run() {
+        env_logger::init();
+        application().run(|cx: &mut App| {
+            cx.open_window(
+                WindowOptions {
+                    titlebar: Some(TitlebarOptions {
+                        title: Some("Custom GPU rendering".into()),
+                        ..Default::default()
+                    }),
+                    window_bounds: Some(WindowBounds::Windowed(Bounds::centered(
+                        None,
+                        size(px(800.0), px(600.0)),
+                        cx,
+                    ))),
+                    ..Default::default()
+                },
+                |window, cx| cx.new(|cx| CustomGpuControl::new(window, cx)),
+            )
+            .unwrap();
+            cx.activate(true);
+        });
+    }
+}
+
+#[cfg(any(target_family = "wasm", target_os = "linux", target_os = "freebsd"))]
+fn main() {
+    custom_gpu::run();
+}
+
+#[cfg(not(any(target_family = "wasm", target_os = "linux", target_os = "freebsd")))]
+fn main() {
+    eprintln!("custom_gpu is supported on Linux, FreeBSD, and WASM targets only");
 }

--- a/crates/gpui_wgpu/src/wgpu_context.rs
+++ b/crates/gpui_wgpu/src/wgpu_context.rs
@@ -248,6 +248,212 @@ pub struct CompositorGpuHint {
     pub device_id: u32,
 }
 
+/// A typed view of the GPU resources shared with GPUI.
+///
+/// The device and queue are owned by GPUI and remain valid until
+/// [`Self::device_lost`] returns `true`. A control should drop its GPU
+/// resources and reacquire this handle after recovery.
+#[derive(Clone)]
+pub struct WgpuContextHandle {
+    device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
+    texture_format: wgpu::TextureFormat,
+    adapter_info: wgpu::AdapterInfo,
+    backend: WgpuBackend,
+    features: wgpu::Features,
+    limits: wgpu::Limits,
+    device_lost: Arc<AtomicBool>,
+}
+
+impl WgpuContextHandle {
+    pub(crate) fn from_resources(
+        device: Arc<wgpu::Device>,
+        queue: Arc<wgpu::Queue>,
+        texture_format: wgpu::TextureFormat,
+        adapter_info: wgpu::AdapterInfo,
+        backend: WgpuBackend,
+        device_lost: Arc<AtomicBool>,
+    ) -> Self {
+        let features = device.features();
+        let limits = device.limits();
+        Self {
+            device,
+            queue,
+            texture_format,
+            adapter_info,
+            backend,
+            features,
+            limits,
+            device_lost,
+        }
+    }
+
+    /// Returns the shared device.
+    pub fn device(&self) -> &wgpu::Device {
+        &self.device
+    }
+
+    /// Returns the shared queue.
+    pub fn queue(&self) -> &wgpu::Queue {
+        &self.queue
+    }
+
+    /// Returns whether two handles refer to the same device instance.
+    pub fn is_same_device(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.device, &other.device)
+    }
+
+    /// Returns the texture format used by GPUI's window surface.
+    pub fn texture_format(&self) -> wgpu::TextureFormat {
+        self.texture_format
+    }
+
+    /// Returns information about the selected adapter.
+    pub fn adapter_info(&self) -> &wgpu::AdapterInfo {
+        &self.adapter_info
+    }
+
+    /// Returns the backend selected for this window.
+    pub fn backend(&self) -> WgpuBackend {
+        self.backend
+    }
+
+    /// Returns the features enabled on the shared device.
+    pub fn features(&self) -> wgpu::Features {
+        self.features
+    }
+
+    /// Returns the limits used when creating the shared device.
+    pub fn limits(&self) -> &wgpu::Limits {
+        &self.limits
+    }
+
+    /// Returns whether the device has been lost and custom resources must be
+    /// recreated after GPUI recovers.
+    pub fn device_lost(&self) -> bool {
+        self.device_lost.load(Ordering::Relaxed)
+    }
+
+    /// Returns the typed wgpu context associated with a GPUI window.
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        all(target_os = "windows", feature = "wgpu-surfaces")
+    ))]
+    pub fn from_window(window: &gpui::Window) -> Option<Self> {
+        window
+            .gpu_context_info()?
+            .downcast::<Self>()
+            .ok()
+            .map(|context| *context)
+    }
+}
+
+/// A reusable offscreen render target suitable for [`gpui::Window::paint_surface`].
+pub struct WgpuRenderTarget {
+    texture: Arc<wgpu::Texture>,
+    view: wgpu::TextureView,
+    size: gpui::Size<gpui::DevicePixels>,
+    format: wgpu::TextureFormat,
+}
+
+impl WgpuRenderTarget {
+    /// Creates a render target using GPUI's surface format.
+    pub fn new(context: &WgpuContextHandle, size: gpui::Size<gpui::DevicePixels>) -> Self {
+        Self::with_format(context, size, context.texture_format())
+    }
+
+    /// Creates a render target with an explicit texture format.
+    pub fn with_format(
+        context: &WgpuContextHandle,
+        size: gpui::Size<gpui::DevicePixels>,
+        format: wgpu::TextureFormat,
+    ) -> Self {
+        let size = normalize_target_size(size);
+        let texture = create_render_target_texture(context.device(), size, format);
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        Self {
+            texture: Arc::new(texture),
+            view,
+            size,
+            format,
+        }
+    }
+
+    /// Resizes the target, preserving its texture format.
+    pub fn resize(&mut self, context: &WgpuContextHandle, size: gpui::Size<gpui::DevicePixels>) {
+        let size = normalize_target_size(size);
+        if self.size == size {
+            return;
+        }
+        let texture = create_render_target_texture(context.device(), size, self.format);
+        self.view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        self.texture = Arc::new(texture);
+        self.size = size;
+    }
+
+    /// Returns the target texture for use as a GPUI surface.
+    pub fn texture(&self) -> Arc<wgpu::Texture> {
+        Arc::clone(&self.texture)
+    }
+
+    /// Creates a GPUI element that composites this target at its layout bounds.
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        all(target_os = "windows", feature = "wgpu-surfaces")
+    ))]
+    pub fn surface(&self) -> gpui::Surface {
+        gpui::surface(gpui::SurfaceSource::Texture {
+            texture: self.texture(),
+            size: self.size,
+        })
+    }
+
+    /// Returns the target texture view for rendering.
+    pub fn view(&self) -> &wgpu::TextureView {
+        &self.view
+    }
+
+    /// Returns the target dimensions in device pixels.
+    pub fn size(&self) -> gpui::Size<gpui::DevicePixels> {
+        self.size
+    }
+
+    /// Returns the target texture format.
+    pub fn format(&self) -> wgpu::TextureFormat {
+        self.format
+    }
+}
+
+fn normalize_target_size(size: gpui::Size<gpui::DevicePixels>) -> gpui::Size<gpui::DevicePixels> {
+    gpui::size(
+        gpui::DevicePixels(size.width.0.max(1)),
+        gpui::DevicePixels(size.height.0.max(1)),
+    )
+}
+
+fn create_render_target_texture(
+    device: &wgpu::Device,
+    size: gpui::Size<gpui::DevicePixels>,
+    format: wgpu::TextureFormat,
+) -> wgpu::Texture {
+    device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("gpui-custom-render-target"),
+        size: wgpu::Extent3d {
+            width: size.width.0 as u32,
+            height: size.height.0 as u32,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+        view_formats: &[],
+    })
+}
+
 /// Extra wgpu features and limits that an application can request on top of
 /// gpui's baseline.  Pass an instance to the platform via
 /// [`gpui::App::set_gpu_requirements`] *before* opening any windows.
@@ -263,6 +469,17 @@ pub struct WgpuDeviceRequirements {
 }
 
 impl WgpuContext {
+    pub(crate) fn handle(&self, texture_format: wgpu::TextureFormat) -> WgpuContextHandle {
+        WgpuContextHandle::from_resources(
+            Arc::clone(&self.device),
+            Arc::clone(&self.queue),
+            texture_format,
+            self.adapter.get_info(),
+            self.backend,
+            Arc::clone(&self.device_lost),
+        )
+    }
+
     /// Creates a native device without a presentation surface.
     #[cfg(not(target_family = "wasm"))]
     pub fn new_headless(

--- a/crates/gpui_wgpu/src/wgpu_context.rs
+++ b/crates/gpui_wgpu/src/wgpu_context.rs
@@ -336,6 +336,7 @@ impl WgpuContextHandle {
 
     /// Returns the typed wgpu context associated with a GPUI window.
     #[cfg(any(
+        target_family = "wasm",
         target_os = "linux",
         target_os = "freebsd",
         all(target_os = "windows", feature = "wgpu-surfaces")
@@ -399,6 +400,7 @@ impl WgpuRenderTarget {
 
     /// Creates a GPUI element that composites this target at its layout bounds.
     #[cfg(any(
+        target_family = "wasm",
         target_os = "linux",
         target_os = "freebsd",
         all(target_os = "windows", feature = "wgpu-surfaces")

--- a/crates/gpui_wgpu/src/wgpu_context.rs
+++ b/crates/gpui_wgpu/src/wgpu_context.rs
@@ -336,10 +336,9 @@ impl WgpuContextHandle {
 
     /// Returns the typed wgpu context associated with a GPUI window.
     #[cfg(any(
-        target_family = "wasm",
         target_os = "linux",
         target_os = "freebsd",
-        all(target_os = "windows", feature = "wgpu-surfaces")
+        all(target_family = "wasm", feature = "custom-gpu")
     ))]
     pub fn from_window(window: &gpui::Window) -> Option<Self> {
         window
@@ -400,10 +399,9 @@ impl WgpuRenderTarget {
 
     /// Creates a GPUI element that composites this target at its layout bounds.
     #[cfg(any(
-        target_family = "wasm",
         target_os = "linux",
         target_os = "freebsd",
-        all(target_os = "windows", feature = "wgpu-surfaces")
+        all(target_family = "wasm", feature = "custom-gpu")
     ))]
     pub fn surface(&self) -> gpui::Surface {
         gpui::surface(gpui::SurfaceSource::Texture {

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -232,6 +232,7 @@ impl WgpuRenderer {
                 self.target.format(),
                 self.adapter_info.clone(),
                 match self.adapter_info.backend {
+                    wgpu::Backend::BrowserWebGpu => crate::WgpuBackend::BrowserWebGpu,
                     wgpu::Backend::Gl => crate::WgpuBackend::Gl,
                     backend => crate::WgpuBackend::Native(backend),
                 },

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -1,4 +1,4 @@
-use crate::{CompositorGpuHint, WgpuAtlas, WgpuContext, WgpuDeviceRequirements};
+use crate::{CompositorGpuHint, WgpuAtlas, WgpuContext, WgpuContextHandle, WgpuDeviceRequirements};
 use gpui::{DevicePixels, GpuSpecs, Scene, Size};
 
 #[cfg(test)]
@@ -214,6 +214,30 @@ impl WgpuRenderer {
     pub fn gpu_context(&self) -> (Arc<wgpu::Device>, Arc<wgpu::Queue>) {
         let resources = self.resources();
         (resources.device.clone(), resources.queue.clone())
+    }
+
+    pub fn gpu_context_info(&self) -> Option<WgpuContextHandle> {
+        if let Some(context) = self.context.as_ref().and_then(|context| {
+            context
+                .borrow()
+                .as_ref()
+                .map(|context| context.handle(self.target.format()))
+        }) {
+            return Some(context);
+        }
+        self.resources.as_ref().map(|resources| {
+            WgpuContextHandle::from_resources(
+                resources.device.clone(),
+                resources.queue.clone(),
+                self.target.format(),
+                self.adapter_info.clone(),
+                match self.adapter_info.backend {
+                    wgpu::Backend::Gl => crate::WgpuBackend::Gl,
+                    backend => crate::WgpuBackend::Native(backend),
+                },
+                self.faults.device_lost.clone(),
+            )
+        })
     }
 
     pub fn gpu_specs(&self) -> GpuSpecs {

--- a/crates/gpui_wgpu/src/wgpu_renderer/buffers.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/buffers.rs
@@ -217,6 +217,9 @@ impl InstanceUpload {
 }
 
 /// Mapped per-batch `DATA_RANGE` slots: batch base in texels plus element count.
+///
+/// The shader reads only the first two fields, but browser/WebGL downlevel
+/// backends require uniform binding sizes to be 16-byte aligned.
 struct RangeUpload {
     staging: wgpu::QueueWriteBufferView,
     stride: u64,
@@ -232,11 +235,11 @@ impl RangeUpload {
         }
         self.next_slot += 1;
         let offset = slot * self.stride;
-        let mut bytes = [0u8; 8];
+        let mut bytes = [0u8; 16];
         bytes[..4].copy_from_slice(&base_texel.to_le_bytes());
-        bytes[4..].copy_from_slice(&elements.to_le_bytes());
+        bytes[4..8].copy_from_slice(&elements.to_le_bytes());
         self.staging
-            .slice(offset as usize..(offset + 8) as usize)
+            .slice(offset as usize..(offset + 16) as usize)
             .copy_from_slice(&bytes);
         u32::try_from(offset).ok()
     }

--- a/crates/gpui_wgpu/src/wgpu_renderer/frame.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/frame.rs
@@ -605,9 +605,11 @@ fn encode_inline_batch(
                 instances,
                 pass,
             ),
-        PrimitiveBatch::Surfaces(range) => {
-            renderer.draw_surfaces(&scene.surfaces[range.clone()], pass)
-        }
+        PrimitiveBatch::Surfaces(range) => renderer.draw_surfaces(
+            &scene.surfaces[range.clone()],
+            &scene.surface_opacities()[range.clone()],
+            pass,
+        ),
         PrimitiveBatch::Paths { .. }
         | PrimitiveBatch::BackdropFilters(_)
         | PrimitiveBatch::FilterBoundary(_) => {

--- a/crates/gpui_wgpu/src/wgpu_renderer/pipelines.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/pipelines.rs
@@ -59,7 +59,7 @@ pub(super) struct WgpuPipelines {
     pub(super) polychrome_sprites: WgpuRenderPipeline,
     #[cfg_attr(
         not(any(
-            target_family = "wasm",
+            all(target_family = "wasm", feature = "custom-gpu"),
             target_os = "macos",
             target_os = "linux",
             target_os = "freebsd",
@@ -256,7 +256,7 @@ impl WgpuBindGroupLayouts {
     }
 
     #[cfg(any(
-        target_family = "wasm",
+        all(target_family = "wasm", feature = "custom-gpu"),
         target_os = "macos",
         target_os = "linux",
         target_os = "freebsd",
@@ -736,7 +736,7 @@ mod tests {
             &sampler,
         );
         #[cfg(any(
-            target_family = "wasm",
+            all(target_family = "wasm", feature = "custom-gpu"),
             target_os = "macos",
             target_os = "linux",
             target_os = "freebsd",

--- a/crates/gpui_wgpu/src/wgpu_renderer/pipelines.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/pipelines.rs
@@ -59,6 +59,7 @@ pub(super) struct WgpuPipelines {
     pub(super) polychrome_sprites: WgpuRenderPipeline,
     #[cfg_attr(
         not(any(
+            target_family = "wasm",
             target_os = "macos",
             target_os = "linux",
             target_os = "freebsd",
@@ -255,6 +256,7 @@ impl WgpuBindGroupLayouts {
     }
 
     #[cfg(any(
+        target_family = "wasm",
         target_os = "macos",
         target_os = "linux",
         target_os = "freebsd",
@@ -733,6 +735,7 @@ mod tests {
             &sampler,
         );
         #[cfg(any(
+            target_family = "wasm",
             target_os = "macos",
             target_os = "linux",
             target_os = "freebsd",

--- a/crates/gpui_wgpu/src/wgpu_renderer/pipelines.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/pipelines.rs
@@ -504,8 +504,9 @@ fn generated_bind_group_layout(
                 GeneratedBindingKind::RangeUniform => wgpu::BindingType::Buffer {
                     ty: wgpu::BufferBindingType::Uniform,
                     has_dynamic_offset: true,
-                    // The generated `vec2<u32> DATA_RANGE` batch base.
-                    min_binding_size: NonZeroU64::new(8),
+                    // The generated `DATA_RANGE` batch base, padded to satisfy
+                    // browser/WebGL downlevel uniform-binding alignment.
+                    min_binding_size: NonZeroU64::new(16),
                 },
             },
             count: None,

--- a/crates/gpui_wgpu/src/wgpu_renderer/resources.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/resources.rs
@@ -39,6 +39,7 @@ pub(super) struct WgpuResources {
     pub(super) surface_uniforms: DynamicUniformBuffer<SurfaceUniforms>,
     #[cfg_attr(
         not(any(
+            target_family = "wasm",
             target_os = "macos",
             target_os = "linux",
             target_os = "freebsd",

--- a/crates/gpui_wgpu/src/wgpu_renderer/resources.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/resources.rs
@@ -39,7 +39,7 @@ pub(super) struct WgpuResources {
     pub(super) surface_uniforms: DynamicUniformBuffer<SurfaceUniforms>,
     #[cfg_attr(
         not(any(
-            target_family = "wasm",
+            all(target_family = "wasm", feature = "custom-gpu"),
             target_os = "macos",
             target_os = "linux",
             target_os = "freebsd",

--- a/crates/gpui_wgpu/src/wgpu_renderer/surfaces.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/surfaces.rs
@@ -132,6 +132,7 @@ impl WgpuRenderer {
             padding0: 0,
             padding1: 0,
             padding2: 0,
+            padding3: 0,
         };
         let resources = self.resources();
         let uniform_offset = resources.surface_uniforms.write(&uniforms);

--- a/crates/gpui_wgpu/src/wgpu_renderer/surfaces.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/surfaces.rs
@@ -1,5 +1,6 @@
 use gpui::PaintSurface;
 #[cfg(any(
+    target_family = "wasm",
     target_os = "macos",
     target_os = "linux",
     target_os = "freebsd",
@@ -14,8 +15,8 @@ use super::{WgpuRenderer, frame};
 #[cfg(target_os = "macos")]
 #[path = "surfaces/macos.rs"]
 mod platform;
-#[cfg(any(target_os = "linux", target_os = "freebsd"))]
-#[path = "surfaces/linux.rs"]
+#[cfg(any(target_family = "wasm", target_os = "linux", target_os = "freebsd"))]
+#[path = "surfaces/texture.rs"]
 mod platform;
 #[cfg(all(target_os = "windows", feature = "wgpu-surfaces"))]
 #[path = "surfaces/windows.rs"]
@@ -24,6 +25,7 @@ mod platform;
     target_os = "macos",
     target_os = "linux",
     target_os = "freebsd",
+    target_family = "wasm",
     all(target_os = "windows", feature = "wgpu-surfaces")
 )))]
 #[path = "surfaces/unsupported.rs"]
@@ -32,6 +34,7 @@ mod platform;
 pub(super) use platform::SurfaceCache;
 
 #[cfg(any(
+    target_family = "wasm",
     target_os = "macos",
     target_os = "linux",
     target_os = "freebsd",
@@ -45,6 +48,7 @@ struct SurfaceBinding {
 }
 
 #[cfg(any(
+    target_family = "wasm",
     target_os = "macos",
     target_os = "linux",
     target_os = "freebsd",
@@ -80,6 +84,7 @@ impl WgpuRenderer {
     }
 
     #[cfg(any(
+        target_family = "wasm",
         target_os = "macos",
         target_os = "linux",
         target_os = "freebsd",
@@ -105,6 +110,7 @@ impl WgpuRenderer {
     }
 
     #[cfg(any(
+        target_family = "wasm",
         target_os = "macos",
         target_os = "linux",
         target_os = "freebsd",

--- a/crates/gpui_wgpu/src/wgpu_renderer/surfaces.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/surfaces.rs
@@ -122,6 +122,7 @@ impl WgpuRenderer {
             bounds: surface.bounds.into(),
             content_mask: surface.content_mask.bounds.into(),
             color_format,
+            opacity: surface.opacity,
             padding0: 0,
             padding1: 0,
             padding2: 0,

--- a/crates/gpui_wgpu/src/wgpu_renderer/surfaces.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/surfaces.rs
@@ -133,6 +133,8 @@ impl WgpuRenderer {
             padding1: 0,
             padding2: 0,
             padding3: 0,
+            padding4: 0,
+            padding5: 0,
         };
         let resources = self.resources();
         let uniform_offset = resources.surface_uniforms.write(&uniforms);

--- a/crates/gpui_wgpu/src/wgpu_renderer/surfaces.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/surfaces.rs
@@ -1,6 +1,6 @@
 use gpui::PaintSurface;
 #[cfg(any(
-    target_family = "wasm",
+    all(target_family = "wasm", feature = "custom-gpu"),
     target_os = "macos",
     target_os = "linux",
     target_os = "freebsd",
@@ -15,7 +15,11 @@ use super::{WgpuRenderer, frame};
 #[cfg(target_os = "macos")]
 #[path = "surfaces/macos.rs"]
 mod platform;
-#[cfg(any(target_family = "wasm", target_os = "linux", target_os = "freebsd"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    all(target_family = "wasm", feature = "custom-gpu")
+))]
 #[path = "surfaces/texture.rs"]
 mod platform;
 #[cfg(all(target_os = "windows", feature = "wgpu-surfaces"))]
@@ -25,7 +29,7 @@ mod platform;
     target_os = "macos",
     target_os = "linux",
     target_os = "freebsd",
-    target_family = "wasm",
+    all(target_family = "wasm", feature = "custom-gpu"),
     all(target_os = "windows", feature = "wgpu-surfaces")
 )))]
 #[path = "surfaces/unsupported.rs"]
@@ -34,7 +38,7 @@ mod platform;
 pub(super) use platform::SurfaceCache;
 
 #[cfg(any(
-    target_family = "wasm",
+    all(target_family = "wasm", feature = "custom-gpu"),
     target_os = "macos",
     target_os = "linux",
     target_os = "freebsd",
@@ -48,7 +52,7 @@ struct SurfaceBinding {
 }
 
 #[cfg(any(
-    target_family = "wasm",
+    all(target_family = "wasm", feature = "custom-gpu"),
     target_os = "macos",
     target_os = "linux",
     target_os = "freebsd",
@@ -84,7 +88,7 @@ impl WgpuRenderer {
     }
 
     #[cfg(any(
-        target_family = "wasm",
+        all(target_family = "wasm", feature = "custom-gpu"),
         target_os = "macos",
         target_os = "linux",
         target_os = "freebsd",
@@ -110,7 +114,7 @@ impl WgpuRenderer {
     }
 
     #[cfg(any(
-        target_family = "wasm",
+        all(target_family = "wasm", feature = "custom-gpu"),
         target_os = "macos",
         target_os = "linux",
         target_os = "freebsd",
@@ -120,6 +124,7 @@ impl WgpuRenderer {
         &self,
         surface: &PaintSurface,
         color_format: SurfaceColorFormat,
+        opacity: f32,
         binding: &mut SurfaceBinding,
         pass: &mut wgpu::RenderPass<'_>,
     ) -> frame::DrawResult {
@@ -128,7 +133,7 @@ impl WgpuRenderer {
             bounds: surface.bounds.into(),
             content_mask: surface.content_mask.bounds.into(),
             color_format,
-            opacity: surface.opacity,
+            opacity,
             padding0: 0,
             padding1: 0,
             padding2: 0,
@@ -152,8 +157,9 @@ impl WgpuRenderer {
     pub(super) fn draw_surfaces(
         &self,
         surfaces: &[PaintSurface],
+        opacities: &[f32],
         pass: &mut wgpu::RenderPass<'_>,
     ) -> frame::DrawResult {
-        platform::draw_surfaces(self, surfaces, pass)
+        platform::draw_surfaces(self, surfaces, opacities, pass)
     }
 }

--- a/crates/gpui_wgpu/src/wgpu_renderer/surfaces/macos.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/surfaces/macos.rs
@@ -55,12 +55,13 @@ pub(super) fn retain_surface_cache(renderer: &WgpuRenderer, surfaces: &[PaintSur
 pub(super) fn draw_surfaces(
     renderer: &WgpuRenderer,
     surfaces: &[PaintSurface],
+    opacities: &[f32],
     pass: &mut wgpu::RenderPass<'_>,
 ) -> frame::DrawResult {
     use core_video::pixel_buffer::kCVPixelFormatType_420YpCbCr8BiPlanarFullRange;
 
     let mut keyed_surfaces = smallvec::SmallVec::<[(&PaintSurface, usize); 4]>::new();
-    for surface in surfaces {
+    for (index, surface) in surfaces.iter().enumerate() {
         let gpui::SurfaceSource::Surface(image_buffer) = &surface.source else {
             log::error!("surface source cannot be imported by the macOS renderer");
             return Err(frame::DrawError::ExternalSurface);
@@ -69,13 +70,17 @@ pub(super) fn draw_surfaces(
             log::error!("unsupported CoreVideo surface pixel format");
             return Err(frame::DrawError::ExternalSurface);
         }
-        keyed_surfaces.push((surface, core_video_surface_key(image_buffer)?));
+        keyed_surfaces.push((
+            surface,
+            core_video_surface_key(image_buffer)?,
+            opacities.get(index).copied().unwrap_or(1.0),
+        ));
     }
 
     let resources = renderer.resources();
     let mut cache = resources.surface_cache.borrow_mut();
 
-    for (surface, key) in keyed_surfaces {
+    for (surface, key, opacity) in keyed_surfaces {
         let gpui::SurfaceSource::Surface(image_buffer) = &surface.source else {
             return Err(frame::DrawError::ExternalSurface);
         };
@@ -85,6 +90,7 @@ pub(super) fn draw_surfaces(
         renderer.draw_surface_binding(
             surface,
             SurfaceColorFormat::Yuv,
+            opacity,
             &mut imported.binding,
             pass,
         )?;

--- a/crates/gpui_wgpu/src/wgpu_renderer/surfaces/macos.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/surfaces/macos.rs
@@ -60,7 +60,7 @@ pub(super) fn draw_surfaces(
 ) -> frame::DrawResult {
     use core_video::pixel_buffer::kCVPixelFormatType_420YpCbCr8BiPlanarFullRange;
 
-    let mut keyed_surfaces = smallvec::SmallVec::<[(&PaintSurface, usize); 4]>::new();
+    let mut keyed_surfaces = smallvec::SmallVec::<[(&PaintSurface, usize, f32); 4]>::new();
     for (index, surface) in surfaces.iter().enumerate() {
         let gpui::SurfaceSource::Surface(image_buffer) = &surface.source else {
             log::error!("surface source cannot be imported by the macOS renderer");
@@ -85,7 +85,7 @@ pub(super) fn draw_surfaces(
             return Err(frame::DrawError::ExternalSurface);
         };
         let mut imported = cache.surfaces.remove(&key).map(Ok).unwrap_or_else(|| {
-            create_core_video_surface(renderer, &cache.texture_cache, image_buffer)
+            create_core_video_surface(renderer, &cache.texture_cache, &image_buffer)
         })?;
         renderer.draw_surface_binding(
             surface,

--- a/crates/gpui_wgpu/src/wgpu_renderer/surfaces/texture.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/surfaces/texture.rs
@@ -39,7 +39,7 @@ pub(super) fn draw_surfaces(
     let mut textures = smallvec::SmallVec::<[(&PaintSurface, &wgpu::Texture); 4]>::new();
     for surface in surfaces {
         let gpui::SurfaceSource::Texture { texture, .. } = &surface.source else {
-            log::error!("surface source cannot be imported by the Linux renderer");
+            log::error!("surface source cannot be imported by the WGPU texture renderer");
             return Err(frame::DrawError::ExternalSurface);
         };
         let Some(texture) = texture.downcast_ref::<wgpu::Texture>() else {

--- a/crates/gpui_wgpu/src/wgpu_renderer/surfaces/texture.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/surfaces/texture.rs
@@ -34,10 +34,11 @@ pub(super) fn retain_surface_cache(renderer: &WgpuRenderer, surfaces: &[PaintSur
 pub(super) fn draw_surfaces(
     renderer: &WgpuRenderer,
     surfaces: &[PaintSurface],
+    opacities: &[f32],
     pass: &mut wgpu::RenderPass<'_>,
 ) -> frame::DrawResult {
-    let mut textures = smallvec::SmallVec::<[(&PaintSurface, &wgpu::Texture); 4]>::new();
-    for surface in surfaces {
+    let mut textures = smallvec::SmallVec::<[(&PaintSurface, &wgpu::Texture, f32); 4]>::new();
+    for (index, surface) in surfaces.iter().enumerate() {
         let gpui::SurfaceSource::Texture { texture, .. } = &surface.source else {
             log::error!("surface source cannot be imported by the WGPU texture renderer");
             return Err(frame::DrawError::ExternalSurface);
@@ -46,13 +47,17 @@ pub(super) fn draw_surfaces(
             log::error!("surface source is not a WGPU texture");
             return Err(frame::DrawError::ExternalSurface);
         };
-        textures.push((surface, texture));
+        textures.push((
+            surface,
+            texture,
+            opacities.get(index).copied().unwrap_or(1.0),
+        ));
     }
 
     let resources = renderer.resources();
     let mut cache = resources.surface_cache.borrow_mut();
 
-    for (surface, texture) in textures {
+    for (surface, texture, opacity) in textures {
         if !cache.textures.contains_key(texture) {
             let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
             cache.textures.insert(
@@ -64,7 +69,7 @@ pub(super) fn draw_surfaces(
             log::error!("surface texture cache insertion failed");
             return Err(frame::DrawError::ExternalSurface);
         };
-        renderer.draw_surface_binding(surface, SurfaceColorFormat::Rgba, cached, pass)?;
+        renderer.draw_surface_binding(surface, SurfaceColorFormat::Rgba, opacity, cached, pass)?;
     }
     Ok(())
 }

--- a/crates/gpui_wgpu/src/wgpu_renderer/surfaces/unsupported.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/surfaces/unsupported.rs
@@ -13,6 +13,7 @@ pub(super) fn retain_surface_cache(_renderer: &WgpuRenderer, _surfaces: &[PaintS
 pub(super) fn draw_surfaces(
     _renderer: &WgpuRenderer,
     surfaces: &[PaintSurface],
+    _opacities: &[f32],
     _pass: &mut wgpu::RenderPass<'_>,
 ) -> frame::DrawResult {
     if surfaces.is_empty() {

--- a/crates/gpui_wgpu/src/wgpu_renderer/surfaces/windows.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/surfaces/windows.rs
@@ -42,11 +42,12 @@ pub(super) fn retain_surface_cache(renderer: &WgpuRenderer, surfaces: &[PaintSur
 pub(super) fn draw_surfaces(
     renderer: &WgpuRenderer,
     surfaces: &[PaintSurface],
+    opacities: &[f32],
     pass: &mut wgpu::RenderPass<'_>,
 ) -> frame::DrawResult {
     let resources = renderer.resources();
     let mut cache = resources.surface_cache.borrow_mut();
-    for surface in surfaces {
+    for (index, surface) in surfaces.iter().enumerate() {
         let Some(frame) = capture_frame(surface) else {
             log::error!("surface source cannot be imported by the Windows renderer");
             return Err(frame::DrawError::ExternalSurface);
@@ -91,6 +92,7 @@ pub(super) fn draw_surfaces(
         renderer.draw_surface_binding(
             surface,
             SurfaceColorFormat::Rgba,
+            opacities.get(index).copied().unwrap_or(1.0),
             &mut cached.binding,
             pass,
         )?;

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -1200,6 +1200,8 @@ impl DirectXRenderer {
                 padding1: 0,
                 padding2: 0,
                 padding3: 0,
+                padding4: 0,
+                padding5: 0,
             };
             update_buffer(ctx, &self.pipelines.surfaces.params_buffer, &[uniforms])?;
 

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -1199,6 +1199,7 @@ impl DirectXRenderer {
                 padding0: 0,
                 padding1: 0,
                 padding2: 0,
+                padding3: 0,
             };
             update_buffer(ctx, &self.pipelines.surfaces.params_buffer, &[uniforms])?;
 

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -1195,6 +1195,7 @@ impl DirectXRenderer {
                 bounds: surface.bounds.into(),
                 content_mask: surface.content_mask.bounds.into(),
                 color_format: SurfaceColorFormat::Rgba,
+                opacity: surface.opacity,
                 padding0: 0,
                 padding1: 0,
                 padding2: 0,

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -669,7 +669,10 @@ impl DirectXRenderer {
                     range,
                 }) => self.draw_polychrome_sprites(*texture_id, instance_range(range)?),
                 RenderCommand::Batch(PrimitiveBatch::Surfaces(range)) => {
-                    self.draw_surfaces(&scene.surfaces[range.clone()])
+                    self.draw_surfaces(
+                        &scene.surfaces[range.clone()],
+                        &scene.surface_opacities()[range.clone()],
+                    )
                 }
                 RenderCommand::Batch(PrimitiveBatch::BackdropFilters(range)) => {
                     let result = (|| {
@@ -1151,7 +1154,7 @@ impl DirectXRenderer {
         )
     }
 
-    fn draw_surfaces(&mut self, surfaces: &[PaintSurface]) -> Result<()> {
+    fn draw_surfaces(&mut self, surfaces: &[PaintSurface], opacities: &[f32]) -> Result<()> {
         if surfaces.is_empty() {
             return Ok(());
         }
@@ -1162,7 +1165,7 @@ impl DirectXRenderer {
         let surface_cb = [Some(self.pipelines.surfaces.params_buffer.clone())];
         let sampler = [self.globals.sampler.clone()];
 
-        for surface in surfaces {
+        for (index, surface) in surfaces.iter().enumerate() {
             let gpui::SurfaceSource::WindowsCapture(frame) = &surface.source else {
                 log::error!("DirectX renderer cannot import this surface source");
                 anyhow::bail!("unsupported surface source");
@@ -1195,7 +1198,7 @@ impl DirectXRenderer {
                 bounds: surface.bounds.into(),
                 content_mask: surface.content_mask.bounds.into(),
                 color_format: SurfaceColorFormat::Rgba,
-                opacity: surface.opacity,
+                opacity: opacities.get(index).copied().unwrap_or(1.0),
                 padding0: 0,
                 padding1: 0,
                 padding2: 0,


### PR DESCRIPTION
Custom controls can share GPUI's WGPU device and queue, create compatible offscreen targets, and composite their output while surviving resize and device recovery.

This revived implementation is updated against the current upstream main and includes the typed WgpuContextHandle, reusable WgpuRenderTarget, backend context plumbing on Linux, surface opacity propagation, and an animated custom GPU example.

Browser/WASM support is intentionally wired through the same typed API instead of preserving older type-erased compatibility methods. The cfgs now include `target_family = "wasm"` where the API is tied to WGPU texture compositing rather than a native OS surface: `Window::gpu_context_info()`, `WgpuContextHandle::from_window()`, `WgpuRenderTarget::surface()`, and `SurfaceSource::Texture`. The legacy `Window::gpu_context()` / `gpu_device_lost()` methods remain native-only, so downstream browser apps should use `WgpuContextHandle` and `WgpuRenderTarget` directly. WASM also omits `Send + Sync` on the type-erased texture handle because browser WGPU handles are thread-local.

The original PR #228 could not be reopened after its deleted head repository was removed, so this replacement preserves the work on the restored fork branch.

AI disclosure: This pull request was implemented with assistance from GitHub Copilot. The changes were reviewed and directed by the author.

Closes #224