### PR TITLE
Expand Deferred element api

### DIFF
--- a/crates/gpui/src/elements/anchored.rs
+++ b/crates/gpui/src/elements/anchored.rs
@@ -320,7 +320,7 @@ mod tests {
                                         .h(px(300.)),
                                 ),
                         )
-                        .with_priority(1),
+                        .priority(1),
                     ),
             )
         }

--- a/crates/gpui/src/elements/deferred.rs
+++ b/crates/gpui/src/elements/deferred.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AnyElement, App, Bounds, Element, GlobalElementId, InspectorElementId, IntoElement, LayoutId,
-    Pixels, Window,
+    AnyElement, App, Bounds, ContentMask, Element, GlobalElementId, InspectorElementId,
+    IntoElement, LayoutId, Pixels, Window,
 };
 
 /// Builds a `Deferred` element, which delays the layout and paint of its child.
@@ -8,6 +8,7 @@ pub fn deferred(child: impl IntoElement) -> Deferred {
     Deferred {
         child: Some(child.into_any_element()),
         priority: 0,
+        content_mask: None,
     }
 }
 
@@ -16,6 +17,7 @@ pub fn deferred(child: impl IntoElement) -> Deferred {
 pub struct Deferred {
     child: Option<AnyElement>,
     priority: usize,
+    content_mask: Option<ContentMask<Pixels>>,
 }
 
 impl Element for Deferred {
@@ -52,7 +54,7 @@ impl Element for Deferred {
     ) {
         let child = self.child.take().unwrap();
         let element_offset = window.element_offset();
-        window.defer_draw(child, element_offset, self.priority, None)
+        window.defer_draw(child, element_offset, self.priority, self.content_mask)
     }
 
     fn paint(
@@ -77,6 +79,13 @@ impl IntoElement for Deferred {
 }
 
 impl Deferred {
+    /// When a content mask is provided, the deferred element will be clipped to that region during
+    /// both prepaint and paint.
+    pub fn content_mask(mut self, mask: ContentMask<Pixels>) -> Self {
+        self.content_mask = Some(mask);
+        self
+    }
+
     /// Sets a priority for the element. A higher priority conceptually means painting the element
     /// on top of deferred draws with a lower priority (i.e. closer to the viewer).
     pub fn priority(mut self, priority: usize) -> Self {

--- a/crates/gpui/src/elements/deferred.rs
+++ b/crates/gpui/src/elements/deferred.rs
@@ -7,16 +7,20 @@ use crate::{
 pub fn deferred(child: impl IntoElement) -> Deferred {
     Deferred {
         child: Some(child.into_any_element()),
-        priority: 0,
+        priority: DeferredPriority::from(0),
         content_mask: None,
     }
 }
 
 /// An element which delays the painting of its child until after all of
 /// its ancestors, while keeping its layout as part of the current element tree.
+///
+/// Per [`Window::prepaint_deferred_draws`], deferred elements causing additional deferred elements
+/// should be constrained to limited circumstances and will stop processing after some depth
+/// (otherwise the renderer would be subject to an infinite loop when processing deferred draws).
 pub struct Deferred {
     child: Option<AnyElement>,
-    priority: usize,
+    priority: DeferredPriority,
     content_mask: Option<ContentMask<Pixels>>,
 }
 
@@ -50,11 +54,12 @@ impl Element for Deferred {
         _bounds: Bounds<Pixels>,
         _request_layout: &mut Self::RequestLayoutState,
         window: &mut Window,
-        _cx: &mut App,
+        cx: &mut App,
     ) {
         let child = self.child.take().unwrap();
         let element_offset = window.element_offset();
-        window.defer_draw(child, element_offset, self.priority, self.content_mask)
+        let priority = self.priority.evaluate(cx);
+        window.defer_draw(child, element_offset, priority, self.content_mask);
     }
 
     fn paint(
@@ -79,18 +84,73 @@ impl IntoElement for Deferred {
 }
 
 impl Deferred {
+    /// Sets a priority for the element. A higher priority conceptually means painting the element
+    /// on top of deferred draws with a lower priority (i.e. closer to the viewer).
+    pub fn priority(mut self, priority: impl Into<DeferredPriority>) -> Self {
+        self.priority = priority.into();
+        self
+    }
+
+    /// Configures the priority of the deferred element to be 1 greater than the previous
+    /// deferred element (when this element is caused by another deferred element, even if indirectly).
+    /// Defaults to 1 when this is a deferred element caused by non-deferred elements.
+    pub fn priority_auto(mut self) -> Self {
+        self.priority = DeferredPriority::Auto;
+        self
+    }
+
     /// When a content mask is provided, the deferred element will be clipped to that region during
     /// both prepaint and paint.
     pub fn content_mask(mut self, mask: ContentMask<Pixels>) -> Self {
         self.content_mask = Some(mask);
         self
     }
+}
 
-    /// Sets a priority for the element. A higher priority conceptually means painting the element
-    /// on top of deferred draws with a lower priority (i.e. closer to the viewer).
-    pub fn priority(mut self, priority: usize) -> Self {
-        self.priority = priority;
-        self
+/// Describes how the priority for a [`Deferred`] element is calculated.
+pub enum DeferredPriority {
+    /// The priority is calculated based on whether the deferred element is a by-product of another deferred element.
+    /// If this is the first deferred element in a rendering stack, priority is 1.
+    /// Otherwise the priority is the previous priority + 1 (so this element renders in front of the previous in the stack).
+    Auto,
+    /// Takes an explicit priority value for the deferred element.
+    Value(usize),
+}
+impl From<usize> for DeferredPriority {
+    fn from(value: usize) -> Self {
+        Self::Value(value)
+    }
+}
+impl DeferredPriority {
+    /// Calculates the new priority based on the current value in the [`DeferredPriorityStackCache`].
+    /// Should only be called during prepaint of a [`Deferred`] element.
+    fn evaluate(&self, cx: &App) -> usize {
+        match self {
+            DeferredPriority::Value(value) => *value,
+            DeferredPriority::Auto => match DeferredPriorityStackCache::current_depth(cx) {
+                None => 1, // NOTE: functionality change. If using auto, we start at a priority of 1 instead of 0.
+                Some(prev_deferred_priority) => prev_deferred_priority.saturating_add(1),
+            },
+        }
+    }
+}
+
+/// Internal global to track the depth of deferred renders during prepaint.
+#[derive(Default)]
+pub(crate) struct DeferredPriorityStackCache(Vec<usize>);
+impl crate::Global for DeferredPriorityStackCache {}
+impl DeferredPriorityStackCache {
+    pub(crate) fn push(priority: usize, cx: &mut App) {
+        cx.default_global::<Self>().0.push(priority);
+    }
+
+    pub(crate) fn pop(cx: &mut App) {
+        cx.default_global::<Self>().0.pop();
+    }
+
+    fn current_depth(cx: &App) -> Option<usize> {
+        let cache = cx.try_global::<Self>()?;
+        cache.0.last().copied()
     }
 }
 

--- a/crates/gpui/src/elements/deferred.rs
+++ b/crates/gpui/src/elements/deferred.rs
@@ -18,16 +18,6 @@ pub struct Deferred {
     priority: usize,
 }
 
-impl Deferred {
-    /// Sets the `priority` value of the `deferred` element, which
-    /// determines the drawing order relative to other deferred elements,
-    /// with higher values being drawn on top.
-    pub fn with_priority(mut self, priority: usize) -> Self {
-        self.priority = priority;
-        self
-    }
-}
-
 impl Element for Deferred {
     type RequestLayoutState = ();
     type PrepaintState = ();
@@ -122,11 +112,11 @@ mod tests {
                                         .h(px(50.)),
                                 ),
                             )
-                            .with_priority(2),
+                            .priority(2),
                         ),
                     ),
                 )
-                .with_priority(1),
+                .priority(1),
             )
         }
     }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3343,13 +3343,22 @@ impl Window {
             traversal_order.sort_by_key(|ix| self.next_frame.deferred_draws[*ix].priority);
 
             for deferred_draw_ix in traversal_order {
-                let (element, parent_node, current_view, rem_size, absolute_offset, prepaint_range) = {
+                let (
+                    priority,
+                    element,
+                    parent_node,
+                    current_view,
+                    rem_size,
+                    absolute_offset,
+                    prepaint_range,
+                ) = {
                     let deferred_draw = &mut self.next_frame.deferred_draws[deferred_draw_ix];
                     self.element_id_stack
                         .clone_from(&deferred_draw.element_id_stack);
                     self.text_style_stack
                         .clone_from(&deferred_draw.text_style_stack);
                     (
+                        deferred_draw.priority,
                         deferred_draw.element.take(),
                         deferred_draw.parent_node,
                         deferred_draw.current_view,
@@ -3365,7 +3374,9 @@ impl Window {
                     self.with_rendered_view(current_view, |window| {
                         window.with_rem_size(Some(rem_size), |window| {
                             window.with_absolute_element_offset(absolute_offset, |window| {
+                                crate::DeferredPriorityStackCache::push(priority, cx);
                                 element.prepaint(window, cx);
+                                crate::DeferredPriorityStackCache::pop(cx);
                             });
                         });
                     });


### PR DESCRIPTION
- Remove duplicate `Deferred::with_priority` in favor of pre-existing `Deferred::priority` (both exist upstream since April 2024). Users will be expected to use the original function w/o the `with_` prefix.
- Add `Deferred::content_mask` to allow users to supply the content mask forwarded to `Window::defer_draw`.
- Update `Deferred::priority` to take an argument that converts into the new `DeferredPriority` enum (implemented for the previous arg type `usize`) and add `Deferred::priority_auto`. Auto priority will increment for each `Deferred` element in a stack such that deferred elements added by deferred elements are always in front of their parent/causer.

`priority_auto` is specifically useful for implementing popovers for context-menus: [PopoverMenu](https://codeberg.org/temportalflux/jjui/src/commit/73ae738a1c9ae8f08b1e395400a0028c1990dbfd/src/elements/popover/menu.rs#L107) and [non-menu interactable popovers](https://codeberg.org/temportalflux/jjui/src/commit/73ae738a1c9ae8f08b1e395400a0028c1990dbfd/src/view/repository_view.rs#L396). Its specifically useful for the popover-menu case because context menus that have submenus that could have submenus should cause child menus to close when a parent is clicked but shouldnt cause a parent popover to close if a child is clicked (`popover::dismiss_when_clicked_behind` in the linked PopoverMenu code).
