### PR TITLE
Extract GPUI API primitives into a new gpui_types crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,6 +2312,7 @@ dependencies = [
  "gpui_ce_shared_string",
  "gpui_ce_sum_tree",
  "gpui_ce_util",
+ "gpui_types",
  "hdrhistogram",
  "heapless",
  "http",
@@ -2436,6 +2437,7 @@ dependencies = [
  "gpui_ce_collections",
  "gpui_ce_util",
  "gpui_ce_wgpu",
+ "gpui_types",
  "image",
  "itertools 0.14.0",
  "libc",
@@ -2768,6 +2770,22 @@ dependencies = [
  "walkdir",
  "which",
  "windows 0.62.2",
+]
+
+[[package]]
+name = "gpui_types"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "etagere",
+ "gpui_ce_refineable",
+ "lyon",
+ "proptest",
+ "schemars",
+ "serde",
+ "serde_json",
+ "taffy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "./crates/gpui_windows/",
   "./crates/gpui_platform/",
   "./crates/gpui_shared_string/",
+  "./crates/gpui_types/",
   "./crates/gpui_elements/",
   "./crates/gpui_collections/",
   "./crates/gpui_refineable/",
@@ -245,6 +246,7 @@ gpui_wgpu = { path = "./crates/gpui_wgpu/", version = "0.1.0", package = "gpui_c
 
 gpui_macros = { path = "./crates/gpui_macros/", version = "0.1.0", package = "gpui_ce_macros" }
 gpui_shared_string = { path = "./crates/gpui_shared_string/", version = "0.1.0", package = "gpui_ce_shared_string" }
+gpui_types = { path = "./crates/gpui_types/", version = "0.1.0" }
 gpui_tokio = { path = "./crates/gpui_tokio/", version = "0.1.0", package = "gpui_ce_tokio" }
 
 [workspace.dependencies.windows]

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -25,6 +25,7 @@ wgpu-surfaces = []
 test-support = [
   "leak-detection",
   "collections/test-support",
+  "gpui_types/test-support",
   "wayland",
   "x11",
   "proptest",
@@ -62,6 +63,7 @@ futures.workspace = true
 futures-concurrency.workspace = true
 gpui_macros.workspace = true
 gpui_shared_string.workspace = true
+gpui_types = { workspace = true, features = ["lyon"] }
 http.workspace = true
 image.workspace = true
 inventory.workspace = true

--- a/crates/gpui/src/app/bench_context.rs
+++ b/crates/gpui/src/app/bench_context.rs
@@ -10,10 +10,11 @@ use anyhow::{Result, anyhow};
 use hdrhistogram::Histogram;
 
 use crate::{
-    AnyView, AnyWindowHandle, App, AppCell, AppContext, BackgroundExecutor, Bounds, Context, Empty,
-    Entity, EntityId, EventEmitter, Focusable, ForegroundExecutor, Global, Platform,
-    PlatformHeadlessRenderer, PlatformTextSystem, Render, Reservation, Task, TestPlatform,
-    ThreadedDispatcher, VisualContext, Window, WindowBounds, WindowHandle, WindowOptions,
+    AnyView, AnyWindowHandle, App, AppCell, AppContext, BackgroundExecutor, Bounds, BoundsExt,
+    Context, Empty, Entity, EntityId, EventEmitter, Focusable, ForegroundExecutor, Global,
+    Platform, PlatformHeadlessRenderer, PlatformTextSystem, Render, Reservation, Task,
+    TestPlatform, ThreadedDispatcher, VisualContext, Window, WindowBounds, WindowHandle,
+    WindowOptions,
     app::GpuiBorrow,
     profiler::{
         self, FrameEvent, FrameTimingCollector,

--- a/crates/gpui/src/app/test_app.rs
+++ b/crates/gpui/src/app/test_app.rs
@@ -26,8 +26,8 @@
 
 use crate::{
     AnyWindowHandle, App, AppCell, AppContext, AsyncApp, BackgroundExecutor, BorrowAppContext,
-    Bounds, ClipboardItem, Context, Entity, ForegroundExecutor, Global, InputEvent, Keystroke,
-    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Platform,
+    Bounds, BoundsExt, ClipboardItem, Context, Entity, ForegroundExecutor, Global, InputEvent,
+    Keystroke, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Platform,
     PlatformTextSystem, Point, Render, Size, Task, TestDispatcher, TestPlatform, TextSystem,
     Window, WindowBounds, WindowHandle, WindowOptions, app::GpuiMode,
 };

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -1,9 +1,9 @@
 use crate::{
     Action, AnyView, AnyWindowHandle, App, AppCell, AppContext, AsyncApp, AvailableSpace,
-    BackgroundExecutor, BorrowAppContext, Bounds, Capslock, ClipboardItem, DrawPhase, Drawable,
-    Element, Empty, EntityId, EventEmitter, ForegroundExecutor, Global, InputEvent, Keystroke,
-    Modifiers, ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
-    Pixels, Platform, Point, Render, Result, SharedString, Size, SystemNotification,
+    BackgroundExecutor, BorrowAppContext, Bounds, BoundsExt, Capslock, ClipboardItem, DrawPhase,
+    Drawable, Element, Empty, EntityId, EventEmitter, ForegroundExecutor, Global, InputEvent,
+    Keystroke, Modifiers, ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseMoveEvent,
+    MouseUpEvent, Pixels, Platform, Point, Render, Result, SharedString, Size, SystemNotification,
     SystemNotificationResponse, Task, TestDispatcher, TestPlatform, TestScreenCaptureSource,
     TestWindow, TextSystem, VisualContext, Window, WindowBounds, WindowHandle, WindowOptions,
     app::GpuiMode, window::ElementArenaScope,

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -24,7 +24,6 @@ mod elements;
 mod executor;
 mod platform_scheduler;
 pub(crate) use platform_scheduler::PlatformScheduler;
-mod geometry;
 mod gestures;
 mod global;
 mod input;
@@ -108,7 +107,6 @@ pub use debug_overlay::*;
 pub use element::*;
 pub use elements::*;
 pub use executor::*;
-pub use geometry::*;
 pub use gestures::*;
 pub use global::*;
 pub use gpui_macros::{
@@ -140,6 +138,7 @@ macro_rules! bench_main {
     };
 }
 pub use gpui_shared_string::*;
+pub use gpui_types::*;
 pub use gpui_util::arc_cow::ArcCow;
 /// HTTP client abstraction for making requests.
 pub mod http_client;
@@ -165,8 +164,8 @@ pub use styled::*;
 pub use subscription::*;
 pub use svg_renderer::*;
 pub(crate) use tab_stop::*;
+pub use taffy::LayoutId;
 use taffy::TaffyLayoutEngine;
-pub use taffy::{AvailableSpace, LayoutId};
 #[cfg(any(test, feature = "test-support"))]
 pub use test::*;
 pub use text_system::*;
@@ -177,6 +176,52 @@ pub use window::*;
 
 #[cfg(not(target_family = "wasm"))]
 pub use pollster::block_on;
+
+/// Extension methods on [`Bounds`] that need to resolve the application's displays.
+///
+/// These live in `gpui` rather than `gpui_types` because they require [`App`], while
+/// the base [`Bounds`] type is defined in the platform-agnostic `gpui_types` crate.
+pub trait BoundsExt: Sized {
+    /// Generate a centered bounds for the given display or primary display if none is provided
+    fn centered(display_id: Option<DisplayId>, size: Size<Pixels>, cx: &App) -> Self;
+
+    /// Generate maximized bounds for the given display or primary display if none is provided
+    fn maximized(display_id: Option<DisplayId>, cx: &App) -> Self;
+}
+
+impl BoundsExt for Bounds<Pixels> {
+    fn centered(display_id: Option<DisplayId>, size: Size<Pixels>, cx: &App) -> Self {
+        let display = display_id
+            .and_then(|id| cx.find_display(id))
+            .or_else(|| cx.primary_display());
+
+        display
+            .map(|display| Bounds::centered_at(display.bounds().center(), size))
+            .unwrap_or_else(|| Bounds {
+                origin: point(px(0.), px(0.)),
+                size,
+            })
+    }
+
+    fn maximized(display_id: Option<DisplayId>, cx: &App) -> Self {
+        let display = display_id
+            .and_then(|id| cx.find_display(id))
+            .or_else(|| cx.primary_display());
+
+        display
+            .map(|display| display.bounds())
+            .unwrap_or_else(|| Bounds {
+                origin: point(px(0.), px(0.)),
+                size: size(px(1024.), px(768.)),
+            })
+    }
+}
+
+impl HasRemSize for Window {
+    fn rem_size(&self) -> Pixels {
+        Window::rem_size(self)
+    }
+}
 
 /// The context trait, allows the different contexts in GPUI to be used
 /// interchangeably for certain operations.

--- a/crates/gpui/src/path_builder.rs
+++ b/crates/gpui/src/path_builder.rs
@@ -1,7 +1,6 @@
 use anyhow::Error;
-use etagere::euclid::{Point2D, Vector2D};
+use etagere::euclid::Vector2D;
 use lyon::geom::Angle;
-use lyon::math::{Vector, vector};
 use lyon::path::traits::SvgPathBuilder;
 use lyon::path::{ArcFlags, Polygon};
 use lyon::tessellation::{
@@ -11,7 +10,7 @@ use lyon::tessellation::{
 pub use lyon::math::Transform;
 pub use lyon::tessellation::{FillOptions, FillRule, StrokeOptions};
 
-use crate::{Path, Pixels, Point, point, px};
+use crate::{Path, Pixels, Point, point};
 
 /// Style of the PathBuilder
 pub enum PathStyle {
@@ -45,30 +44,6 @@ impl From<lyon::path::builder::WithSvg<lyon::path::BuilderImpl>> for PathBuilder
             raw,
             ..Default::default()
         }
-    }
-}
-
-impl From<lyon::math::Point> for Point<Pixels> {
-    fn from(p: lyon::math::Point) -> Self {
-        point(px(p.x), px(p.y))
-    }
-}
-
-impl From<Point<Pixels>> for lyon::math::Point {
-    fn from(p: Point<Pixels>) -> Self {
-        lyon::math::point(p.x.0, p.y.0)
-    }
-}
-
-impl From<Point<Pixels>> for Vector {
-    fn from(p: Point<Pixels>) -> Self {
-        vector(p.x.0, p.y.0)
-    }
-}
-
-impl From<Point<Pixels>> for Point2D<f32, Pixels> {
-    fn from(p: Point<Pixels>) -> Self {
-        Point2D::new(p.x.0, p.y.0)
     }
 }
 

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -41,7 +41,7 @@ pub(crate) type PlatformScreenCaptureFrame = core_video::image_buffer::CVImageBu
 pub(crate) type PlatformScreenCaptureFrame = ();
 
 use crate::{
-    Action, AnyWindowHandle, App, AsyncWindowContext, BackgroundExecutor, Bounds,
+    Action, AnyWindowHandle, App, AsyncWindowContext, BackgroundExecutor, Bounds, BoundsExt,
     DEFAULT_WINDOW_SIZE, DevicePixels, DispatchEventResult, Edges, ExternalDragPayload, Font,
     FontId, FontMetrics, FontRun, ForegroundExecutor, GlyphId, GpuSpecs, ImageSource, Keymap,
     LineLayout, Pixels, PlatformGestures, PlatformInput, Point, Priority, RenderGlyphParams,

--- a/crates/gpui/src/prelude.rs
+++ b/crates/gpui/src/prelude.rs
@@ -3,7 +3,7 @@
 //! application to avoid having to import each trait individually.
 
 pub use crate::{
-    AppContext as _, BorrowAppContext, Context, Element, InteractiveElement, IntoElement,
-    ParentElement, Refineable, Render, RenderOnce, StatefulInteractiveElement, Styled, StyledImage,
-    TaskExt as _, VisualContext, util::FluentBuilder,
+    AppContext as _, BorrowAppContext, BoundsExt, Context, Element, InteractiveElement,
+    IntoElement, ParentElement, Refineable, Render, RenderOnce, StatefulInteractiveElement, Styled,
+    StyledImage, TaskExt as _, VisualContext, util::FluentBuilder,
 };

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AbsoluteLength, App, Bounds, DefiniteLength, Edges, GridTemplate, Length, Pixels, Point, Size,
-    Style, Window, size,
+    AbsoluteLength, App, AvailableSpace, Bounds, DefiniteLength, Edges, GridTemplate, Length,
+    Pixels, Point, Size, Style, Window, size,
     util::{
         ceil_to_device_pixel, round_half_toward_zero, round_stroke_to_device_pixel,
         round_to_device_pixel,
@@ -10,9 +10,8 @@ use collections::{FxHashMap, FxHashSet};
 use std::{fmt::Debug, ops::Range};
 use taffy::{
     TaffyTree, TraversePartialTree as _,
-    geometry::{Point as TaffyPoint, Rect as TaffyRect, Size as TaffySize},
+    geometry::{Rect as TaffyRect, Size as TaffySize},
     prelude::{max_content, min_content},
-    style::AvailableSpace as TaffyAvailableSpace,
     tree::NodeId,
 };
 
@@ -687,31 +686,6 @@ impl ToTaffy<taffy::style::Dimension> for AbsoluteLength {
     }
 }
 
-impl<T, T2> From<TaffyPoint<T>> for Point<T2>
-where
-    T: Into<T2>,
-    T2: Clone + Debug + Default + PartialEq,
-{
-    fn from(point: TaffyPoint<T>) -> Point<T2> {
-        Point {
-            x: point.x.into(),
-            y: point.y.into(),
-        }
-    }
-}
-
-impl<T, T2> From<Point<T>> for TaffyPoint<T2>
-where
-    T: Into<T2> + Clone + Debug + Default + PartialEq,
-{
-    fn from(val: Point<T>) -> Self {
-        TaffyPoint {
-            x: val.x.into(),
-            y: val.y.into(),
-        }
-    }
-}
-
 impl<T, U> ToTaffy<TaffySize<U>> for Size<T>
 where
     T: ToTaffy<U> + Clone + Debug + Default + PartialEq,
@@ -734,100 +708,6 @@ where
             right: self.right.to_taffy(rem_size, scale_factor),
             bottom: self.bottom.to_taffy(rem_size, scale_factor),
             left: self.left.to_taffy(rem_size, scale_factor),
-        }
-    }
-}
-
-impl<T, U> From<TaffySize<T>> for Size<U>
-where
-    T: Into<U>,
-    U: Clone + Debug + Default + PartialEq,
-{
-    fn from(taffy_size: TaffySize<T>) -> Self {
-        Size {
-            width: taffy_size.width.into(),
-            height: taffy_size.height.into(),
-        }
-    }
-}
-
-impl<T, U> From<Size<T>> for TaffySize<U>
-where
-    T: Into<U> + Clone + Debug + Default + PartialEq,
-{
-    fn from(size: Size<T>) -> Self {
-        TaffySize {
-            width: size.width.into(),
-            height: size.height.into(),
-        }
-    }
-}
-
-/// The space available for an element to be laid out in
-#[derive(Copy, Clone, Default, Debug, Eq, PartialEq)]
-pub enum AvailableSpace {
-    /// The amount of space available is the specified number of pixels
-    Definite(Pixels),
-    /// The amount of space available is indefinite and the node should be laid out under a min-content constraint
-    #[default]
-    MinContent,
-    /// The amount of space available is indefinite and the node should be laid out under a max-content constraint
-    MaxContent,
-}
-
-impl AvailableSpace {
-    /// Returns a `Size` with both width and height set to `AvailableSpace::MinContent`.
-    ///
-    /// This function is useful when you want to create a `Size` with the minimum content constraints
-    /// for both dimensions.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use gpui::AvailableSpace;
-    /// let min_content_size = AvailableSpace::min_size();
-    /// assert_eq!(min_content_size.width, AvailableSpace::MinContent);
-    /// assert_eq!(min_content_size.height, AvailableSpace::MinContent);
-    /// ```
-    pub const fn min_size() -> Size<Self> {
-        Size {
-            width: Self::MinContent,
-            height: Self::MinContent,
-        }
-    }
-}
-
-impl From<AvailableSpace> for TaffyAvailableSpace {
-    fn from(space: AvailableSpace) -> TaffyAvailableSpace {
-        match space {
-            AvailableSpace::Definite(Pixels(value)) => TaffyAvailableSpace::Definite(value),
-            AvailableSpace::MinContent => TaffyAvailableSpace::MinContent,
-            AvailableSpace::MaxContent => TaffyAvailableSpace::MaxContent,
-        }
-    }
-}
-
-impl From<TaffyAvailableSpace> for AvailableSpace {
-    fn from(space: TaffyAvailableSpace) -> AvailableSpace {
-        match space {
-            TaffyAvailableSpace::Definite(value) => AvailableSpace::Definite(Pixels(value)),
-            TaffyAvailableSpace::MinContent => AvailableSpace::MinContent,
-            TaffyAvailableSpace::MaxContent => AvailableSpace::MaxContent,
-        }
-    }
-}
-
-impl From<Pixels> for AvailableSpace {
-    fn from(pixels: Pixels) -> Self {
-        AvailableSpace::Definite(pixels)
-    }
-}
-
-impl From<Size<Pixels>> for Size<AvailableSpace> {
-    fn from(size: Size<Pixels>) -> Self {
-        Size {
-            width: AvailableSpace::Definite(size.width),
-            height: AvailableSpace::Definite(size.height),
         }
     }
 }

--- a/crates/gpui_linux/Cargo.toml
+++ b/crates/gpui_linux/Cargo.toml
@@ -56,6 +56,7 @@ collections.workspace = true
 image.workspace = true
 futures.workspace = true
 gpui.workspace = true
+gpui_types.workspace = true
 gpui_util.workspace = true
 gpui_wgpu = { workspace = true, optional = true, features = ["font-kit"] }
 itertools.workspace = true

--- a/crates/gpui_linux/src/linux/platform.rs
+++ b/crates/gpui_linux/src/linux/platform.rs
@@ -31,7 +31,7 @@ use gpui::{
     WindowButtonLayout, WindowParams,
 };
 #[cfg(any(feature = "wayland", feature = "x11"))]
-use gpui::{Pixels, Point, px};
+use gpui_types::{Pixels, Point, px};
 
 #[cfg(any(feature = "wayland", feature = "x11"))]
 pub(crate) const SCROLL_LINES: f32 = 3.0;

--- a/crates/gpui_types/Cargo.toml
+++ b/crates/gpui_types/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "gpui_types"
+version = "0.1.0"
+publish.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/gpui_types.rs"
+doctest = false
+
+[features]
+default = []
+lyon = ["dep:lyon", "dep:etagere"]
+proptest = ["dep:proptest"]
+test-support = ["proptest"]
+
+[dependencies]
+anyhow.workspace = true
+derive_more.workspace = true
+etagere = { workspace = true, optional = true }
+lyon = { version = "1.0", optional = true }
+refineable.workspace = true
+schemars.workspace = true
+serde.workspace = true
+taffy = "=0.13.0"
+proptest = { workspace = true, optional = true }
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/gpui_types/LICENSE-APACHE
+++ b/crates/gpui_types/LICENSE-APACHE
@@ -1,0 +1,222 @@
+Copyright 2022 - 2025 Zed Industries, Inc.
+
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+
+
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+
+   1. Definitions.
+
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+
+   END OF TERMS AND CONDITIONS

--- a/crates/gpui_types/src/geometry.rs
+++ b/crates/gpui_types/src/geometry.rs
@@ -18,8 +18,6 @@ use std::{
 };
 use taffy::prelude::{TaffyGridLine, TaffyGridSpan};
 
-use crate::{App, DisplayId};
-
 /// Axis in a 2D cartesian space.
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub enum Axis {
@@ -762,36 +760,6 @@ pub fn bounds<T: Clone + Debug + Default + PartialEq>(
     size: Size<T>,
 ) -> Bounds<T> {
     Bounds { origin, size }
-}
-
-impl Bounds<Pixels> {
-    /// Generate a centered bounds for the given display or primary display if none is provided
-    pub fn centered(display_id: Option<DisplayId>, size: Size<Pixels>, cx: &App) -> Self {
-        let display = display_id
-            .and_then(|id| cx.find_display(id))
-            .or_else(|| cx.primary_display());
-
-        display
-            .map(|display| Bounds::centered_at(display.bounds().center(), size))
-            .unwrap_or_else(|| Bounds {
-                origin: point(px(0.), px(0.)),
-                size,
-            })
-    }
-
-    /// Generate maximized bounds for the given display or primary display if none is provided
-    pub fn maximized(display_id: Option<DisplayId>, cx: &App) -> Self {
-        let display = display_id
-            .and_then(|id| cx.find_display(id))
-            .or_else(|| cx.primary_display());
-
-        display
-            .map(|display| display.bounds())
-            .unwrap_or_else(|| Bounds {
-                origin: point(px(0.), px(0.)),
-                size: size(px(1024.), px(768.)),
-            })
-    }
 }
 
 impl<T> Bounds<T>
@@ -2672,7 +2640,10 @@ impl From<Percentage> for Radians {
     JsonSchema,
 )]
 #[repr(transparent)]
-pub struct Pixels(pub(crate) f32);
+pub struct Pixels(
+    /// The raw pixel value.
+    pub f32,
+);
 
 impl Div for Pixels {
     type Output = f32;
@@ -3222,7 +3193,7 @@ impl MulAssign<f32> for ScaledPixels {
     }
 }
 
-/// Represents a length in rems, a unit based on the font-size of the window, which can be assigned with [`Window::set_rem_size`][set_rem_size].
+/// Represents a length in rems, a unit based on the font-size of the window, which can be assigned with `Window::set_rem_size`.
 ///
 /// Rems are used for defining lengths that are scalable and consistent across different UI elements.
 /// The value of `1rem` is typically equal to the font-size of the root element (often the `<html>` element in browsers),
@@ -3230,10 +3201,17 @@ impl MulAssign<f32> for ScaledPixels {
 /// purpose, allowing for scalable and accessible design that can adjust to different display settings or user preferences.
 ///
 /// For example, if the root element's font-size is `16px`, then `1rem` equals `16px`. A length of `2rems` would then be `32px`.
-///
-/// [set_rem_size]: crate::Window::set_rem_size
 #[derive(Clone, Copy, Default, Add, Sub, Mul, Div, Neg, PartialEq)]
 pub struct Rems(pub f32);
+
+/// A source of the current rem size, used to convert [`Pixels`] to [`Rems`].
+///
+/// Implementing this for the window type lets [`Rems::from_pixels`] live in this
+/// crate without depending on the rest of GPUI.
+pub trait HasRemSize {
+    /// The size of one rem, in pixels.
+    fn rem_size(&self) -> Pixels;
+}
 
 impl Rems {
     /// A length of zero.
@@ -3242,9 +3220,9 @@ impl Rems {
     pub fn to_pixels(self, rem_size: Pixels) -> Pixels {
         self * rem_size
     }
-    /// Convert from pixels to Rem
-    pub fn from_pixels(length: Pixels, window: &gpui::Window) -> Self {
-        Self(length / window.rem_size())
+    /// Convert from pixels to Rem, using the rem size reported by `source`.
+    pub fn from_pixels(length: Pixels, source: &impl HasRemSize) -> Self {
+        Self(length / source.rem_size())
     }
 }
 

--- a/crates/gpui_types/src/gpui_types.rs
+++ b/crates/gpui_types/src/gpui_types.rs
@@ -1,0 +1,22 @@
+//! Core API primitive types shared between GPUI and its platform backends.
+//!
+//! This crate sits at the bottom of GPUI's dependency graph. It holds the pure
+//! value types — geometry (`Pixels`, `Point`, `Size`, `Bounds`, …) and colors
+//! (`Rgba`, `Hsla`, `Background`, …) — that both the `gpui` crate and the
+//! platform implementations depend on.
+//!
+//! Keeping these types here means a platform backend can depend on the API
+//! primitives without depending on all of `gpui`. The `gpui` crate re-exports
+//! everything in this crate, so `gpui::Pixels` and `gpui_types::Pixels` name
+//! the same type and consumers do not need to know this crate exists.
+
+#![warn(missing_docs)]
+
+mod geometry;
+mod layout;
+
+#[cfg(feature = "lyon")]
+mod lyon_bridge;
+
+pub use geometry::*;
+pub use layout::*;

--- a/crates/gpui_types/src/layout.rs
+++ b/crates/gpui_types/src/layout.rs
@@ -1,0 +1,125 @@
+//! Layout-space primitives and conversions to [`taffy`] types.
+//!
+//! These live here because Rust's orphan rules require `From` impls that bridge
+//! two foreign types to be defined in the crate that owns one of them. Now that
+//! [`Point`] and [`Size`] live in this crate, the conversions between them and
+//! taffy's geometry types must be defined here too.
+
+use core::fmt::Debug;
+
+use taffy::{
+    geometry::{Point as TaffyPoint, Size as TaffySize},
+    style::AvailableSpace as TaffyAvailableSpace,
+};
+
+use crate::{Pixels, Point, Size};
+
+impl<T, T2> From<TaffyPoint<T>> for Point<T2>
+where
+    T: Into<T2>,
+    T2: Clone + Debug + Default + PartialEq,
+{
+    fn from(point: TaffyPoint<T>) -> Point<T2> {
+        Point {
+            x: point.x.into(),
+            y: point.y.into(),
+        }
+    }
+}
+
+impl<T, T2> From<Point<T>> for TaffyPoint<T2>
+where
+    T: Into<T2> + Clone + Debug + Default + PartialEq,
+{
+    fn from(val: Point<T>) -> Self {
+        TaffyPoint {
+            x: val.x.into(),
+            y: val.y.into(),
+        }
+    }
+}
+
+impl<T, U> From<TaffySize<T>> for Size<U>
+where
+    T: Into<U>,
+    U: Clone + Debug + Default + PartialEq,
+{
+    fn from(taffy_size: TaffySize<T>) -> Self {
+        Size {
+            width: taffy_size.width.into(),
+            height: taffy_size.height.into(),
+        }
+    }
+}
+
+impl<T, U> From<Size<T>> for TaffySize<U>
+where
+    T: Into<U> + Clone + Debug + Default + PartialEq,
+{
+    fn from(size: Size<T>) -> Self {
+        TaffySize {
+            width: size.width.into(),
+            height: size.height.into(),
+        }
+    }
+}
+
+/// The space available for an element to be laid out in
+#[derive(Copy, Clone, Default, Debug, Eq, PartialEq)]
+pub enum AvailableSpace {
+    /// The amount of space available is the specified number of pixels
+    Definite(Pixels),
+    /// The amount of space available is indefinite and the node should be laid out under a min-content constraint
+    #[default]
+    MinContent,
+    /// The amount of space available is indefinite and the node should be laid out under a max-content constraint
+    MaxContent,
+}
+
+impl AvailableSpace {
+    /// Returns a `Size` with both width and height set to `AvailableSpace::MinContent`.
+    ///
+    /// This function is useful when you want to create a `Size` with the minimum content constraints
+    /// for both dimensions.
+    pub const fn min_size() -> Size<Self> {
+        Size {
+            width: Self::MinContent,
+            height: Self::MinContent,
+        }
+    }
+}
+
+impl From<AvailableSpace> for TaffyAvailableSpace {
+    fn from(space: AvailableSpace) -> TaffyAvailableSpace {
+        match space {
+            AvailableSpace::Definite(Pixels(value)) => TaffyAvailableSpace::Definite(value),
+            AvailableSpace::MinContent => TaffyAvailableSpace::MinContent,
+            AvailableSpace::MaxContent => TaffyAvailableSpace::MaxContent,
+        }
+    }
+}
+
+impl From<TaffyAvailableSpace> for AvailableSpace {
+    fn from(space: TaffyAvailableSpace) -> AvailableSpace {
+        match space {
+            TaffyAvailableSpace::Definite(value) => AvailableSpace::Definite(Pixels(value)),
+            TaffyAvailableSpace::MinContent => AvailableSpace::MinContent,
+            TaffyAvailableSpace::MaxContent => AvailableSpace::MaxContent,
+        }
+    }
+}
+
+impl From<Pixels> for AvailableSpace {
+    fn from(pixels: Pixels) -> Self {
+        AvailableSpace::Definite(pixels)
+    }
+}
+
+impl From<Size<Pixels>> for Size<AvailableSpace> {
+    fn from(size: Size<Pixels>) -> Self {
+        Size {
+            width: AvailableSpace::Definite(size.width),
+            height: AvailableSpace::Definite(size.height),
+        }
+    }
+}

--- a/crates/gpui_types/src/lyon_bridge.rs
+++ b/crates/gpui_types/src/lyon_bridge.rs
@@ -1,0 +1,36 @@
+//! Conversions between this crate's geometry and [`lyon`] path geometry.
+//!
+//! These conversions are gated behind the `lyon` feature so that consumers of
+//! the core primitives do not pull in a rendering dependency. They live here,
+//! rather than next to the path builder that uses them, because Rust's orphan
+//! rules only allow `From` impls bridging two foreign types to be defined in the
+//! crate that owns one of them.
+
+use etagere::euclid::Point2D;
+use lyon::math::{Vector, vector};
+
+use crate::{Pixels, Point, point, px};
+
+impl From<lyon::math::Point> for Point<Pixels> {
+    fn from(p: lyon::math::Point) -> Self {
+        point(px(p.x), px(p.y))
+    }
+}
+
+impl From<Point<Pixels>> for lyon::math::Point {
+    fn from(p: Point<Pixels>) -> Self {
+        lyon::math::point(p.x.0, p.y.0)
+    }
+}
+
+impl From<Point<Pixels>> for Vector {
+    fn from(p: Point<Pixels>) -> Self {
+        vector(p.x.0, p.y.0)
+    }
+}
+
+impl From<Point<Pixels>> for Point2D<f32, Pixels> {
+    fn from(p: Point<Pixels>) -> Self {
+        Point2D::new(p.x.0, p.y.0)
+    }
+}


### PR DESCRIPTION
Cherry-pick from https://github.com/zed-industries/zed/pull/64087

Introduce crates/gpui_types, holding the self-contained value types shared by GPUI and its platform backends. In this port it contains geometry (Pixels, Point, Size, Bounds, ...) and the taffy layout bridge (AvailableSpace, ...).

gpui now depends on and re-exports gpui_types, so gpui::Pixels and gpui_types::Pixels name the same type and downstream code is unchanged. gpui_linux imports its geometry primitives from gpui_types directly.

Unlike upstream, color is not extracted: gpui-ce's color module re-exports palette's Hsla/Rgba, and its Background/LinearColorStop are backed by SceneHsla (defined in scene.rs), so that module is not self-contained.

Methods that require App/Window stay in gpui as the BoundsExt and HasRemSize extension traits. Conversions bridging two foreign types (taffy, lyon) moved to gpui_types to satisfy the orphan rule, with the lyon conversions behind an optional lyon feature.

Release Notes:

- N/A