### PR TITLE
Add runtime window visibility

### DIFF
--- a/crates/gpui/examples/window_visibility.rs
+++ b/crates/gpui/examples/window_visibility.rs
@@ -1,0 +1,105 @@
+//! Run with `cargo run -p gpui-ce --example window_visibility`.
+//! Pass `-- --smoke` for an automatic hide/show cycle followed by exit.
+
+use gpui::{
+    App, Bounds, Context, TitlebarOptions, Window, WindowBounds, WindowOptions, div, prelude::*,
+    px, rgb, size,
+};
+use gpui_platform::application;
+use std::time::Duration;
+
+struct VisibilityExample {
+    restores: usize,
+}
+
+impl Render for VisibilityExample {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .size_full()
+            .flex()
+            .flex_col()
+            .gap_4()
+            .p_8()
+            .bg(rgb(0x18181b))
+            .text_color(rgb(0xf4f4f5))
+            .child(div().text_2xl().child("Window visibility test"))
+            .child("Hide this window without closing it. It returns after three seconds.")
+            .child(format!("Successful restores: {}", self.restores))
+            .child(
+                div()
+                    .id("hide")
+                    .p_4()
+                    .bg(rgb(0x2563eb))
+                    .rounded_md()
+                    .cursor_pointer()
+                    .child("Hide for 3 seconds")
+                    .on_click(cx.listener(|_, _, window, cx| {
+                        let handle = window.window_handle();
+                        window.set_visible(false);
+                        cx.spawn(async move |this, cx| {
+                            cx.background_executor().timer(Duration::from_secs(3)).await;
+                            this.update(cx, |this, cx| {
+                                this.restores += 1;
+                                cx.notify();
+                            })
+                            .ok();
+                            handle
+                                .update(cx, |_, window, _| window.set_visible(true))
+                                .ok();
+                        })
+                        .detach();
+                    })),
+            )
+    }
+}
+
+fn main() {
+    let smoke = std::env::args().any(|arg| arg == "--smoke");
+    application().run(move |cx: &mut App| {
+        let bounds = Bounds::centered(None, size(px(520.), px(280.)), cx);
+        let handle = cx
+            .open_window(
+                WindowOptions {
+                    show: false,
+                    focus: false,
+                    app_id: Some("dev.gpui.visibility-test".into()),
+                    titlebar: Some(TitlebarOptions {
+                        title: Some("GPUI visibility test".into()),
+                        ..Default::default()
+                    }),
+                    window_bounds: Some(WindowBounds::Windowed(bounds)),
+                    ..Default::default()
+                },
+                |_, cx| cx.new(|_| VisibilityExample { restores: 0 }),
+            )
+            .unwrap();
+        eprintln!("VISIBILITY hidden initially");
+        cx.spawn(async move |cx| {
+            let states: &[bool] = if smoke {
+                &[true, false, true, false, true]
+            } else {
+                &[true]
+            };
+            for &visible in states {
+                cx.background_executor().timer(Duration::from_secs(3)).await;
+                handle
+                    .update(cx, |this, window, cx| {
+                        // Repeated calls should be harmless.
+                        window.set_visible(visible);
+                        window.set_visible(visible);
+                        if visible {
+                            this.restores += 1;
+                            cx.notify();
+                        }
+                    })
+                    .unwrap();
+                eprintln!("VISIBILITY {}", if visible { "shown" } else { "hidden" });
+            }
+            if smoke {
+                cx.background_executor().timer(Duration::from_secs(3)).await;
+                cx.update(|cx| cx.quit());
+            }
+        })
+        .detach();
+    });
+}

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -900,6 +900,11 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn background_appearance(&self) -> WindowBackgroundAppearance;
     fn set_title(&mut self, title: &str);
     fn set_background_appearance(&self, background_appearance: WindowBackgroundAppearance);
+    /// Show or hide the window without explicitly requesting focus.
+    ///
+    /// The default implementation does nothing for platforms that do not support
+    /// changing window visibility at runtime.
+    fn set_visible(&self, _visible: bool) {}
     fn minimize(&self);
     fn zoom(&self);
     fn toggle_fullscreen(&self);

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -45,6 +45,7 @@ pub(crate) struct TestWindowState {
     input_handler: Option<PlatformInputHandler>,
     text_input_configurations: Vec<TextInputConfiguration>,
     text_input_state_changes: Vec<TextInputStateChange>,
+    visible: bool,
     is_fullscreen: bool,
     appearance: WindowAppearance,
     external_drag_files: Vec<(PathBuf, bool)>,
@@ -109,6 +110,7 @@ impl TestWindow {
             input_handler: None,
             text_input_configurations: Vec::new(),
             text_input_state_changes: Vec::new(),
+            visible: params.show,
             is_fullscreen: false,
             appearance: WindowAppearance::Light,
             external_drag_files: Vec::new(),
@@ -136,6 +138,11 @@ impl TestWindow {
 
     pub fn frame_scheduled(&self) -> bool {
         self.0.lock().frame_scheduled
+    }
+
+    /// Returns whether this test window is visible.
+    pub fn is_visible(&self) -> bool {
+        self.0.lock().visible
     }
 
     /// Every [`TextInputConfiguration`] forwarded to this window, in order.
@@ -329,6 +336,10 @@ impl PlatformWindow for TestWindow {
     fn set_app_id(&mut self, _app_id: &str) {}
 
     fn set_background_appearance(&self, _background: WindowBackgroundAppearance) {}
+
+    fn set_visible(&self, visible: bool) {
+        self.0.lock().visible = visible;
+    }
 
     fn set_edited(&mut self, edited: bool) {
         self.0.lock().edited = edited;

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -6121,6 +6121,14 @@ impl Window {
         self.platform_window.minimize();
     }
 
+    /// Show or hide the current window at the platform level.
+    ///
+    /// Call [`Window::activate_window`] separately when the window should also receive focus.
+    /// The window manager may still focus a window when it is shown.
+    pub fn set_visible(&self, visible: bool) {
+        self.platform_window.set_visible(visible);
+    }
+
     /// Toggle full screen status on the current window at the platform level.
     pub fn toggle_fullscreen(&self) {
         self.platform_window.toggle_fullscreen();
@@ -7496,6 +7504,31 @@ mod tests {
                 ));
             })
             .unwrap();
+    }
+
+    #[gpui::test]
+    fn test_window_visibility_can_be_changed(cx: &mut TestAppContext) {
+        for show in [false, true] {
+            let window = cx.update(|cx| {
+                cx.open_window(
+                    WindowOptions {
+                        show,
+                        ..Default::default()
+                    },
+                    |_, cx| cx.new(|_| EmptyView),
+                )
+                .unwrap()
+            });
+            let platform_window = cx.test_window(window.into());
+            assert_eq!(platform_window.is_visible(), show);
+
+            for visible in [false, false, true, true, false, true] {
+                window
+                    .update(cx, |_, window, _| window.set_visible(visible))
+                    .unwrap();
+                assert_eq!(platform_window.is_visible(), visible);
+            }
+        }
     }
 
     #[gpui::test]

--- a/crates/gpui_linux/src/linux/headless/window.rs
+++ b/crates/gpui_linux/src/linux/headless/window.rs
@@ -177,6 +177,8 @@ impl PlatformWindow for HeadlessWindow {
 
     fn set_background_appearance(&self, _background: WindowBackgroundAppearance) {}
 
+    fn set_visible(&self, _visible: bool) {}
+
     fn minimize(&self) {}
 
     fn zoom(&self) {}

--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -108,6 +108,8 @@ pub struct WaylandWindowState {
     children: FxHashMap<ObjectId, bool>,
     pub surface: wl_surface::WlSurface,
     app_id: Option<String>,
+    title: Option<String>,
+    window_min_size: Option<Size<Pixels>>,
     appearance: WindowAppearance,
     blur: Option<org_kde_kwin_blur::OrgKdeKwinBlur>,
     viewport: Option<wp_viewport::WpViewport>,
@@ -128,6 +130,7 @@ pub struct WaylandWindowState {
     handle: AnyWindowHandle,
     active: bool,
     hovered: bool,
+    visible: bool,
     redraw_requested: bool,
     presentation: PresentationState,
     pending_frame_callback: Option<wl_callback::WlCallback>,
@@ -592,9 +595,15 @@ impl WaylandWindowState {
             )?
         };
 
+        let title = options
+            .titlebar
+            .as_ref()
+            .and_then(|titlebar| titlebar.title.as_ref())
+            .map(ToString::to_string);
+
         if let WaylandSurfaceState::Xdg(ref xdg_state) = surface_state {
-            if let Some(title) = options.titlebar.and_then(|titlebar| titlebar.title) {
-                xdg_state.toplevel.set_title(title.to_string());
+            if let Some(title) = title.as_ref() {
+                xdg_state.toplevel.set_title(title.clone());
             }
 
             if let Some(app_id) = options.app_id.as_ref() {
@@ -615,6 +624,8 @@ impl WaylandWindowState {
             children: FxHashMap::default(),
             surface,
             app_id: options.app_id,
+            title,
+            window_min_size: options.window_min_size,
             icon: options.icon,
             generated_icons: Vec::default(),
             blur: None,
@@ -639,6 +650,7 @@ impl WaylandWindowState {
             handle,
             active: false,
             hovered: false,
+            visible: options.show,
             redraw_requested: false,
             presentation: PresentationState::Unpresented,
             pending_frame_callback: None,
@@ -652,6 +664,40 @@ impl WaylandWindowState {
     pub fn is_transparent(&self) -> bool {
         self.decorations == WindowDecorations::Client
             || self.background_appearance != WindowBackgroundAppearance::Opaque
+    }
+
+    fn prepare_to_map(&self) {
+        let WaylandSurfaceState::Xdg(xdg_state) = &self.surface_state else {
+            return;
+        };
+
+        if let Some(title) = self.title.as_ref() {
+            xdg_state.toplevel.set_title(title.clone());
+        }
+        if let Some(app_id) = self.app_id.as_ref() {
+            xdg_state.toplevel.set_app_id(app_id.clone());
+        }
+        if let Some(size) = self.window_min_size {
+            xdg_state
+                .toplevel
+                .set_min_size(f32::from(size.width) as i32, f32::from(size.height) as i32);
+        }
+
+        let max_texture_size = self.renderer.max_texture_size() as i32;
+        xdg_state
+            .toplevel
+            .set_max_size(max_texture_size, max_texture_size);
+
+        if let Some(parent) = self.parent.as_ref() {
+            let parent_toplevel = parent.toplevel();
+            xdg_state.toplevel.set_parent(parent_toplevel.as_ref());
+        }
+
+        if self.fullscreen {
+            xdg_state.toplevel.set_fullscreen(None);
+        } else if self.maximized {
+            xdg_state.toplevel.set_maximized();
+        }
     }
 
     fn update_subpixel_layout(&mut self) {
@@ -880,8 +926,11 @@ impl WaylandWindow {
             frame_ping,
         });
 
-        // Kick things off
-        surface.commit();
+        // An initial empty commit asks the compositor to configure the surface. If the caller
+        // requested a hidden window, defer that commit until the window is shown.
+        if this.borrow().visible {
+            surface.commit();
+        }
 
         Ok((this, surface.id()))
     }
@@ -964,7 +1013,8 @@ impl WaylandWindowStatePtr {
         let mut state = self.state.borrow_mut();
 
         let frame_loop = self.frame_loop.get();
-        if frame_loop == FrameLoop::AwaitingCallback {
+        // Hiding during a frame resets the loop; wait for a new configure before retrying.
+        if frame_loop == FrameLoop::Unconfigured || frame_loop == FrameLoop::AwaitingCallback {
             return;
         }
 
@@ -1142,8 +1192,11 @@ impl WaylandWindowStatePtr {
             );
 
             let initial_configure = self.frame_loop.get() == FrameLoop::Unconfigured;
+            let visible = state.visible;
             drop(state);
-            if initial_configure {
+            if !visible {
+                return;
+            } else if initial_configure {
                 self.frame();
             } else {
                 self.request_redraw();
@@ -1886,7 +1939,9 @@ impl PlatformWindow for WaylandWindow {
     }
 
     fn set_title(&mut self, title: &str) {
-        if let Some(toplevel) = self.borrow().surface_state.toplevel() {
+        let mut state = self.borrow_mut();
+        state.title = Some(title.to_owned());
+        if let Some(toplevel) = state.surface_state.toplevel() {
             toplevel.set_title(title.to_string());
         }
     }
@@ -1911,6 +1966,29 @@ impl PlatformWindow for WaylandWindow {
 
     fn background_appearance(&self) -> WindowBackgroundAppearance {
         self.borrow().background_appearance
+    }
+
+    fn set_visible(&self, visible: bool) {
+        let mut state = self.borrow_mut();
+        if state.visible == visible {
+            return;
+        }
+
+        state.visible = visible;
+        if visible {
+            // Remapping an xdg surface starts with an empty commit and a fresh configure cycle.
+            state.prepare_to_map();
+            state.surface.commit();
+        } else {
+            // Attaching a null buffer unmaps an xdg surface without destroying its role objects.
+            // The next map must wait for a new configure before presenting another buffer.
+            state.pending_frame_callback.take();
+            state.surface.attach(None, 0, 0);
+            state.surface.commit();
+            state.presentation = PresentationState::Unpresented;
+            state.redraw_requested = true;
+            self.0.frame_loop.set(FrameLoop::Unconfigured);
+        }
     }
 
     fn is_subpixel_rendering_supported(&self) -> bool {
@@ -2000,6 +2078,12 @@ impl PlatformWindow for WaylandWindow {
 
     fn draw(&self, scene: &Scene) {
         let mut state = self.borrow_mut();
+
+        if !state.visible {
+            state.redraw_requested = true;
+            self.0.frame_loop.set(FrameLoop::Unconfigured);
+            return;
+        }
 
         if state.renderer.device_lost() {
             let raw_window = RawWindow {

--- a/crates/gpui_linux/src/linux/x11/window.rs
+++ b/crates/gpui_linux/src/linux/x11/window.rs
@@ -275,6 +275,7 @@ pub struct X11WindowState {
     background_appearance: WindowBackgroundAppearance,
     maximized_vertical: bool,
     maximized_horizontal: bool,
+    visible: bool,
     hidden: bool,
     active: bool,
     hovered: bool,
@@ -839,6 +840,7 @@ impl X11WindowState {
                 fullscreen: false,
                 maximized_vertical: false,
                 maximized_horizontal: false,
+                visible: params.show,
                 hidden: false,
                 appearance,
                 handle,
@@ -1597,10 +1599,12 @@ impl PlatformWindow for X11Window {
     }
 
     fn map_window(&mut self) -> anyhow::Result<()> {
-        check_reply(
-            || "X11 MapWindow failed.",
-            self.0.xcb.map_window(self.0.x_window),
-        )?;
+        if self.0.state.borrow().visible {
+            check_reply(
+                || "X11 MapWindow failed.",
+                self.0.xcb.map_window(self.0.x_window),
+            )?;
+        }
         Ok(())
     }
 
@@ -1613,6 +1617,33 @@ impl PlatformWindow for X11Window {
 
     fn background_appearance(&self) -> WindowBackgroundAppearance {
         self.0.state.borrow().background_appearance
+    }
+
+    fn set_visible(&self, visible: bool) {
+        let mut state = self.0.state.borrow_mut();
+        if state.visible == visible {
+            return;
+        }
+        state.visible = visible;
+        drop(state);
+
+        let result = if visible {
+            self.0.xcb.map_window(self.0.x_window)
+        } else {
+            self.0.xcb.unmap_window(self.0.x_window)
+        };
+        check_reply(
+            || {
+                if visible {
+                    "X11 MapWindow failed."
+                } else {
+                    "X11 UnmapWindow failed."
+                }
+            },
+            result,
+        )
+        .log_err();
+        xcb_flush(&self.0.xcb);
     }
 
     fn is_subpixel_rendering_supported(&self) -> bool {

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -1966,6 +1966,26 @@ impl PlatformWindow for MacWindow {
             .detach();
     }
 
+    fn set_visible(&self, visible: bool) {
+        let lock = self.0.lock();
+        let window = lock.native_window;
+        let closed = lock.closed.clone();
+        let executor = lock.foreground_executor.clone();
+        executor
+            .spawn(async move {
+                if !closed.load(Ordering::Acquire) {
+                    unsafe {
+                        if visible {
+                            let _: () = msg_send![window, orderFront: NIL];
+                        } else {
+                            let _: () = msg_send![window, orderOut: NIL];
+                        }
+                    }
+                }
+            })
+            .detach();
+    }
+
     fn minimize(&self) {
         let window = self.0.lock().native_window;
         unsafe {

--- a/crates/gpui_web/src/window.rs
+++ b/crates/gpui_web/src/window.rs
@@ -138,7 +138,7 @@ impl WebWindow {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         _handle: AnyWindowHandle,
-        _params: WindowParams,
+        params: WindowParams,
         context: &WgpuContext,
         canvas: web_sys::HtmlCanvasElement,
         surface: wgpu::Surface<'static>,
@@ -214,6 +214,14 @@ impl WebWindow {
             raf_id: Cell::new(None),
             raf_function: RefCell::new(None),
         });
+
+        if !params.show {
+            inner
+                .canvas
+                .style()
+                .set_property("display", "none")
+                .map_err(|error| anyhow::anyhow!("Failed to hide canvas: {error:?}"))?;
+        }
 
         let raf_closure = inner.create_raf_closure();
         inner.wake_frame_loop();
@@ -735,6 +743,14 @@ impl PlatformWindow for WebWindow {
     }
 
     fn set_background_appearance(&self, _background: WindowBackgroundAppearance) {}
+
+    fn set_visible(&self, visible: bool) {
+        self.inner
+            .canvas
+            .style()
+            .set_property("display", if visible { "block" } else { "none" })
+            .unwrap_or_else(|error| log::error!("Failed to update canvas visibility: {error:?}"));
+    }
 
     fn minimize(&self) {
         log::warn!("WebWindow::minimize is not supported in the browser");

--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -898,6 +898,31 @@ impl PlatformWindow for WindowsWindow {
         }
     }
 
+    fn set_visible(&self, visible: bool) {
+        let hwnd = self.0.hwnd;
+        let this = self.0.clone();
+        self.0
+            .executor
+            .spawn(async move {
+                if visible {
+                    let initial_placement = this.state.initial_placement.take();
+                    let has_initial_placement = initial_placement.is_some();
+                    this.state.initial_placement.set(initial_placement);
+                    this.set_window_placement().log_err();
+                    if !has_initial_placement {
+                        unsafe {
+                            ShowWindowAsync(hwnd, SW_SHOWNOACTIVATE).ok().log_err();
+                        }
+                    }
+                } else {
+                    unsafe {
+                        ShowWindowAsync(hwnd, SW_HIDE).ok().log_err();
+                    }
+                }
+            })
+            .detach();
+    }
+
     fn minimize(&self) {
         unsafe { ShowWindowAsync(self.0.hwnd, SW_MINIMIZE).ok().log_err() };
     }


### PR DESCRIPTION
Adds `Window::set_visible(bool)` so applications can hide a window without closing it, then restore the same window—for example, from a tray icon. Ports https://github.com/zed-industries/zed/pull/63788 to GPUI CE across Wayland, X11, macOS, Windows, web, headless, and test backends.

Adapts Wayland initialization and macOS calls to this fork, preserves the unconfigured Wayland frame-loop state when hiding during a frame, and adds regression coverage for initial visibility, repeated calls, and hide/show cycles. The new `window_visibility` example supports interactive testing and an automatic `--smoke` mode. API documentation notes that the window manager may focus a window when it is shown.

Validation:
- All 18 `window::tests` passed in the Nix development shell.
- `cargo check -p gpui_ce_linux --locked` passed.
- `cargo build -p gpui-ce --example window_visibility --locked` passed.
- Formatting and whitespace checks passed.
- Tested on Wayland/Niri: compositor monitoring confirmed initial hiding and three show cycles; interactive hide/restore was also confirmed manually.
- Other platform backends have not been runtime-tested.

Fix #115 #87