### PR TITLE
Asset Improvements

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -201,6 +201,9 @@ impl Application {
     }
 
     /// Assigns the source of assets for the application.
+    ///
+    /// Pass a tuple to use multiple sources. Sources are searched in tuple order when loading an
+    /// asset, and their results are concatenated in tuple order when listing assets.
     pub fn with_assets(self, asset_source: impl AssetSource) -> Self {
         let mut context_lock = self.0.borrow_mut();
         let asset_source = Arc::new(asset_source);

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -213,6 +213,14 @@ impl Application {
         self
     }
 
+    /// Configures whether fonts under `fonts` are loaded from the asset source at startup.
+    /// This is enabled by default.
+    pub fn load_font_assets(self, load_font_assets: bool) -> Self {
+        self.0.borrow_mut().load_font_assets = load_font_assets;
+
+        self
+    }
+
     /// Configures arguments to pass when restarting the application.
     pub fn with_restart_arguments(self, arguments: Vec<OsString>) -> Self {
         self.0.borrow_mut().restart_arguments = arguments;
@@ -266,6 +274,11 @@ impl Application {
         let platform = self.0.borrow().platform.clone();
         platform.run(Box::new(move || {
             let cx = &mut *this.borrow_mut();
+
+            if cx.load_font_assets {
+                load_font_assets(cx).log_err();
+            }
+
             on_finish_launching(cx);
         }));
     }
@@ -287,6 +300,11 @@ impl Application {
         let platform = self.0.borrow().platform.clone();
         platform.run(Box::new(move || {
             let cx = &mut *this.borrow_mut();
+
+            if cx.load_font_assets {
+                load_font_assets(cx).log_err();
+            }
+
             on_finish_launching(cx);
         }));
         ApplicationHandle { app: self.0 }
@@ -336,6 +354,35 @@ impl Application {
     pub fn path_for_auxiliary_executable(&self, name: &str) -> Result<PathBuf> {
         self.0.borrow().path_for_auxiliary_executable(name)
     }
+}
+
+fn load_font_assets(cx: &App) -> Result<()> {
+    let font_paths = cx
+        .asset_source()
+        .list("fonts")
+        .context("failed to list font assets")?;
+
+    let mut embedded_fonts = Vec::new();
+
+    for font_path in font_paths {
+        if !font_path.ends_with(".ttf") {
+            continue;
+        }
+
+        let Some(font_bytes) = cx
+            .asset_source()
+            .load(&font_path)
+            .with_context(|| format!("failed to load font asset {font_path}"))?
+        else {
+            continue;
+        };
+
+        embedded_fonts.push(font_bytes);
+    }
+
+    cx.text_system()
+        .add_fonts(embedded_fonts)
+        .context("failed to register font assets")
 }
 
 type Handler = Box<dyn FnMut(&mut App) -> bool + 'static>;
@@ -763,6 +810,7 @@ pub struct App {
     // assets
     pub(crate) loading_assets: FxHashMap<(TypeId, u64), Box<dyn Any>>,
     asset_source: Arc<dyn AssetSource>,
+    load_font_assets: bool,
     pub(crate) svg_renderer: SvgRenderer,
     http_client: Arc<dyn HttpClient>,
 
@@ -850,6 +898,7 @@ impl App {
                 svg_renderer: SvgRenderer::new(asset_source.clone()),
                 loading_assets: Default::default(),
                 asset_source,
+                load_font_assets: true,
                 http_client,
                 globals_by_type: Default::default(),
                 global_entities: Default::default(),
@@ -3167,16 +3216,64 @@ impl<'a, T> Drop for GpuiBorrow<'a, T> {
 #[cfg(test)]
 mod test {
     use std::{
+        borrow::Cow,
         cell::{Cell, RefCell},
         ffi::OsString,
         path::PathBuf,
         rc::Rc,
+        sync::{Arc, Mutex},
     };
 
     #[cfg(unix)]
     use std::os::unix::ffi::OsStringExt;
 
-    use crate::{AppContext, Context, Empty, IntoElement, Render, TestAppContext, Window};
+    use anyhow::anyhow;
+
+    use crate::{
+        AppContext, AssetSource, Context, Empty, IntoElement, Render, Result, SharedString,
+        TestAppContext, Window,
+    };
+
+    use super::{Application, load_font_assets};
+
+    struct RecordingFontAssets {
+        list_requests: Arc<Mutex<Vec<String>>>,
+        load_requests: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl AssetSource for RecordingFontAssets {
+        fn load(&self, path: &str) -> Result<Option<Cow<'static, [u8]>>> {
+            self.load_requests.lock().unwrap().push(path.to_owned());
+
+            if path == "fonts/regular.ttf" {
+                return Ok(Some(Cow::Borrowed(b"font")));
+            }
+
+            Ok(None)
+        }
+
+        fn list(&self, path: &str) -> Result<Vec<SharedString>> {
+            self.list_requests.lock().unwrap().push(path.to_owned());
+
+            Ok(vec![
+                "fonts/regular.ttf".into(),
+                "fonts/missing.ttf".into(),
+                "fonts/ignored.otf".into(),
+            ])
+        }
+    }
+
+    struct FailingFontAssets;
+
+    impl AssetSource for FailingFontAssets {
+        fn load(&self, _path: &str) -> Result<Option<Cow<'static, [u8]>>> {
+            Ok(None)
+        }
+
+        fn list(&self, _path: &str) -> Result<Vec<SharedString>> {
+            Err(anyhow!("font listing failed"))
+        }
+    }
 
     struct RenderCounter(Rc<Cell<usize>>);
 
@@ -3185,6 +3282,41 @@ mod test {
             self.0.set(self.0.get() + 1);
             Empty
         }
+    }
+
+    #[test]
+    fn loads_ttf_font_assets() {
+        let cx = TestAppContext::single();
+        let list_requests = Arc::new(Mutex::new(Vec::new()));
+        let load_requests = Arc::new(Mutex::new(Vec::new()));
+
+        Application(cx.app.clone()).with_assets(RecordingFontAssets {
+            list_requests: list_requests.clone(),
+            load_requests: load_requests.clone(),
+        });
+
+        assert!(cx.app.borrow().load_font_assets);
+
+        cx.update(|cx| load_font_assets(cx)).unwrap();
+
+        assert_eq!(list_requests.lock().unwrap().as_slice(), ["fonts"]);
+
+        assert_eq!(
+            load_requests.lock().unwrap().as_slice(),
+            ["fonts/regular.ttf", "fonts/missing.ttf"]
+        );
+
+        Application(cx.app.clone()).load_font_assets(false);
+
+        assert!(!cx.app.borrow().load_font_assets);
+
+        Application(cx.app.clone())
+            .with_assets(FailingFontAssets)
+            .load_font_assets(true);
+
+        let error = cx.update(|cx| load_font_assets(cx)).unwrap_err();
+
+        assert_eq!(error.to_string(), "failed to list font assets");
     }
 
     #[gpui::test]

--- a/crates/gpui/src/assets.rs
+++ b/crates/gpui/src/assets.rs
@@ -1,4 +1,4 @@
-use crate::{DevicePixels, Pixels, Result, SharedString, Size, size};
+use crate::{size, DevicePixels, Pixels, Result, SharedString, Size};
 use smallvec::SmallVec;
 
 use image::{Delay, Frame};
@@ -57,7 +57,6 @@ macro_rules! impl_asset_source_for_tuples {
 }
 
 impl_asset_source_for_tuples!(
-    (T0: 0),
     (T0: 0, T1: 1),
     (T0: 0, T1: 1, T2: 2),
     (T0: 0, T1: 1, T2: 2, T3: 3),

--- a/crates/gpui/src/assets.rs
+++ b/crates/gpui/src/assets.rs
@@ -28,6 +28,45 @@ impl AssetSource for () {
     }
 }
 
+macro_rules! impl_asset_source_for_tuples {
+    ($(($($source:ident: $index:tt),+)),+ $(,)?) => {
+        $(
+            impl<$($source: AssetSource),+> AssetSource for ($($source,)+) {
+                fn load(&self, path: &str) -> Result<Option<Cow<'static, [u8]>>> {
+                    $(
+                        if let Some(asset) = self.$index.load(path)? {
+                            return Ok(Some(asset));
+                        }
+                    )+
+
+                    Ok(None)
+                }
+
+                fn list(&self, path: &str) -> Result<Vec<SharedString>> {
+                    let mut assets = Vec::new();
+
+                    $(
+                        assets.extend(self.$index.list(path)?);
+                    )+
+
+                    Ok(assets)
+                }
+            }
+        )+
+    };
+}
+
+impl_asset_source_for_tuples!(
+    (T0: 0),
+    (T0: 0, T1: 1),
+    (T0: 0, T1: 1, T2: 2),
+    (T0: 0, T1: 1, T2: 2, T3: 3),
+    (T0: 0, T1: 1, T2: 2, T3: 3, T4: 4),
+    (T0: 0, T1: 1, T2: 2, T3: 3, T4: 4, T5: 5),
+    (T0: 0, T1: 1, T2: 2, T3: 3, T4: 4, T5: 5, T6: 6),
+    (T0: 0, T1: 1, T2: 2, T3: 3, T4: 4, T5: 5, T6: 6, T7: 7),
+);
+
 /// A unique identifier for the image cache
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ImageId(pub usize);
@@ -119,6 +158,102 @@ impl fmt::Debug for RenderImage {
 mod tests {
     use super::*;
     use smallvec::SmallVec;
+    use std::sync::{Arc, Mutex};
+
+    struct TestAssetSource<const INDEX: usize> {
+        asset: Option<&'static [u8]>,
+        files: &'static [&'static str],
+        loads: Arc<Mutex<Vec<usize>>>,
+    }
+
+    impl<const INDEX: usize> AssetSource for TestAssetSource<INDEX> {
+        fn load(&self, _path: &str) -> Result<Option<Cow<'static, [u8]>>> {
+            self.loads.lock().unwrap().push(INDEX);
+            Ok(self.asset.map(Cow::Borrowed))
+        }
+
+        fn list(&self, _path: &str) -> Result<Vec<SharedString>> {
+            Ok(self.files.iter().copied().map(SharedString::from).collect())
+        }
+    }
+
+    #[test]
+    fn tuple_asset_sources_list_assets_in_order() {
+        let loads = Arc::new(Mutex::new(Vec::new()));
+
+        let sources = (
+            TestAssetSource::<0> {
+                asset: None,
+                files: &["a", "shared"],
+                loads: loads.clone(),
+            },
+            TestAssetSource::<1> {
+                asset: None,
+                files: &["b", "shared"],
+                loads,
+            },
+        );
+
+        assert_eq!(
+            sources.list("").unwrap(),
+            vec![
+                SharedString::from("a"),
+                SharedString::from("shared"),
+                SharedString::from("b"),
+                SharedString::from("shared"),
+            ]
+        );
+    }
+
+    #[test]
+    fn tuple_asset_sources_load_first_match() {
+        let loads = Arc::new(Mutex::new(Vec::new()));
+
+        let sources = (
+            TestAssetSource::<0> {
+                asset: None,
+                files: &[],
+                loads: loads.clone(),
+            },
+            TestAssetSource::<1> {
+                asset: Some(b"asset"),
+                files: &[],
+                loads: loads.clone(),
+            },
+            TestAssetSource::<2> {
+                asset: Some(b"shadowed"),
+                files: &[],
+                loads: loads.clone(),
+            },
+        );
+
+        assert_eq!(
+            sources.load("asset").unwrap().as_deref(),
+            Some(b"asset".as_slice())
+        );
+        assert_eq!(*loads.lock().unwrap(), vec![0, 1]);
+    }
+
+    #[test]
+    fn tuple_asset_sources_return_none_when_all_sources_miss() {
+        let loads = Arc::new(Mutex::new(Vec::new()));
+
+        let sources = (
+            TestAssetSource::<0> {
+                asset: None,
+                files: &[],
+                loads: loads.clone(),
+            },
+            TestAssetSource::<1> {
+                asset: None,
+                files: &[],
+                loads: loads.clone(),
+            },
+        );
+
+        assert_eq!(sources.load("missing").unwrap(), None);
+        assert_eq!(*loads.lock().unwrap(), vec![0, 1]);
+    }
 
     #[test]
     fn empty_render_image_does_not_panic() {

--- a/crates/gpui/src/assets.rs
+++ b/crates/gpui/src/assets.rs
@@ -1,4 +1,4 @@
-use crate::{size, DevicePixels, Pixels, Result, SharedString, Size};
+use crate::{DevicePixels, Pixels, Result, SharedString, Size, size};
 use smallvec::SmallVec;
 
 use image::{Delay, Frame};


### PR DESCRIPTION
Fixes #220

# Summary
Improves assets by allowing consumers to pass in multiple sources into `Application::with_assets` via a tuple. Since rust doesn't support variadic tuple impls, we need to create an impl for each arity. This PR implements arities from 2 through 7 - which means consumers can have a maximum of 7 asset sources.

We also automatically load all font assets into the gpui application at startup. Consumers can opt out of this by calling `Application::load_font_assets(false)`. 

## Example
```rs
gpui_platform::application()
    .with_assets((AssetsA, AssetsB, AssetsC))
    .load_font_assets(false);
    
gpui_platform::application()
     // Loading a singular asset source still works as before.
     .with_assets(AssetsA).
```

## AI Disclosure
GPT 5.6-Sol helped me with this PR. All code in this PR has been read and reviewed by me. 