### PR TITLE
Surfaces clip to their element's corner radii

### DIFF
--- a/crates/gpui/src/elements/surface.rs
+++ b/crates/gpui/src/elements/surface.rs
@@ -173,11 +173,11 @@ impl Element for Surface {
         _: &mut App,
     ) {
         let new_bounds = self.object_fit.get_bounds(_bounds, self.source.size());
-        // TODO: Add support for corner_radii.
         let mut style = Style::default();
         style.refine(&self.style);
         _window.with_element_opacity(style.opacity, |window| {
-            window.paint_surface(new_bounds, self.source.clone());
+            let corner_radii = style.corner_radii.to_pixels(window.rem_size());
+            window.paint_surface(new_bounds, corner_radii, self.source.clone());
         });
     }
 }
@@ -193,5 +193,94 @@ impl IntoElement for Surface {
 impl Styled for Surface {
     fn style(&mut self) -> &mut StyleRefinement {
         &mut self.style
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{TestAppContext, point, px, size};
+
+    /// A surface inside a rounded frame must carry the frame's curve into the scene. Before
+    /// this, `paint_surface` took no radii at all and the texture drew square corners under
+    /// the frame, which is visible as four bright wedges wherever a rounded pane holds one.
+    #[crate::test]
+    fn a_rounded_surface_carries_its_radii_into_the_scene(cx: &mut TestAppContext) {
+        let window = cx.add_empty_window();
+        window.draw(point(px(0.), px(0.)), size(px(100.), px(100.)), |_, _| {
+            surface(SurfaceSource::Unsupported(size(
+                DevicePixels(100),
+                DevicePixels(100),
+            )))
+            .size_full()
+            .rounded(px(12.))
+            .into_any_element()
+        });
+
+        let (radii, expected) = window.update(|window, _| {
+            (
+                window
+                    .rendered_frame
+                    .scene
+                    .surfaces
+                    .last()
+                    .map(|painted| painted.corner_radii.top_left),
+                px(12.).scale(window.scale_factor()),
+            )
+        });
+        assert_eq!(radii, Some(expected));
+    }
+
+    /// The radii are clamped to the surface's own bounds the way an image's are, so a radius
+    /// larger than the element cannot fold the distance field back on itself.
+    #[crate::test]
+    fn radii_larger_than_the_surface_are_clamped_to_it(cx: &mut TestAppContext) {
+        let window = cx.add_empty_window();
+        window.draw(point(px(0.), px(0.)), size(px(100.), px(100.)), |_, _| {
+            surface(SurfaceSource::Unsupported(size(
+                DevicePixels(100),
+                DevicePixels(100),
+            )))
+            .size_full()
+            .rounded(px(400.))
+            .into_any_element()
+        });
+
+        let (radii, expected) = window.update(|window, _| {
+            (
+                window
+                    .rendered_frame
+                    .scene
+                    .surfaces
+                    .last()
+                    .map(|painted| painted.corner_radii.top_left),
+                px(50.).scale(window.scale_factor()),
+            )
+        });
+        assert_eq!(radii, Some(expected));
+    }
+
+    /// A plain surface still asks for square corners, so nothing that does not opt in changes.
+    #[crate::test]
+    fn a_plain_surface_still_has_square_corners(cx: &mut TestAppContext) {
+        let window = cx.add_empty_window();
+        window.draw(point(px(0.), px(0.)), size(px(100.), px(100.)), |_, _| {
+            surface(SurfaceSource::Unsupported(size(
+                DevicePixels(100),
+                DevicePixels(100),
+            )))
+            .size_full()
+            .into_any_element()
+        });
+
+        let radii = window.update(|window, _| {
+            window
+                .rendered_frame
+                .scene
+                .surfaces
+                .last()
+                .map(|painted| painted.corner_radii)
+        });
+        assert_eq!(radii, Some(crate::Corners::default()));
     }
 }

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -1075,6 +1075,7 @@ pub struct PaintSurface {
     pub order: DrawOrder,
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
+    pub corner_radii: Corners<ScaledPixels>,
     pub source: crate::SurfaceSource,
 }
 
@@ -1339,6 +1340,7 @@ mod tests {
             order: 0,
             bounds: full_bounds(),
             content_mask: mask(),
+            corner_radii: Corners::default(),
             source: SurfaceSource::Unsupported(Size::default()),
         }
     }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4795,12 +4795,16 @@ impl Window {
     pub fn paint_surface(
         &mut self,
         bounds: Bounds<Pixels>,
+        corner_radii: Corners<Pixels>,
         source: impl Into<crate::SurfaceSource>,
     ) {
         use crate::PaintSurface;
 
         self.invalidator.debug_assert_paint();
 
+        let corner_radii = corner_radii
+            .clamp_radii_for_quad_size(bounds.size)
+            .scale(self.scale_factor());
         let bounds = self.snap_bounds(bounds);
         let content_mask = self.snapped_content_mask();
         self.next_frame.scene.insert_surface(
@@ -4808,6 +4812,7 @@ impl Window {
                 order: 0,
                 bounds,
                 content_mask,
+                corner_radii,
                 source: source.into(),
             },
             self.element_opacity(),

--- a/crates/gpui_render/src/shaders/filters.rs
+++ b/crates/gpui_render/src/shaders/filters.rs
@@ -8,14 +8,11 @@ pub mod surface {
     pub struct SurfaceUniforms {
         pub bounds: Bounds,
         pub content_mask: Bounds,
+        pub corner_radii: Corners,
         pub color_format: SurfaceColorFormat,
         pub opacity: f32,
         pub padding0: u32,
         pub padding1: u32,
-        pub padding2: u32,
-        pub padding3: u32,
-        pub padding4: u32,
-        pub padding5: u32,
     }
     uniform!(group(1), binding(0), SURFACE_LOCALS: SurfaceUniforms);
     texture!(group(1), binding(1), SURFACE_TEXTURE: Texture2D<f32>);
@@ -69,15 +66,25 @@ pub mod surface {
         if is_clipped(input.clip_distances) {
             return transparent();
         }
+        // A surface inside a rounded frame must follow the frame's curve, so the sample fades
+        // by the same antialiased rounded-quad coverage a polychrome sprite uses. Square
+        // corners are the common case and cost nothing extra: zero radii make the distance
+        // field a plain rectangle, whose coverage is 1 everywhere inside the bounds.
+        let factor = get!(SURFACE_LOCALS).opacity
+            * antialiased_coverage(rounded_rectangle_signed_distance(
+                input.position.xy(),
+                get!(SURFACE_LOCALS).bounds,
+                get!(SURFACE_LOCALS).corner_radii,
+            ));
         if get!(SURFACE_LOCALS).color_format == SurfaceColorFormat::Yuv {
-            return sample_yuv_surface(input.texture_position) * get!(SURFACE_LOCALS).opacity;
+            return sample_yuv_surface(input.texture_position) * factor;
         }
         texture_sample_level(
             SURFACE_TEXTURE,
             SURFACE_SAMPLER,
             input.texture_position,
             0.0,
-        ) * get!(SURFACE_LOCALS).opacity
+        ) * factor
     }
 }
 

--- a/crates/gpui_render/src/shaders/interface.rs
+++ b/crates/gpui_render/src/shaders/interface.rs
@@ -199,14 +199,11 @@ pub const RENDER_BUFFER_LAYOUTS: &[gpui::SceneBufferLayout] = &[
         "SurfaceUniforms",
         bounds,
         content_mask,
+        corner_radii,
         color_format,
         opacity,
         padding0,
-        padding1,
-        padding2,
-        padding3,
-        padding4,
-        padding5
+        padding1
     ),
     render_layout!(
         super::blur::BlurUniforms,

--- a/crates/gpui_wgpu/src/wgpu_renderer/surfaces.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer/surfaces.rs
@@ -132,14 +132,11 @@ impl WgpuRenderer {
         let uniforms = SurfaceUniforms {
             bounds: surface.bounds.into(),
             content_mask: surface.content_mask.bounds.into(),
+            corner_radii: surface.corner_radii.into(),
             color_format,
             opacity,
             padding0: 0,
             padding1: 0,
-            padding2: 0,
-            padding3: 0,
-            padding4: 0,
-            padding5: 0,
         };
         let resources = self.resources();
         let uniform_offset = resources.surface_uniforms.write(&uniforms);

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -1197,14 +1197,11 @@ impl DirectXRenderer {
             let uniforms = SurfaceUniforms {
                 bounds: surface.bounds.into(),
                 content_mask: surface.content_mask.bounds.into(),
+                corner_radii: surface.corner_radii.into(),
                 color_format: SurfaceColorFormat::Rgba,
                 opacity: opacities.get(index).copied().unwrap_or(1.0),
                 padding0: 0,
                 padding1: 0,
-                padding2: 0,
-                padding3: 0,
-                padding4: 0,
-                padding5: 0,
             };
             update_buffer(ctx, &self.pipelines.surfaces.params_buffer, &[uniforms])?;
 


### PR DESCRIPTION
`crates/gpui/src/elements/surface.rs` carries `// TODO: Add support for corner_radii`, so a texture surface inside a rounded frame draws square corners under the frame's curve — four bright wedges wherever a rounded pane holds one. This implements it.

### What changed

- `PaintSurface` gains `corner_radii: Corners<ScaledPixels>`.
- `Window::paint_surface` takes `corner_radii: Corners<Pixels>` and clamps them to the surface's own bounds before scaling, the same way `paint_image` does.
- `Surface::paint` resolves them from its style via `style.corner_radii.to_pixels(rem_size)`, like an image element.
- `SurfaceUniforms` gains a `Corners` in place of four of its six padding words, so the struct's size is unchanged.
- `fragment_surface` fades the sample by `antialiased_coverage(rounded_rectangle_signed_distance(...))`, exactly as `fragment_polychrome_sprite` already does. Because the shaders are authored once in Rust, WGSL, HLSL, MSL and GLSL all pick this up from the one change.
- The DirectX and wgpu renderers fill the new field.

Square corners stay free: zero radii make the distance field a plain rectangle, whose coverage is 1 everywhere inside the bounds.

### Compatibility

`paint_surface` is a public method and gains a parameter, so this is a breaking change for direct callers. Happy to add a `paint_surface_with_corner_radii` and leave the old signature delegating to it instead — say the word.

### Tests

Three new element tests in `surface.rs`:
- radii reach the scene, scaled by the window's scale factor
- radii larger than the element clamp to half its size
- a plain surface still asks for square corners

The existing `shader_buffer_layouts_match_host_layouts` and `shader_interface_matches_generated_sources` guard the uniform change, and `shaders::filters::surface::__validate_wgsl` still passes.

`cargo check --workspace --all-targets`, `cargo test -p gpui-ce --lib` (335 passed), `cargo test -p gpui_ce_render` (22 passed) and `cargo fmt --all --check` are green on Windows.

One note: `cargo test -p gpui_ce_windows` does not build on `main` right now — `method render_to_image is not a member of trait PlatformWindow` — which I confirmed by stashing this change. Unrelated to this PR.